### PR TITLE
feat: make proposal transactions editable

### DIFF
--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -8,6 +8,8 @@ import { Transaction } from '@/types';
 const address = spaces.pasta.wallets[0];
 
 const txs: Ref<Transaction[]> = ref([]);
+const editedTx: Ref<number | null> = ref(null);
+const modalState: Ref<object> = ref({});
 const modalOpen = ref({
   sendToken: false,
   sendNft: false,
@@ -34,11 +36,29 @@ const formattedTxs = computed(() =>
 );
 
 function addTx(tx: Transaction) {
-  txs.value.push(tx);
+  if (editedTx.value !== null) {
+    txs.value[editedTx.value] = tx;
+  } else {
+    txs.value.push(tx);
+  }
 }
 
 function removeTx(index) {
   txs.value = txs.value.filter((tx, i) => i !== index);
+}
+
+function openModal(type: 'sendToken' | 'sendNft' | 'contractCall') {
+  editedTx.value = null;
+  modalState.value[type] = null;
+  modalOpen.value[type] = true;
+}
+
+function editTx(index) {
+  const tx = txs.value[index];
+
+  editedTx.value = index;
+  modalState.value[tx._type] = tx._form;
+  modalOpen.value[tx._type] = true;
 }
 </script>
 <template>
@@ -48,21 +68,21 @@ function removeTx(index) {
         class="mb-3 flex flex-no-wrap overflow-x-scroll no-scrollbar scrolling-touch items-start space-x-3"
       >
         <a
-          @click="modalOpen.sendToken = true"
+          @click="openModal('sendToken')"
           class="px-4 py-3 border-b border rounded-lg block min-w-[165px]"
         >
           <IH-stop />
           Send token
         </a>
         <a
-          @click="modalOpen.sendNft = true"
+          @click="openModal('sendNft')"
           class="px-4 py-3 border-b border rounded-lg block min-w-[165px]"
         >
           <IH-photograph />
           Send NFT
         </a>
         <a
-          @click="modalOpen.contractCall = true"
+          @click="openModal('contractCall')"
           class="px-4 py-3 border-b border rounded-lg block min-w-[165px]"
         >
           <IH-chip />
@@ -84,28 +104,34 @@ function removeTx(index) {
             {{ tx.title }}
           </h4>
         </div>
-        <span>
+        <div class="flex gap-3">
+          <a @click="editTx(i)">
+            <IH-pencil />
+          </a>
           <a @click="removeTx(i)">
             <IH-trash />
           </a>
-        </span>
+        </div>
       </div>
     </div>
     <teleport to="#modal">
       <ModalSendToken
         :open="modalOpen.sendToken"
         :address="address"
+        :initialState="modalState.sendToken"
         @close="modalOpen.sendToken = false"
         @add="addTx"
       />
       <ModalSendNft
         :open="modalOpen.sendNft"
         :address="address"
+        :initialState="modalState.sendNft"
         @close="modalOpen.sendNft = false"
         @add="addTx"
       />
       <ModalTransaction
         :open="modalOpen.contractCall"
+        :initialState="modalState.contractCall"
         @close="modalOpen.contractCall = false"
         @add="addTx"
       />

--- a/src/components/Modal/SendNft.vue
+++ b/src/components/Modal/SendNft.vue
@@ -4,12 +4,19 @@ import { useNfts } from '@/composables/useNfts';
 import { createSendNftTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
 
+const DEFAULT_FORM_STATE = {
+  to: '',
+  nft: '',
+  amount: ''
+};
+
 const props = defineProps({
   open: Boolean,
   address: {
     type: String,
     required: true
-  }
+  },
+  initialState: Object
 });
 
 const emit = defineEmits(['add', 'close']);
@@ -18,11 +25,9 @@ const searchInput: Ref<HTMLElement | null> = ref(null);
 const showPicker = ref(false);
 const searchValue = ref('');
 
-const form: { to: string; nft: string; amount: string | number } = reactive({
-  to: '',
-  nft: '',
-  amount: ''
-});
+const form: { to: string; nft: string; amount: string | number } = reactive(
+  clone(DEFAULT_FORM_STATE)
+);
 
 const { loading, loaded, nfts, nftsMap, loadNfts } = useNfts();
 
@@ -63,6 +68,16 @@ watch(
   () => props.open,
   () => {
     showPicker.value = false;
+
+    if (props.initialState) {
+      form.to = props.initialState.recipient;
+      form.nft = `${props.initialState.nft.address}:${props.initialState.nft.id}`;
+      form.amount = props.initialState.amount;
+    } else {
+      form.to = DEFAULT_FORM_STATE.to;
+      form.nft = DEFAULT_FORM_STATE.nft;
+      form.amount = DEFAULT_FORM_STATE.amount;
+    }
   }
 );
 </script>

--- a/src/components/Modal/SendToken.vue
+++ b/src/components/Modal/SendToken.vue
@@ -6,12 +6,20 @@ import { createSendTokenTransaction } from '@/helpers/transactions';
 import { ETH_CONTRACT } from '@/helpers/constants';
 import { clone } from '@/helpers/utils';
 
+const DEFAULT_FORM_STATE = {
+  to: '',
+  token: ETH_CONTRACT,
+  amount: '',
+  value: ''
+};
+
 const props = defineProps({
   open: Boolean,
   address: {
     type: String,
     required: true
-  }
+  },
+  initialState: Object
 });
 
 const emit = defineEmits(['add', 'close']);
@@ -22,12 +30,7 @@ const form: {
   token: string;
   amount: string | number;
   value: string | number;
-} = reactive({
-  to: '',
-  token: ETH_CONTRACT,
-  amount: '',
-  value: ''
-});
+} = reactive(clone(DEFAULT_FORM_STATE));
 
 const showPicker = ref(false);
 const searchValue = ref('');
@@ -110,6 +113,21 @@ watch(
   () => props.open,
   () => {
     showPicker.value = false;
+
+    if (props.initialState) {
+      form.to = props.initialState.recipient;
+      form.token = props.initialState.token.address;
+      handleAmountUpdate(
+        formatUnits(
+          props.initialState.amount,
+          props.initialState.token.decimals
+        )
+      );
+    } else {
+      form.to = DEFAULT_FORM_STATE.to;
+      form.token = DEFAULT_FORM_STATE.token;
+      handleAmountUpdate(DEFAULT_FORM_STATE.amount);
+    }
   }
 );
 

--- a/src/components/S/IObject.vue
+++ b/src/components/S/IObject.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, computed } from 'vue';
 
 import IObject from './IObject.vue';
 import IArray from './IArray.vue';
@@ -14,7 +14,22 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue']);
 
-const input = ref(props.modelValue || props.definition.default || {});
+const dirty = ref(false);
+
+const inputValue = computed({
+  get() {
+    if (!props.value && !dirty.value && props.definition.default) {
+      return props.definition.default;
+    }
+
+    return props.modelValue;
+  },
+  set(newValue) {
+    dirty.value = true;
+
+    emit('update:modelValue', newValue);
+  }
+});
 
 const getComponent = name => {
   switch (name) {
@@ -32,8 +47,6 @@ const getComponent = name => {
       return null;
   }
 };
-
-watch(input, () => emit('update:modelValue', input.value));
 </script>
 
 <template>
@@ -42,6 +55,6 @@ watch(input, () => emit('update:modelValue', input.value));
     :key="i"
     :is="getComponent(property.type)"
     :definition="property"
-    v-model="input[i]"
+    v-model="inputValue[i]"
   />
 </template>

--- a/src/components/S/IString.vue
+++ b/src/components/S/IString.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, computed } from 'vue';
 
 const props = defineProps({
   modelValue: String,
@@ -8,16 +8,29 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue']);
 
-const input = ref(props.modelValue || props.definition.default || undefined);
+const dirty = ref(false);
 
-watch(input, () => emit('update:modelValue', input.value));
+const inputValue = computed({
+  get() {
+    if (!props.value && !dirty.value && props.definition.default) {
+      return props.definition.default;
+    }
+
+    return props.modelValue;
+  },
+  set(newValue) {
+    dirty.value = true;
+
+    emit('update:modelValue', newValue);
+  }
+});
 </script>
 
 <template>
   <SBase :definition="definition">
     <input
       type="text"
-      v-model="input"
+      v-model="inputValue"
       class="s-input"
       :placeholder="definition.examples && definition.examples[0]"
     />

--- a/src/helpers/__tests__/__snapshots__/transactions.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/transactions.test.ts.snap
@@ -3,10 +3,14 @@
 exports[`transactions > createContractCallTransaction > should create contract call transaction 1`] = `
 {
   "_form": {
-    "args": [
-      "0x000000000000000000000000000000000000dead",
+    "abi": [
+      "function deny(address guy)",
     ],
+    "args": {
+      "guy": "0x000000000000000000000000000000000000dead",
+    },
     "method": "deny",
+    "recipient": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
   },
   "_type": "contractCall",
   "data": "0x9c52a7f1000000000000000000000000000000000000000000000000000000000000dead",

--- a/src/helpers/transactions.ts
+++ b/src/helpers/transactions.ts
@@ -116,8 +116,10 @@ export function createContractCallTransaction({
     data,
     value: '0x',
     _form: {
+      abi: form.abi,
+      recipient: form.to,
       method: form.method,
-      args
+      args: form.args
     }
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,10 @@ export type SendNftTransaction = BaseTransaction & {
 export type ContractCallTransaction = BaseTransaction & {
   _type: 'contractCall';
   _form: {
+    abi: any[];
+    recipient: string;
     method: string;
-    args: any[];
+    args: any;
   };
 };
 


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/165

- Update `IObject` and `IString` to properly do two-way binding (same as changes in INumber before).
- Update TransactionModal to use `computed` values so it better handles data coming from two places.
- Bugfixes in TransactionModal that handle issues when switching methods on already populated forms or when ABI gets updated.
- Add edit option to all transaction types.

## Test plan
- Add bunch of transactions (token, nfts, contract calls).
- Try editing some of them (changing recipients, values, tokens, different contracts, methods etc.).
- Nothing should go terribly wrong.

I used those two contracts to get ABIs:
- `0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6`
- `0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844`

## Screenshot

<img width="566" alt="image" src="https://user-images.githubusercontent.com/1968722/175784618-891420f4-60e1-4b9d-bbdb-3415c7d24aa5.png">
