### PR TITLE
feat: add form validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@snapshot-labs/sx": "^0.1.0-beta.4",
     "@vueuse/core": "^8.9.1",
     "@walletconnect/client": "^1.7.8",
+    "ajv": "^8.11.0",
     "dayjs": "^1.11.2",
     "electron": "^19.0.3",
     "graphql": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@braintree/sanitize-url": "^6.0.0",
     "@ensdomains/eth-ens-namehash": "^2.0.15",
     "@ethersproject/address": "^5.6.1",
+    "@ethersproject/bignumber": "^5.6.2",
+    "@ethersproject/constants": "^5.6.1",
     "@ethersproject/providers": "^5.6.4",
     "@ethersproject/units": "^5.6.1",
     "@snapshot-labs/lock": "^0.1.91",

--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -5,6 +5,7 @@ import getProvider from '@snapshot-labs/snapshot.js/src/utils/provider';
 import { getABI } from '@/helpers/etherscan';
 import { createContractCallTransaction } from '@/helpers/transactions';
 import { abiToDefinition, clone } from '@/helpers/utils';
+import { validateForm } from '@/helpers/validation';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -76,6 +77,23 @@ watch(currentMethod, () => {
   }
 });
 
+const errors = computed(() =>
+  validateForm(
+    {
+      type: 'object',
+      properties: {
+        to: {
+          type: 'string',
+          format: 'address'
+        }
+      },
+      additionalProperties: true
+    },
+    { to: form.to }
+  )
+);
+const argsErrors = computed(() => validateForm(definition.value, form.args));
+
 watch(
   () => form.to,
   async v => {
@@ -135,6 +153,7 @@ watch(
         <UiLoading v-if="loading" class="absolute top-[14px] right-3" />
         <SIString
           v-model="form.to"
+          :error="errors.to"
           :definition="{
             type: 'string',
             title: 'Contract address',
@@ -160,7 +179,11 @@ watch(
         }"
       />
       <div v-if="definition">
-        <SIObject v-model="form.args" :definition="definition" />
+        <SIObject
+          v-model="form.args"
+          :error="argsErrors"
+          :definition="definition"
+        />
       </div>
     </div>
     <template v-slot:footer>

--- a/src/components/S/Base.vue
+++ b/src/components/S/Base.vue
@@ -1,11 +1,20 @@
-<script setup>
-defineProps({ definition: Object });
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  definition: any;
+  error?: string;
+  dirty?: boolean;
+}>();
+
+const showError = computed(() => props.error && props.dirty);
 </script>
 
 <template>
-  <div class="s-base">
+  <div class="s-base" :class="showError ? 's-error' : ''">
     <label v-if="definition.title" v-text="definition.title" class="s-label" />
     <slot />
+    <span v-if="showError" class="s-input-error-message">{{ error }}</span>
     <legend v-if="definition.description" v-text="definition.description" />
   </div>
 </template>

--- a/src/components/S/IBoolean.vue
+++ b/src/components/S/IBoolean.vue
@@ -1,20 +1,40 @@
-<script setup>
-import { ref, watch } from 'vue';
+<script setup lang="ts">
+import { ref, computed } from 'vue';
 
-const props = defineProps({
-  modelValue: Boolean,
-  definition: Object
+const props = defineProps<{
+  modelValue?: boolean;
+  error?: string;
+  definition: any;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean);
+}>();
+
+const dirty = ref(false);
+
+const inputValue = computed({
+  get() {
+    if (
+      props.modelValue === undefined &&
+      !dirty.value &&
+      props.definition.default !== undefined
+    ) {
+      return props.definition.default;
+    }
+
+    return props.modelValue;
+  },
+  set(newValue: boolean) {
+    dirty.value = true;
+
+    emit('update:modelValue', newValue);
+  }
 });
-
-const emit = defineEmits(['update:modelValue']);
-
-const input = ref(props.modelValue || props.definition.default || undefined);
-
-watch(input, () => emit('update:modelValue', input.value));
 </script>
 
 <template>
-  <SBase :definition="definition">
-    <input type="checkbox" v-model="input" />
+  <SBase :definition="definition" :error="error" :dirty="dirty">
+    <input type="checkbox" v-model="inputValue" />
   </SBase>
 </template>

--- a/src/components/S/INumber.vue
+++ b/src/components/S/INumber.vue
@@ -1,24 +1,27 @@
-<script setup>
+<script setup lang="ts">
 import { ref, computed } from 'vue';
 
-const props = defineProps({
-  modelValue: [Number, String],
-  definition: Object
-});
+const props = defineProps<{
+  modelValue?: string | number;
+  error?: string;
+  definition: any;
+}>();
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string);
+}>();
 
 const dirty = ref(false);
 
 const inputValue = computed({
   get() {
-    if (!props.value && !dirty.value && props.definition.default) {
+    if (!props.modelValue && !dirty.value && props.definition.default) {
       return props.definition.default;
     }
 
     return props.modelValue;
   },
-  set(newValue) {
+  set(newValue: string) {
     dirty.value = true;
 
     emit('update:modelValue', newValue);
@@ -27,7 +30,7 @@ const inputValue = computed({
 </script>
 
 <template>
-  <SBase :definition="definition">
+  <SBase :definition="definition" :error="error" :dirty="dirty">
     <input
       type="number"
       v-model="inputValue"

--- a/src/components/S/IObject.vue
+++ b/src/components/S/IObject.vue
@@ -9,6 +9,7 @@ import IBoolean from './IBoolean.vue';
 
 const props = defineProps({
   modelValue: Object,
+  error: undefined,
   definition: Object
 });
 
@@ -18,7 +19,7 @@ const dirty = ref(false);
 
 const inputValue = computed({
   get() {
-    if (!props.value && !dirty.value && props.definition.default) {
+    if (!props.modelValue && !dirty.value && props.definition.default) {
       return props.definition.default;
     }
 
@@ -55,6 +56,7 @@ const getComponent = name => {
     :key="i"
     :is="getComponent(property.type)"
     :definition="property"
+    :error="error?.[i]"
     v-model="inputValue[i]"
   />
 </template>

--- a/src/components/S/IString.vue
+++ b/src/components/S/IString.vue
@@ -1,24 +1,27 @@
-<script setup>
+<script setup lang="ts">
 import { ref, computed } from 'vue';
 
-const props = defineProps({
-  modelValue: String,
-  definition: Object
-});
+const props = defineProps<{
+  modelValue?: string;
+  error?: string;
+  definition: any;
+}>();
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string);
+}>();
 
 const dirty = ref(false);
 
 const inputValue = computed({
   get() {
-    if (!props.value && !dirty.value && props.definition.default) {
+    if (!props.modelValue && !dirty.value && props.definition.default) {
       return props.definition.default;
     }
 
     return props.modelValue;
   },
-  set(newValue) {
+  set(newValue: string) {
     dirty.value = true;
 
     emit('update:modelValue', newValue);
@@ -27,7 +30,7 @@ const inputValue = computed({
 </script>
 
 <template>
-  <SBase :definition="definition">
+  <SBase :definition="definition" :error="error" :dirty="dirty">
     <input
       type="text"
       v-model="inputValue"

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -116,6 +116,10 @@ export function abiToDefinition(abi) {
       definition.properties[input.name].format = 'uint256';
       definition.properties[input.name].examples = ['0'];
     }
+    if (input.type === 'int256') {
+      definition.properties[input.name].format = 'int256';
+      definition.properties[input.name].examples = ['0'];
+    }
     if (input.type === 'address') {
       definition.properties[input.name].format = 'address';
       definition.properties[input.name].examples = ['0x0000…'];

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,0 +1,36 @@
+import Ajv from 'ajv';
+import { isAddress } from '@ethersproject/address';
+
+export function validateForm(schema, form) {
+  const ajv = new Ajv({ allErrors: true });
+
+  ajv.addFormat('address', {
+    validate: isAddress
+  });
+
+  ajv.addFormat('uint256', {
+    validate: value => !!value.match(/^[0-9]+$/)
+  });
+
+  ajv.validate(schema, form);
+
+  const output = {};
+  if (!ajv.errors) {
+    return output;
+  }
+
+  for (const error of ajv.errors) {
+    const path = error.dataPath.split('.').slice(1);
+
+    let current = output;
+    for (let i = 0; i < path.length - 1; i++) {
+      const subpath = path[i];
+      if (!current[subpath]) current[subpath] = {};
+      current = current[subpath];
+    }
+
+    current[path[path.length - 1]] = 'Invalid field';
+  }
+
+  return output;
+}

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,5 +1,12 @@
 import Ajv from 'ajv';
 import { isAddress } from '@ethersproject/address';
+import {
+  Zero,
+  MinInt256,
+  MaxInt256,
+  MaxUint256
+} from '@ethersproject/constants';
+import { BigNumber } from '@ethersproject/bignumber';
 
 export function validateForm(schema, form) {
   const ajv = new Ajv({ allErrors: true });
@@ -9,7 +16,29 @@ export function validateForm(schema, form) {
   });
 
   ajv.addFormat('uint256', {
-    validate: value => !!value.match(/^[0-9]+$/)
+    validate: value => {
+      if (!value.match(/^([0-9]|[1-9][0-9]+)$/)) return false;
+
+      try {
+        const number = BigNumber.from(value);
+        return number.gte(Zero) && number.lte(MaxUint256);
+      } catch {
+        return false;
+      }
+    }
+  });
+
+  ajv.addFormat('int256', {
+    validate: value => {
+      if (!value.match(/^-?([0-9]|[1-9][0-9]+)$/)) return false;
+
+      try {
+        const number = BigNumber.from(value);
+        return number.gte(MinInt256) && number.lte(MaxInt256);
+      } catch {
+        return false;
+      }
+    }
   });
 
   ajv.validate(schema, form);
@@ -20,7 +49,7 @@ export function validateForm(schema, form) {
   }
 
   for (const error of ajv.errors) {
-    const path = error.dataPath.split('.').slice(1);
+    const path = error.instancePath.split('/').slice(1);
 
     let current = output;
     for (let i = 0; i < path.length - 1; i++) {

--- a/src/style.scss
+++ b/src/style.scss
@@ -70,7 +70,7 @@ h4 {
 }
 
 h5 {
-  @apply text-sm
+  @apply text-sm;
 }
 
 p {
@@ -99,9 +99,15 @@ a,
 }
 
 .choice-bg {
-  &._1 { @apply bg-green; }
-  &._2 { @apply bg-red; }
-  &._3 { @apply bg-gray-500; }
+  &._1 {
+    @apply bg-green;
+  }
+  &._2 {
+    @apply bg-red;
+  }
+  &._3 {
+    @apply bg-gray-500;
+  }
 }
 
 #app {
@@ -127,7 +133,6 @@ a,
   @apply block border-y border-x-0 sm:border-x sm:rounded-lg;
 }
 
-
 .lazy-loading {
   @apply bg-skin-text animate-pulse-fast;
 }
@@ -138,11 +143,21 @@ a,
 }
 
 .dark .hero {
-  background-image: radial-gradient(400px circle at bottom, transparent, var(--bg-color)), url('@/assets/grid-dark.svg');
+  background-image: radial-gradient(
+      400px circle at bottom,
+      transparent,
+      var(--bg-color)
+    ),
+    url('@/assets/grid-dark.svg');
 }
 
 .light .hero {
-  background-image: radial-gradient(400px circle at bottom, transparent, var(--bg-color)), url('@/assets/grid-light.svg');
+  background-image: radial-gradient(
+      400px circle at bottom,
+      transparent,
+      var(--bg-color)
+    ),
+    url('@/assets/grid-light.svg');
 }
 
 .no-scrollbar::-webkit-scrollbar {
@@ -159,14 +174,29 @@ a,
 .s-input {
   @apply text-skin-heading border border-skin-border focus-within:border-skin-link block rounded-[24px] py-2 px-3 w-full bg-transparent mb-3;
 }
-
 .s-label {
   @apply block mb-1;
 }
 
+.s-error {
+  @apply mb-2;
+
+  .s-input {
+    @apply mb-1 border border-red #{!important};
+  }
+
+  .s-label {
+    @apply text-red;
+  }
+
+  .s-input-error-message {
+    @apply text-red;
+  }
+}
+
 .s-box {
   .s-base {
-    @apply relative
+    @apply relative;
   }
 
   .s-label {
@@ -184,7 +214,7 @@ a,
 
 .s-compact {
   .s-base {
-    @apply relative pt-[8px]
+    @apply relative pt-[8px];
   }
 
   .s-label {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,8 @@ module.exports = {
   theme: {
     extend: {
       borderColor: {
-        DEFAULT: 'var(--border-color)'
+        DEFAULT: 'var(--border-color)',
+        red: '#ff3856'
       },
       colors: {
         primary: 'var(--primary-color)',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,6 +2042,16 @@ ajv@^8.0.0, ajv@^8.6.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/164

Adds validation for forms using ajv schema.

- Validation is done at top level and components just react to `error` prop. It could be possible to do it at the component level (as those components already receive definitions), but getting validation status out of deeper components back seems weird and it seems most libraries do it at top level.
- Fixed components checking wrong prop for defaultValue, became apparent after enabling TS.

## Test plan
- Go to Contract call modal.
- Invalid contract address should give you error message.
- Input correct address.
- Inputting invalid address or uint256 into args should result in error message as well

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/178844364-572162c8-0946-498b-b427-0b6dbe9b491d.png" width="400" />
