### PR TITLE
feat: add nonce and operation to proposal file

### DIFF
--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -116,7 +116,7 @@ function editTx(index: number) {
       </div>
     </div>
     <div v-if="txs.length > 0" class="x-block !border-x rounded-lg">
-      <draggable v-model="txs" handle=".handle">
+      <draggable v-model="txs" handle=".handle" :item-key="() => undefined">
         <template #item="{ element: tx, index: i }">
           <div
             class="border-b last:border-b-0 px-4 py-3 space-x-2 flex items-center justify-between"

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -5,7 +5,7 @@ import { useWeb3 } from '@/composables/useWeb3';
 import { useTxStatus } from '@/composables/useTxStatus';
 import { useAccount } from '@/composables/useAccount';
 import { useModal } from '@/composables/useModal';
-import type { Transaction } from '@/types';
+import type { Transaction, TransactionData } from '@/types';
 
 export function useActions() {
   const { web3 } = useWeb3();
@@ -45,7 +45,21 @@ export function useActions() {
     execution: Transaction[]
   ) {
     if (!web3.value.account) return await forceLogin();
-    const pinned = await pin({ title, body, discussion, execution });
+
+    const executionData = execution.map(
+      (tx: Transaction, i: number): TransactionData => ({
+        ...tx,
+        nonce: i,
+        operation: '0'
+      })
+    );
+
+    const pinned = await pin({
+      title,
+      body,
+      discussion,
+      execution: executionData
+    });
     if (!pinned || !pinned.cid) return;
     console.log('IPFS', pinned);
     const isStarkNet = web3.value.type === 'argentx';

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,11 @@ export type BaseTransaction = {
   value: string;
 };
 
+export type TransactionData = BaseTransaction & {
+  nonce: number;
+  operation: '0';
+};
+
 export type SendTokenTransaction = BaseTransaction & {
   _type: 'sendToken';
   _form: {


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/183

- Added missing required `itemKey` prop, we don't have a good key to use for those, but we can use function to opt-out to default Vue keying.
- Nonce and operation are added when those are submitted to IPFS as those are derivatives or existing data in UI so it doesn't make sense to add it outside of it and would make it harder to work with (making sure we keep those in sync when we add/remove/reorder entries).