### PR TITLE
feat: handle payable methods

### DIFF
--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -11,7 +11,8 @@ const DEFAULT_FORM_STATE = {
   to: '',
   abi: [],
   method: '',
-  args: {}
+  args: {},
+  amount: ''
 };
 
 const props = defineProps({
@@ -74,6 +75,7 @@ watch(currentMethod, () => {
     ignoreFormUpdates.value = false;
   } else {
     form.args = {};
+    form.amount = DEFAULT_FORM_STATE.amount;
   }
 });
 
@@ -85,11 +87,19 @@ const errors = computed(() =>
         to: {
           type: 'string',
           format: 'address'
-        }
+        },
+        ...(currentMethod.value.payable
+          ? {
+              amount: {
+                type: 'string',
+                format: 'ethValue'
+              }
+            }
+          : {})
       },
       additionalProperties: true
     },
-    { to: form.to }
+    { to: form.to, amount: form.amount }
   )
 );
 const argsErrors = computed(() => validateForm(definition.value, form.args));
@@ -129,6 +139,7 @@ watch(
       form.abi = props.initialState.abi;
       form.method = props.initialState.method;
       form.args = props.initialState.args;
+      form.amount = props.initialState.amount;
 
       ignoreFormUpdates.value = true;
     } else {
@@ -136,6 +147,7 @@ watch(
       form.abi = DEFAULT_FORM_STATE.abi;
       form.method = DEFAULT_FORM_STATE.method;
       form.args = DEFAULT_FORM_STATE.args;
+      form.amount = DEFAULT_FORM_STATE.amount;
 
       ignoreFormUpdates.value = false;
     }
@@ -150,7 +162,7 @@ watch(
     </template>
     <div class="s-box p-4">
       <div class="relative">
-        <UiLoading v-if="loading" class="absolute top-[14px] right-3" />
+        <UiLoading v-if="loading" class="absolute top-[14px] right-3 z-10" />
         <SIString
           v-model="form.to"
           :error="errors.to"
@@ -171,11 +183,14 @@ watch(
           <option v-for="(method, i) in methods" :key="i" v-text="method" />
         </select>
       </div>
-      <SINumber
+      <SIString
         v-if="currentMethod.payable"
+        v-model="form.amount"
+        :error="errors.amount"
         :definition="{
-          type: 'number',
-          title: 'ETH value'
+          format: 'ethValue',
+          title: 'ETH amount',
+          examples: ['Payable amount']
         }"
       />
       <div v-if="definition">

--- a/src/helpers/__tests__/__snapshots__/transactions.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/transactions.test.ts.snap
@@ -6,6 +6,7 @@ exports[`transactions > createContractCallTransaction > should create contract c
     "abi": [
       "function deny(address guy)",
     ],
+    "amount": undefined,
     "args": {
       "guy": "0x000000000000000000000000000000000000dead",
     },
@@ -15,7 +16,25 @@ exports[`transactions > createContractCallTransaction > should create contract c
   "_type": "contractCall",
   "data": "0x9c52a7f1000000000000000000000000000000000000000000000000000000000000dead",
   "to": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
-  "value": "0x",
+  "value": "0",
+}
+`;
+
+exports[`transactions > createContractCallTransaction > should create contract call transaction with payable 1`] = `
+{
+  "_form": {
+    "abi": [
+      "function deposit() payable",
+    ],
+    "amount": "20",
+    "args": {},
+    "method": "deposit",
+    "recipient": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
+  },
+  "_type": "contractCall",
+  "data": "0xd0e30db0",
+  "to": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
+  "value": "20000000000000000000",
 }
 `;
 

--- a/src/helpers/__tests__/transactions.test.ts
+++ b/src/helpers/__tests__/transactions.test.ts
@@ -91,20 +91,30 @@ describe('transactions', () => {
   });
 
   describe('createContractCallTransaction', () => {
-    const form = {
-      to: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
-      value: '',
-      method: 'deny',
-      args: {
-        guy: '0x000000000000000000000000000000000000dead'
-      },
-      abi: ['function deny(address guy)'],
-      data: ''
-    };
-
     it('should create contract call transaction', () => {
       const tx = createContractCallTransaction({
-        form
+        form: {
+          to: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
+          abi: ['function deny(address guy)'],
+          method: 'deny',
+          args: {
+            guy: '0x000000000000000000000000000000000000dead'
+          }
+        }
+      });
+
+      expect(tx).toMatchSnapshot();
+    });
+
+    it('should create contract call transaction with payable', () => {
+      const tx = createContractCallTransaction({
+        form: {
+          to: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
+          abi: ['function deposit() payable'],
+          method: 'deposit',
+          args: {},
+          amount: '20'
+        }
       });
 
       expect(tx).toMatchSnapshot();

--- a/src/helpers/transactions.ts
+++ b/src/helpers/transactions.ts
@@ -114,12 +114,15 @@ export function createContractCallTransaction({
     _type: 'contractCall',
     to: form.to,
     data,
-    value: '0x',
+    value: iface.getFunction(form.method).payable
+      ? parseUnits(form.amount.toString(), 18).toString()
+      : '0',
     _form: {
       abi: form.abi,
       recipient: form.to,
       method: form.method,
-      args: form.args
+      args: form.args,
+      amount: form.amount
     }
   };
 }

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,5 +1,6 @@
 import Ajv from 'ajv';
 import { isAddress } from '@ethersproject/address';
+import { parseUnits } from '@ethersproject/units';
 import {
   Zero,
   MinInt256,
@@ -22,6 +23,19 @@ export function validateForm(schema, form) {
       try {
         const number = BigNumber.from(value);
         return number.gte(Zero) && number.lte(MaxUint256);
+      } catch {
+        return false;
+      }
+    }
+  });
+
+  ajv.addFormat('ethValue', {
+    validate: value => {
+      if (!value.match(/^([0-9]|[1-9][0-9]+)(\.[0-9]+)?$/)) return false;
+
+      try {
+        parseUnits(value, 18);
+        return true;
       } catch {
         return false;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type ContractCallTransaction = BaseTransaction & {
     recipient: string;
     method: string;
     args: any;
+    amount?: string;
   };
 };
 


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/178

## Test plan
- add contract call to `0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6`.
- `deposit` method has payable field, `transfer` doesn't.
- add `deposit` method call with amount.
- when editing the amount is there.
- log all `execution` it should contain `value` for calls with payable methods.