### PR TITLE
feat: add manual ABI input

### DIFF
--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { reactive, ref, computed, watch } from 'vue';
+import { Interface } from '@ethersproject/abi';
 import { isAddress } from '@ethersproject/address';
 import getProvider from '@snapshot-labs/snapshot.js/src/utils/provider';
 import { getABI } from '@/helpers/etherscan';
@@ -104,6 +105,17 @@ const errors = computed(() =>
 );
 const argsErrors = computed(() => validateForm(definition.value, form.args));
 
+watch(abiStr, value => {
+  try {
+    const abi = JSON.parse(value);
+    new Interface(abi);
+    form.abi = abi;
+    showAbiInput.value = false;
+  } catch (err) {
+    console.log('invalid abi', value);
+  }
+});
+
 watch(
   () => form.to,
   async v => {
@@ -120,7 +132,6 @@ watch(
         console.log('Address is valid');
         try {
           form.abi = await getABI(v);
-          abiStr.value = JSON.stringify(form.abi, null, 2);
         } catch (e) {
           showAbiInput.value = true;
           console.log(e);


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/179

## Test plan

- throw before `getABI` call
- insert some address (`0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6`)
- input shows up, insert JSON ABI (https://www.smartcontracttoolkit.com/abi)
- you can now pick and use methods from ABI
- you can save transaction

## Screenshots

https://user-images.githubusercontent.com/1968722/180624291-6013bae2-8358-4bb0-95d7-f683ac85f513.mov
