### PR TITLE
feat: add contract address based search in token picker

### DIFF
--- a/src/components/Block/TokenPicker.vue
+++ b/src/components/Block/TokenPicker.vue
@@ -23,6 +23,9 @@ const filteredAssets = computed(() =>
           .includes(props.searchValue.toLocaleLowerCase()) ||
         asset.contract_name
           .toLocaleLowerCase()
+          .includes(props.searchValue.toLocaleLowerCase()) ||
+        asset.contract_address
+          .toLocaleLowerCase()
           .includes(props.searchValue.toLocaleLowerCase())
       );
     })

--- a/src/components/Block/TokenPicker.vue
+++ b/src/components/Block/TokenPicker.vue
@@ -24,9 +24,8 @@ const filteredAssets = computed(() =>
         asset.contract_name
           .toLocaleLowerCase()
           .includes(props.searchValue.toLocaleLowerCase()) ||
-        asset.contract_address
-          .toLocaleLowerCase()
-          .includes(props.searchValue.toLocaleLowerCase())
+        asset.contract_address.toLocaleLowerCase() ===
+          props.searchValue.toLocaleLowerCase()
       );
     })
     .sort((a, b) => {


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/188

## Test plan
- Searching for `0xba100000625a3754423978a60c9317c58a424e3D` should return BAL.