### PR TITLE
feat: add ContactPicker

### DIFF
--- a/src/components/Block/ContactPicker.vue
+++ b/src/components/Block/ContactPicker.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { formatUnits } from '@ethersproject/units';
-import { ETH_CONTRACT } from '@/helpers/constants';
-import { _n, shorten } from '@/helpers/utils';
+import { shorten } from '@/helpers/utils';
 
 const CONTACTS = [
   {
@@ -12,6 +10,10 @@ const CONTACTS = [
   {
     name: 'Definitely not Sekhmet',
     address: '0x537f1896541d28F4c70116EEa602b1B34Da95163'
+  },
+  {
+    name: 'WETH',
+    address: '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6'
   }
 ];
 

--- a/src/components/Block/ContactPicker.vue
+++ b/src/components/Block/ContactPicker.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { formatUnits } from '@ethersproject/units';
+import { ETH_CONTRACT } from '@/helpers/constants';
+import { _n, shorten } from '@/helpers/utils';
+
+const CONTACTS = [
+  {
+    name: 'Sekhmet',
+    address: '0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70'
+  },
+  {
+    name: 'Definitely not Sekhmet',
+    address: '0x537f1896541d28F4c70116EEa602b1B34Da95163'
+  }
+];
+
+const props = defineProps<{
+  searchValue: string;
+  loading: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'pick', value: string);
+}>();
+
+const filteredContacts = computed(() =>
+  CONTACTS.filter(contact => {
+    return (
+      contact.name
+        .toLocaleLowerCase()
+        .includes(props.searchValue.toLocaleLowerCase()) ||
+      contact.address.toLocaleLowerCase() ===
+        props.searchValue.toLocaleLowerCase()
+    );
+  })
+);
+</script>
+
+<template>
+  <div v-if="loading" class="px-4 py-3 block flex justify-center">
+    <UiLoading />
+  </div>
+  <template v-else>
+    <div
+      v-if="filteredContacts.length === 0"
+      class="text-center py-3"
+      v-text="'No results'"
+    />
+    <div
+      v-for="contact in filteredContacts"
+      :key="contact.address"
+      role="button"
+      class="px-3 py-[12px] border-b last:border-0 flex justify-between"
+      @click="emit('pick', contact.address)"
+    >
+      <div class="flex items-center max-w-full">
+        <Stamp :id="contact.address" type="avatar" :size="32" />
+        <div class="flex flex-col ml-3 leading-[20px] overflow-hidden">
+          <div class="text-skin-link" v-text="shorten(contact.name, 24)" />
+          <div
+            class="text-sm text-ellipsis overflow-hidden"
+            v-text="contact.address"
+          />
+        </div>
+      </div>
+    </div>
+  </template>
+</template>

--- a/src/components/Block/ContactPicker.vue
+++ b/src/components/Block/ContactPicker.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useAccount } from '@/composables/useAccount';
 import { shorten } from '@/helpers/utils';
 
 const CONTACTS = [
@@ -26,8 +27,22 @@ const emit = defineEmits<{
   (e: 'pick', value: string);
 }>();
 
+const { account } = useAccount();
+
+const allContacts = computed(() => {
+  if (!account) return CONTACTS;
+
+  return [
+    {
+      name: 'You',
+      address: account
+    },
+    ...CONTACTS
+  ];
+});
+
 const filteredContacts = computed(() =>
-  CONTACTS.filter(contact => {
+  allContacts.value.filter(contact => {
     return (
       contact.name
         .toLocaleLowerCase()

--- a/src/components/Modal/SendNft.vue
+++ b/src/components/Modal/SendNft.vue
@@ -133,22 +133,15 @@ watch(
       />
     </template>
     <div v-if="!showPicker" class="s-box p-4">
-      <div class="relative">
-        <a
-          class="absolute top-[20px] right-3 z-10"
-          @click="handlePickerClick('contact')"
-          ><IH-identification
-        /></a>
-        <SIString
-          v-model="form.to"
-          class="!pr-7"
-          :definition="{
-            type: 'string',
-            title: 'Recipient',
-            examples: ['Address or ENS']
-          }"
-        />
-      </div>
+      <SIAddress
+        v-model="form.to"
+        :definition="{
+          type: 'string',
+          title: 'Recipient',
+          examples: ['Address or ENS']
+        }"
+        @pick="handlePickerClick('contact')"
+      />
       <div class="s-base">
         <div class="s-label" v-text="'NFT'" />
         <button

--- a/src/components/Modal/SendNft.vue
+++ b/src/components/Modal/SendNft.vue
@@ -23,6 +23,7 @@ const emit = defineEmits(['add', 'close']);
 
 const searchInput: Ref<HTMLElement | null> = ref(null);
 const showPicker = ref(false);
+const pickerType: Ref<'nft' | 'contact' | null> = ref(null);
 const searchValue = ref('');
 
 const form: { to: string; nft: string; amount: string | number } = reactive(
@@ -39,12 +40,13 @@ const formValid = computed(
     (currentNft.value.type !== 'erc1155' || form.amount !== '')
 );
 
-function handlePickerClick() {
-  if (!loaded.value) {
+function handlePickerClick(type: 'nft' | 'contact') {
+  if (type === 'nft' && !loaded.value) {
     loadNfts(props.address);
   }
 
   showPicker.value = true;
+  pickerType.value = type;
 
   nextTick(() => {
     if (searchInput.value) {
@@ -109,28 +111,50 @@ watch(
         </div>
       </template>
     </template>
-    <BlockNftPicker
-      v-if="showPicker"
-      :nfts="nfts"
-      :loading="loading"
-      :search-value="searchValue"
-      @pick="
-        form.nft = $event;
-        showPicker = false;
-      "
-    />
-    <div v-if="!showPicker" class="s-box p-4">
-      <SIString
-        v-model="form.to"
-        :definition="{
-          type: 'string',
-          title: 'Recipient',
-          examples: ['Address or ENS']
-        }"
+    <template v-if="showPicker">
+      <BlockNftPicker
+        v-if="pickerType === 'nft'"
+        :nfts="nfts"
+        :loading="loading"
+        :search-value="searchValue"
+        @pick="
+          form.nft = $event;
+          showPicker = false;
+        "
       />
+      <BlockContactPicker
+        v-else-if="pickerType === 'contact'"
+        :loading="false"
+        :search-value="searchValue"
+        @pick="
+          form.to = $event;
+          showPicker = false;
+        "
+      />
+    </template>
+    <div v-if="!showPicker" class="s-box p-4">
+      <div class="relative">
+        <a
+          class="absolute top-[20px] right-3 z-10"
+          @click="handlePickerClick('contact')"
+          ><IH-identification
+        /></a>
+        <SIString
+          v-model="form.to"
+          class="!pr-7"
+          :definition="{
+            type: 'string',
+            title: 'Recipient',
+            examples: ['Address or ENS']
+          }"
+        />
+      </div>
       <div class="s-base">
         <div class="s-label" v-text="'NFT'" />
-        <button class="s-input text-left h-[61px]" @click="handlePickerClick">
+        <button
+          class="s-input text-left h-[61px]"
+          @click="handlePickerClick('nft')"
+        >
           <div class="flex items-center">
             <NftPreview
               v-if="currentNft"

--- a/src/components/Modal/SendToken.vue
+++ b/src/components/Modal/SendToken.vue
@@ -37,6 +37,7 @@ const form: {
 } = reactive(clone(DEFAULT_FORM_STATE));
 
 const showPicker = ref(false);
+const pickerType: Ref<'token' | 'contact' | null> = ref(null);
 const searchValue = ref('');
 const { loading, assets, assetsMap, loadBalances } = useBalances();
 
@@ -62,8 +63,9 @@ onMounted(() => {
   loadBalances(props.address, props.network);
 });
 
-function handlePickerClick() {
+function handlePickerClick(type: 'token' | 'contact') {
   showPicker.value = true;
+  pickerType.value = type;
 
   nextTick(() => {
     if (searchInput.value) {
@@ -165,28 +167,50 @@ watch(currentToken, token => {
         </div>
       </template>
     </template>
-    <BlockTokenPicker
-      v-if="showPicker"
-      :assets="assets"
-      :loading="loading"
-      :search-value="searchValue"
-      @pick="
-        form.token = $event;
-        showPicker = false;
-      "
-    />
-    <div v-if="!showPicker" class="s-box p-4">
-      <SIString
-        v-model="form.to"
-        :definition="{
-          type: 'string',
-          title: 'Recipient',
-          examples: ['Address or ENS']
-        }"
+    <template v-if="showPicker">
+      <BlockTokenPicker
+        v-if="pickerType === 'token'"
+        :assets="assets"
+        :loading="loading"
+        :search-value="searchValue"
+        @pick="
+          form.token = $event;
+          showPicker = false;
+        "
       />
+      <BlockContactPicker
+        v-else-if="pickerType === 'contact'"
+        :loading="false"
+        :search-value="searchValue"
+        @pick="
+          form.to = $event;
+          showPicker = false;
+        "
+      />
+    </template>
+    <div v-if="!showPicker" class="s-box p-4">
+      <div class="relative">
+        <a
+          class="absolute top-[20px] right-3 z-10"
+          @click="handlePickerClick('contact')"
+          ><IH-identification
+        /></a>
+        <SIString
+          v-model="form.to"
+          class="!pr-7"
+          :definition="{
+            type: 'string',
+            title: 'Recipient',
+            examples: ['Address or ENS']
+          }"
+        />
+      </div>
       <div class="s-base">
         <div class="s-label" v-text="'Token'" />
-        <button class="s-input text-left h-[61px]" @click="handlePickerClick">
+        <button
+          class="s-input text-left h-[61px]"
+          @click="handlePickerClick('token')"
+        >
           <div class="flex items-center">
             <Stamp
               v-if="currentToken"

--- a/src/components/Modal/SendToken.vue
+++ b/src/components/Modal/SendToken.vue
@@ -189,22 +189,15 @@ watch(currentToken, token => {
       />
     </template>
     <div v-if="!showPicker" class="s-box p-4">
-      <div class="relative">
-        <a
-          class="absolute top-[20px] right-3 z-10"
-          @click="handlePickerClick('contact')"
-          ><IH-identification
-        /></a>
-        <SIString
-          v-model="form.to"
-          class="!pr-7"
-          :definition="{
-            type: 'string',
-            title: 'Recipient',
-            examples: ['Address or ENS']
-          }"
-        />
-      </div>
+      <SIAddress
+        v-model="form.to"
+        :definition="{
+          type: 'string',
+          title: 'Recipient',
+          examples: ['Address or ENS']
+        }"
+        @pick="handlePickerClick('contact')"
+      />
       <div class="s-base">
         <div class="s-label" v-text="'Token'" />
         <button

--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -24,6 +24,7 @@ const props = defineProps({
 const emit = defineEmits(['add', 'close']);
 
 const loading = ref(false);
+const showContractPicker = ref(false);
 const ignoreFormUpdates = ref(true);
 const showAbiInput = ref(false);
 const abiStr = ref('');

--- a/src/components/S/IAddress.vue
+++ b/src/components/S/IAddress.vue
@@ -1,0 +1,30 @@
+<script lang="ts">
+export default {
+  inheritAttrs: false
+};
+</script>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    showPicker?: boolean;
+    path?: string;
+  }>(),
+  {
+    showPicker: true
+  }
+);
+
+const emit = defineEmits<{
+  (e: 'pick', path: string);
+}>();
+</script>
+
+<template>
+  <div class="relative">
+    <div v-if="showPicker" class="absolute top-[20px] right-3 z-10">
+      <a @click="emit('pick', path || '')"><IH-identification /></a>
+    </div>
+    <SIString v-bind="$attrs" class="!pr-7" />
+  </div>
+</template>

--- a/src/components/S/IObject.vue
+++ b/src/components/S/IObject.vue
@@ -1,19 +1,29 @@
-<script setup>
+<script lang="ts">
+export default {
+  inheritAttrs: false
+};
+</script>
+
+<script setup lang="ts">
 import { ref, computed } from 'vue';
 
 import IObject from './IObject.vue';
 import IArray from './IArray.vue';
 import IString from './IString.vue';
+import IAddress from './IAddress.vue';
 import INumber from './INumber.vue';
 import IBoolean from './IBoolean.vue';
 
-const props = defineProps({
-  modelValue: Object,
-  error: undefined,
-  definition: Object
-});
+const props = defineProps<{
+  modelValue: any;
+  error: any;
+  definition: any;
+  path?: string;
+}>();
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: any);
+}>();
 
 const dirty = ref(false);
 
@@ -32,14 +42,14 @@ const inputValue = computed({
   }
 });
 
-const getComponent = name => {
+const getComponent = (name: string, format: string) => {
   switch (name) {
     case 'object':
       return IObject;
     case 'array':
       return IArray;
     case 'string':
-      return IString;
+      return format === 'address' ? IAddress : IString;
     case 'number':
       return INumber;
     case 'boolean':
@@ -52,10 +62,12 @@ const getComponent = name => {
 
 <template>
   <component
-    :is="getComponent(property.type)"
+    :is="getComponent(property.type, property.format)"
     v-for="(property, i) in definition.properties"
     :key="i"
+    v-bind="$attrs"
     v-model="inputValue[i]"
+    :path="path ? `${path}.${i}` : i"
     :definition="property"
     :error="error?.[i]"
   />

--- a/src/components/S/IString.vue
+++ b/src/components/S/IString.vue
@@ -1,3 +1,9 @@
+<script lang="ts">
+export default {
+  inheritAttrs: false
+};
+</script>
+
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 
@@ -35,6 +41,7 @@ const inputValue = computed({
       v-model="inputValue"
       type="text"
       class="s-input"
+      v-bind="$attrs"
       :placeholder="definition.examples && definition.examples[0]"
     />
   </SBase>

--- a/src/composables/useAccount.ts
+++ b/src/composables/useAccount.ts
@@ -27,5 +27,5 @@ export function useAccount() {
     );
   }
 
-  return { loadVotes, votes };
+  return { account: web3.value.account, loadVotes, votes };
 }

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -9,7 +9,7 @@ import {
 } from '@ethersproject/constants';
 import { BigNumber } from '@ethersproject/bignumber';
 
-export function validateForm(schema, form) {
+export function validateForm(schema, form): Record<string, string> {
   const ajv = new Ajv({ allErrors: true });
 
   ajv.addFormat('address', {


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/185

Long term I think it would make sense to create a more robust modal system that can render them at will, outside of main tree so we could just do `const result = await showContactPicker()`. That would improve reusability of modals a lot (right now they need to repeat some of the UI). I have no idea how to do it now, seems common with React/Redux, but for Vue it seems it's never done like that.

## Test plan
- Open different modal types, you can pick address in there.
- Open Contract modal.
- Pick WETH contract and `transferFrom` method.
- You can pick different addresses from picker.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/180665295-9c31af70-0f74-4f88-b7cb-98439e5528d8.png" width="400" />
<img src="https://user-images.githubusercontent.com/1968722/180665302-e782a4b5-aa04-4fea-82a0-f221c72f47ab.png" width="400" />
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1968722/195997571-71d80282-997a-43ef-9fdd-385690415fad.png">

