### PR TITLE
feat: filter proposals by space

### DIFF
--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -27,8 +27,13 @@ export const PROPOSAL_QUERY = gql`
 `;
 
 export const PROPOSALS_QUERY = gql`
-  query ($first: Int!) {
-    proposals(first: $first, orderBy: created, orderDirection: desc) {
+  query ($first: Int!, $space: String) {
+    proposals(
+      first: $first
+      orderBy: created
+      orderDirection: desc
+      where: { space: $space }
+    ) {
       id
       proposal_id
       space

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,18 @@
+export type Space = {
+  id: string;
+  name: string;
+  about?: string;
+  controller: string;
+  voting_delay: number;
+  min_voting_period: number;
+  max_voting_period: number;
+  proposal_threshold: number;
+  quorum: number;
+  proposal_count: number;
+  vote_count: number;
+  created: number;
+};
+
 export type Proposal = {
   title: string;
   body: string;

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -1,21 +1,25 @@
-<script setup>
-import { onMounted, ref } from 'vue';
+<script setup lang="ts">
+import { onMounted, ref, Ref } from 'vue';
 import apollo from '@/helpers/apollo';
 import { PROPOSALS_QUERY } from '@/helpers/queries';
+import { Space, Proposal as ProposalType } from '@/types';
 
-const proposals = ref([]);
-const loaded = ref(false);
+const props = defineProps<{ space: Space }>();
+
+const proposals: Ref<ProposalType[]> = ref([]);
+const loaded: Ref<boolean> = ref(false);
 
 onMounted(async () => {
   const { data } = await apollo.query({
     query: PROPOSALS_QUERY,
-    variables: { first: 6 }
+    variables: {
+      first: 6,
+      space: props.space.id
+    }
   });
   proposals.value = data.proposals;
   loaded.value = true;
 });
-
-defineProps({ space: Object });
 </script>
 
 <template>

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -1,15 +1,21 @@
-<script setup>
-import { onMounted, ref } from 'vue';
+<script setup lang="ts">
+import { onMounted, ref, Ref } from 'vue';
 import apollo from '@/helpers/apollo';
 import { PROPOSALS_QUERY } from '@/helpers/queries';
+import { Space, Proposal as ProposalType } from '@/types';
 
-const proposals = ref([]);
-const loaded = ref(false);
+const props = defineProps<{ space: Space }>();
+
+const proposals: Ref<ProposalType[]> = ref([]);
+const loaded: Ref<boolean> = ref(false);
 
 onMounted(async () => {
   const { data } = await apollo.query({
     query: PROPOSALS_QUERY,
-    variables: { first: 24 }
+    variables: {
+      first: 24,
+      space: props.space.id
+    }
   });
   proposals.value = data.proposals;
   loaded.value = true;


### PR DESCRIPTION
Currently each space page displays all proposals, not filtered by space.

## Test plan
- Go to space page
- You only see proposals for that space.