### PR TITLE
feat: use Pinia to fetch spaces and proposals

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "electron": "^19.0.3",
     "graphql": "^16.5.0",
     "graphql-tag": "^2.12.6",
+    "pinia": "^2.0.22",
     "rollup-plugin-node-polyfills": "^0.2.1",
     "scrollmonitor": "^1.2.9",
     "vue": "^3.2.37",

--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -1,10 +1,11 @@
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import { _rt, shortenAddress } from '@/helpers/utils';
 import { useActions } from '@/composables/useActions';
 import { useAccount } from '@/composables/useAccount';
+import type { Proposal as ProposalType } from '@/types';
 
-defineProps({ proposal: Object });
+defineProps<{ proposal: ProposalType }>();
 
 const { voted } = useAccount();
 const { vote } = useActions();

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,15 +1,11 @@
-<script setup>
-import { onMounted, ref } from 'vue';
-import apollo from '@/helpers/apollo';
-import { SPACES_QUERY } from '@/helpers/queries';
+<script setup lang="ts">
+import { useSpacesStore } from '@/stores/spaces';
+import { onMounted } from 'vue';
 
-const spaces = ref([]);
-const loaded = ref(false);
+const spacesStore = useSpacesStore();
 
-onMounted(async () => {
-  const { data } = await apollo.query({ query: SPACES_QUERY });
-  spaces.value = data.spaces;
-  loaded.value = true;
+onMounted(() => {
+  spacesStore.fetchAll();
 });
 </script>
 
@@ -18,10 +14,10 @@ onMounted(async () => {
     <router-link :to="{ name: 'home' }" class="h-[72px] block">
       <IH-stop class="inline-block my-4 w-[32px] h-[32px] text-skin-link" />
     </router-link>
-    <UiLoading v-if="!loaded" class="block py-2" />
+    <UiLoading v-if="!spacesStore.loaded" class="block py-2" />
     <div v-else class="space-y-3 p-2">
       <router-link
-        v-for="(space, i) in spaces"
+        v-for="(space, i) in spacesStore.spaces"
         :key="i"
         :to="{ name: 'overview', params: { id: space.id } }"
         class="block"

--- a/src/composables/useAccount.ts
+++ b/src/composables/useAccount.ts
@@ -1,9 +1,9 @@
-import { ref } from 'vue';
+import { ref, Ref } from 'vue';
 import apollo from '@/helpers/apollo';
 import { VOTES_QUERY } from '@/helpers/queries';
 import { useWeb3 } from '@/composables/useWeb3';
 
-const voted = ref([]);
+const voted: Ref<string[]> = ref([]);
 
 export function useAccount() {
   const { web3 } = useWeb3();

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -1,10 +1,10 @@
 import { reactive, watch, computed } from 'vue';
 import { lsGet, lsSet, omit } from '@/helpers/utils';
-import type { Proposals } from '@/types';
+import type { Drafts } from '@/types';
 
-const proposals = reactive<Proposals>(lsGet('proposals', {}));
+const proposals = reactive<Drafts>(lsGet('proposals', {}));
 
-function removeEmpty(proposals: Proposals): Proposals {
+function removeEmpty(proposals: Drafts): Drafts {
   return Object.entries(proposals).reduce((acc, [id, proposal]) => {
     const { execution, ...rest } = omit(proposal, ['updatedAt']);
     const hasFormValues = Object.values(rest).some(val => !!val);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer';
 (window as any).Buffer = Buffer;
 import { createApp, h } from 'vue';
+import { createPinia } from 'pinia';
 import { LockPlugin } from '@snapshot-labs/lock/plugins/vue3';
 import options from '@/helpers/auth';
 import App from '@/App.vue';
@@ -8,9 +9,12 @@ import router from '@/router';
 import '@/helpers/auth';
 import '@/style.scss';
 
+const pinia = createPinia();
 const app = createApp({ render: () => h(App) })
   .use(router)
   .use(LockPlugin, options);
+
+app.use(pinia);
 app.mount('#app');
 
 export default app;

--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -14,6 +14,15 @@ export const useProposalsStore = defineStore('proposals', {
   state: () => ({
     proposals: {} as Record<string, SpaceRecord | undefined>
   }),
+  getters: {
+    getProposal: state => {
+      return (spaceId: string, proposalId) => {
+        const proposals = state.proposals[spaceId]?.proposals ?? [];
+
+        return proposals.find(proposal => proposal.proposal_id === proposalId);
+      };
+    }
+  },
   actions: {
     async fetchAll(spaceId: string) {
       if (!this.proposals[spaceId]) {
@@ -51,16 +60,14 @@ export const useProposalsStore = defineStore('proposals', {
       }
 
       const record = toRef(this.proposals, spaceId) as Ref<SpaceRecord>;
-      const alreadyFetched = record.value.proposals.find(
-        proposal => proposal.proposal_id === proposalId
-      );
-      if (alreadyFetched) return;
+      if (this.getProposal(spaceId, proposalId)) return;
 
       const { data } = await apollo.query({
         query: PROPOSAL_QUERY,
         variables: { id: `${spaceId}/${proposalId}` }
       });
 
+      if (this.getProposal(spaceId, proposalId)) return;
       record.value.proposals.push(data.proposal);
     }
   }

--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -1,0 +1,67 @@
+import { Ref, toRef } from 'vue';
+import { defineStore } from 'pinia';
+import apollo from '@/helpers/apollo';
+import { PROPOSALS_QUERY, PROPOSAL_QUERY } from '@/helpers/queries';
+import type { Proposal } from '@/types';
+
+type SpaceRecord = {
+  loading: boolean;
+  loaded: boolean;
+  proposals: Proposal[];
+};
+
+export const useProposalsStore = defineStore('proposals', {
+  state: () => ({
+    proposals: {} as Record<string, SpaceRecord | undefined>
+  }),
+  actions: {
+    async fetchAll(spaceId: string) {
+      if (!this.proposals[spaceId]) {
+        this.proposals[spaceId] = {
+          loading: false,
+          loaded: false,
+          proposals: []
+        };
+      }
+
+      const record = toRef(this.proposals, spaceId) as Ref<SpaceRecord>;
+      if (record.value.loading || record.value.loaded) return;
+
+      record.value.loading = true;
+
+      const { data } = await apollo.query({
+        query: PROPOSALS_QUERY,
+        variables: {
+          first: 5,
+          space: spaceId
+        }
+      });
+
+      record.value.proposals = data.proposals;
+      record.value.loaded = true;
+      record.value.loading = false;
+    },
+    async fetchProposal(spaceId: string, proposalId: number) {
+      if (!this.proposals[spaceId]) {
+        this.proposals[spaceId] = {
+          loading: false,
+          loaded: false,
+          proposals: []
+        };
+      }
+
+      const record = toRef(this.proposals, spaceId) as Ref<SpaceRecord>;
+      const alreadyFetched = record.value.proposals.find(
+        proposal => proposal.proposal_id === proposalId
+      );
+      if (alreadyFetched) return;
+
+      const { data } = await apollo.query({
+        query: PROPOSAL_QUERY,
+        variables: { id: `${spaceId}/${proposalId}` }
+      });
+
+      record.value.proposals.push(data.proposal);
+    }
+  }
+});

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia';
+import apollo from '@/helpers/apollo';
+import { SPACES_QUERY, SPACE_QUERY } from '@/helpers/queries';
+import type { Space } from '@/types';
+
+export const useSpacesStore = defineStore('spaces', {
+  state: () => ({
+    loading: false,
+    loaded: false,
+    spaces: [] as Space[]
+  }),
+  getters: {
+    spacesMap: state => new Map(state.spaces.map(space => [space.id, space]))
+  },
+  actions: {
+    async fetchAll() {
+      if (this.loading) return;
+      this.loading = true;
+
+      const { data } = await apollo.query({ query: SPACES_QUERY });
+      this.spaces = data.spaces;
+      this.loaded = true;
+      this.loading = false;
+    },
+    async fetchSpace(id: string) {
+      if (this.spacesMap.get(id)) return;
+
+      const { data } = await apollo.query({
+        query: SPACE_QUERY,
+        variables: { id }
+      });
+
+      this.spaces.push(data.space);
+    }
+  }
+});

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -30,6 +30,7 @@ export const useSpacesStore = defineStore('spaces', {
         variables: { id }
       });
 
+      if (this.spacesMap.get(id)) return;
       this.spaces.push(data.space);
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,30 @@ export type Space = {
 };
 
 export type Proposal = {
+  id: string;
+  proposal_id: number;
+  space: string;
+  author: string;
+  execution_hash: string;
+  metadata_uri: string;
+  title: string;
+  body: string;
+  discussion: string;
+  execution: string;
+  start: number;
+  min_end: number;
+  max_end: number;
+  snapshot: number;
+  scores_1: number;
+  scores_2: number;
+  scores_3: number;
+  scores_total: number;
+  created: number;
+  tx: string;
+  vote_count: number;
+};
+
+export type Draft = {
   title: string;
   body: string;
   discussion: string;
@@ -24,7 +48,7 @@ export type Proposal = {
   updatedAt: number;
 };
 
-export type Proposals = Record<string, Proposal>;
+export type Drafts = Record<string, Draft>;
 
 export type BaseTransaction = {
   to: string;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,15 +1,11 @@
-<script setup>
-import { onMounted, ref } from 'vue';
-import apollo from '@/helpers/apollo';
-import { SPACES_QUERY } from '@/helpers/queries';
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useSpacesStore } from '@/stores/spaces';
 
-const spaces = ref([]);
-const loaded = ref(false);
+const spacesStore = useSpacesStore();
 
-onMounted(async () => {
-  const { data } = await apollo.query({ query: SPACES_QUERY });
-  spaces.value = data.spaces;
-  loaded.value = true;
+onMounted(() => {
+  spacesStore.fetchAll();
 });
 </script>
 
@@ -23,12 +19,12 @@ onMounted(async () => {
     </div>
     <Container class="max-w-screen-md">
       <h3 class="mb-2" v-text="'Spaces'" />
-      <UiLoading v-if="!loaded" class="block mb-2" />
+      <UiLoading v-if="!spacesStore.loaded" class="block mb-2" />
     </Container>
-    <Container v-if="loaded" class="max-w-screen-md" slim>
+    <Container v-if="spacesStore.loaded" class="max-w-screen-md" slim>
       <div class="x-block mb-3">
         <router-link
-          v-for="space in spaces"
+          v-for="space in spacesStore.spaces"
           :key="space.id"
           :to="{ name: 'overview', params: { id: space.id } }"
           class="p-4 text-skin-text border-b last:border-b-0 block"
@@ -50,7 +46,10 @@ onMounted(async () => {
     </Container>
     <Container class="max-w-screen-md">
       <router-link
-        :to="{ name: 'editor', params: { id: spaces[0]?.id || '0' } }"
+        :to="{
+          name: 'editor',
+          params: { id: spacesStore.spaces[0]?.id || '0' }
+        }"
         class="mb-2 block"
       >
         <h3 v-text="'Editor'" />

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -15,11 +15,7 @@ const space = route.params.space as string;
 const modalOpenVotes = ref(false);
 const modalOpenTimeline = ref(false);
 
-const proposal = computed(() =>
-  proposalsStore.proposals[space]?.proposals.find(
-    proposal => proposal.proposal_id === id
-  )
-);
+const proposal = computed(() => proposalsStore.getProposal(space, id));
 
 const discussion = computed(() => {
   if (!proposal.value?.discussion) return null;

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -1,41 +1,43 @@
-<script setup>
-import { onMounted, ref } from 'vue';
+<script setup lang="ts">
+import { onMounted, ref, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { sanitizeUrl } from '@braintree/sanitize-url';
+import { useProposalsStore } from '@/stores/proposals';
 import { _rt, _n, shortenAddress, getUrl } from '@/helpers/utils';
-import apollo from '@/helpers/apollo';
-import { PROPOSAL_QUERY } from '@/helpers/queries';
 import { useActions } from '@/composables/useActions';
 import txs from '@/helpers/execution.json';
 
 const route = useRoute();
+const proposalsStore = useProposalsStore();
 const { vote } = useActions();
-const id = parseInt(route.params.id || 0);
-const space = route.params.space;
-const proposal = ref({});
-const discussion = ref('');
-const loaded = ref(false);
+const id = parseInt((route.params.id as string) || '0');
+const space = route.params.space as string;
 const modalOpenVotes = ref(false);
 const modalOpenTimeline = ref(false);
 
-onMounted(async () => {
-  const { data } = await apollo.query({
-    query: PROPOSAL_QUERY,
-    variables: { id: `${space}/${id}` }
-  });
-  proposal.value = data.proposal;
-  if (
-    data.proposal.discussion &&
-    sanitizeUrl(data.proposal.discussion) !== 'about:blank'
+const proposal = computed(() =>
+  proposalsStore.proposals[space]?.proposals.find(
+    proposal => proposal.proposal_id === id
   )
-    discussion.value = sanitizeUrl(data.proposal.discussion);
-  loaded.value = true;
+);
+
+const discussion = computed(() => {
+  if (!proposal.value?.discussion) return null;
+
+  const output = sanitizeUrl(proposal.value.discussion);
+  if (output === 'about:blank') return null;
+
+  return output;
+});
+
+onMounted(() => {
+  proposalsStore.fetchProposal(space, id);
 });
 </script>
 
 <template>
   <div>
-    <Container v-if="!loaded" class="pt-5">
+    <Container v-if="!proposal" class="pt-5">
       <UiLoading />
     </Container>
     <div v-else>

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -1,31 +1,14 @@
-<script setup>
+<script setup lang="ts">
 import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import apollo from '@/helpers/apollo';
-import { SPACE_QUERY } from '@/helpers/queries';
-import { useState } from '@/composables/useState';
+import { useSpacesStore } from '@/stores/spaces';
 
 const route = useRoute();
-const { get, set } = useState();
-const id = route.params.id;
+const spacesStore = useSpacesStore();
+const id = route.params.id as string;
 
-let space = $ref({});
-let loaded = $ref(false);
-
-onMounted(async () => {
-  const state = get();
-  if (state?.spaces[id]) {
-    space = state.spaces[id];
-  } else {
-    const { data } = await apollo.query({
-      query: SPACE_QUERY,
-      variables: { id }
-    });
-    state.spaces[id] = data.space;
-    space = data.space;
-    set(state);
-  }
-  loaded = true;
+onMounted(() => {
+  spacesStore.fetchSpace(id);
 });
 </script>
 
@@ -39,8 +22,8 @@ onMounted(async () => {
     </div>
     <div>
       <div class="ml-0 lg:ml-[240px] mr-0 xl:mr-[240px]">
-        <UiLoading v-if="!loaded" class="block p-4" />
-        <router-view v-else :space="space" />
+        <UiLoading v-if="!spacesStore.spacesMap.has(id)" class="block p-4" />
+        <router-view v-else :space="spacesStore.spacesMap.get(id)" />
       </div>
       <div
         class="invisible xl:visible fixed w-[240px] border-l bottom-0 top-[72px] right-0"

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -1,25 +1,19 @@
 <script setup lang="ts">
-import { onMounted, ref, Ref } from 'vue';
-import apollo from '@/helpers/apollo';
-import { PROPOSALS_QUERY } from '@/helpers/queries';
-import { Space, Proposal as ProposalType } from '@/types';
+import { onMounted, computed } from 'vue';
+import { useProposalsStore } from '@/stores/proposals';
+import { Space } from '@/types';
 
 const props = defineProps<{ space: Space }>();
 
-const proposals: Ref<ProposalType[]> = ref([]);
-const loaded: Ref<boolean> = ref(false);
+const proposalsStore = useProposalsStore();
 
-onMounted(async () => {
-  const { data } = await apollo.query({
-    query: PROPOSALS_QUERY,
-    variables: {
-      first: 5,
-      space: props.space.id
-    }
-  });
-  proposals.value = data.proposals;
-  loaded.value = true;
+onMounted(() => {
+  proposalsStore.fetchAll(props.space.id);
 });
+
+const proposalsRecord = computed(
+  () => proposalsStore.proposals[props.space.id]
+);
 </script>
 
 <template>
@@ -55,14 +49,17 @@ onMounted(async () => {
     </div>
     <div>
       <Label :label="'Active proposals'" />
-      <UiLoading v-if="!loaded" class="block px-4 py-3" />
+      <UiLoading v-if="!proposalsRecord?.loaded" class="block px-4 py-3" />
       <div v-else>
         <Proposal
-          v-for="(proposal, i) in proposals"
+          v-for="(proposal, i) in proposalsRecord?.proposals"
           :key="i"
           :proposal="proposal"
         />
-        <div v-if="!proposals.length" class="px-4 py-3 text-skin-link">
+        <div
+          v-if="!proposalsRecord?.proposals.length"
+          class="px-4 py-3 text-skin-link"
+        >
           <IH-exclamation-circle class="inline-block mr-2" />
           <span v-text="'There are no proposals here.'" />
         </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,8 @@
     "noImplicitAny": false,
     "skipLibCheck": true
   },
+  "vueCompilerOptions": {
+    "experimentalAllowTypeNarrowingInInlineHandlers": true
+  },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1740,7 +1740,7 @@
     "@vue/compiler-dom" "3.2.37"
     "@vue/shared" "3.2.37"
 
-"@vue/devtools-api@^6.1.4":
+"@vue/devtools-api@^6.1.4", "@vue/devtools-api@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.2.1.tgz#6f2948ff002ec46df01420dfeff91de16c5b4092"
   integrity sha512-OEgAMeQXvCoJ+1x8WyQuVZzFo0wcyCmUR3baRVLmKBo1LmYZWMlRiXlux5jd0fqVJu6PfDbOrZItVqUEzLobeQ==
@@ -5858,6 +5858,14 @@ pify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
   integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
+
+pinia@^2.0.22:
+  version "2.0.22"
+  resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.22.tgz#435468e8e6d6aa6f319cb727b23bd51db0844c4a"
+  integrity sha512-u+b8/BC+tmvo3ACbYO2w5NfxHWFOjvvw9DQnyT0dW8aUMCPRQT5QnfZ5R5W2MzZBMTeZRMQI7V/QFbafmM9QHw==
+  dependencies:
+    "@vue/devtools-api" "^6.2.1"
+    vue-demi "*"
 
 pkg-dir@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/sx-ui/issues/312

- Added Pinia.
- Migrated Spaces/Proposals to fetch data from Pinia action to global store.
- Renamed old `Proposal` type to `Draft`.

## Test plan
- Go to Homepage - spaces load in sidebar and homepage.
- Click space - it loads instantly (only proposals are loading).
- Refresh page. Space is displayed.
- Click Proposals on the right. It displays proposals without refetching.
- Click on proposal - it loads instantly.
- Refresh page. Proposal is displayed.