### PR TITLE
chore: enforce prettier to pass

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,8 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     'vue/multi-word-component-names': 'off',
     'vue/require-default-prop': 'off',
-    'vue/no-v-html': 'off'
+    'vue/no-v-html': 'off',
+    'prettier/prettier': 'error'
   },
   globals: {
     $ref: 'readonly',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --port=8080",
     "build": "vite build",
-    "lint:nofix": "eslint \"./src/*/**/*.{ts,vue,json}\"",
+    "lint:nofix": "eslint \"./src/**/*.{ts,vue,json}\"",
     "lint": "yarn lint:nofix --fix",
     "test:unit": "vitest",
     "electron:start": "electron ."

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,11 +36,14 @@ watch(web3Account, async () => {
   >
     <UiLoading v-if="app.loading || !app.init" class="overlay big" />
     <div v-else class="pb-6 flex">
-	    <Sidebar class="invisible md:visible"/>
-	    <div class="flex-auto">
-		    <Topnav />
-		    <router-view :key="$route.path" class="flex-auto mt-[72px] ml-0 md:ml-[72px]" />
-	    </div>
+      <Sidebar class="invisible md:visible" />
+      <div class="flex-auto">
+        <Topnav />
+        <router-view
+          :key="$route.path"
+          class="flex-auto mt-[72px] ml-0 md:ml-[72px]"
+        />
+      </div>
     </div>
     <div id="modal" />
   </div>

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,16 +12,20 @@ import User from '@/views/User.vue';
 
 const routes: any[] = [
   { path: '/', name: 'home', component: Home },
-  { path: '/:id', component: Space, children: [
+  {
+    path: '/:id',
+    component: Space,
+    children: [
       { path: '', name: 'overview', component: Overview },
       { path: 'proposals', name: 'proposals', component: Proposals },
       { path: 'settings', name: 'settings', component: Settings },
       { path: 'treasury', name: 'treasury', component: Treasury }
     ]
   },
-  { path: '/:id/create/:key?', component: Create, children: [
-      { path: '', name: 'editor', component: Editor }
-    ]
+  {
+    path: '/:id/create/:key?',
+    component: Create,
+    children: [{ path: '', name: 'editor', component: Editor }]
   },
   { path: '/:space/proposal/:id?', name: 'proposal', component: Proposal },
   { path: '/:id/create', name: 'create', component: Create },


### PR DESCRIPTION
- Make prettier ruler errors.
- Update eslint path so it runs on files directly in `src` too.
- Reformat files that are not properly formatted.