### PR TITLE
feat: add Vote component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
   env: {
-    node: true
+    node: true,
+    'vue/setup-compiler-macros': true
   },
   extends: [
     'plugin:vue/vue3-recommended',

--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -47,6 +47,9 @@ const modalOpenTimeline = ref(false);
           <template #voted>
             <Results :proposal="proposal" />
           </template>
+          <template #ended>
+            <Results :proposal="proposal" />
+          </template>
           <div class="space-x-2 py-2">
             <UiButton
               class="w-full !text-green !border-green !w-[40px] !h-[40px] !px-0"

--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -2,12 +2,10 @@
 import { ref } from 'vue';
 import { _rt, shortenAddress } from '@/helpers/utils';
 import { useActions } from '@/composables/useActions';
-import { useAccount } from '@/composables/useAccount';
 import type { Proposal as ProposalType } from '@/types';
 
 defineProps<{ proposal: ProposalType }>();
 
-const { voted } = useAccount();
 const { vote } = useActions();
 const modalOpenVotes = ref(false);
 const modalOpenTimeline = ref(false);
@@ -44,40 +42,47 @@ const modalOpenTimeline = ref(false);
         </span>
       </div>
       <div class="hidden md:block">
-        <div v-if="!voted.includes(proposal.id)" class="space-x-2 py-2">
-          <UiButton
-            class="w-full !text-green !border-green !w-[40px] !h-[40px] !px-0"
-            @click="vote(proposal.space.id, proposal.proposal_id, 1)"
-          >
-            <IH-check class="inline-block" />
-          </UiButton>
-          <UiButton
-            class="w-full !text-red !border-red !w-[40px] !h-[40px] !px-0"
-            @click="vote(proposal.space.id, proposal.proposal_id, 2)"
-          >
-            <IH-x class="inline-block" />
-          </UiButton>
-          <UiButton
-            class="w-full !text-gray-500 !border-gray-500 !w-[40px] !h-[40px] !px-0"
-            @click="vote(proposal.space.id, proposal.proposal_id, 3)"
-          >
-            <IH-arrow-sm-right class="inline-block" />
-          </UiButton>
-        </div>
-        <div v-else class="rounded-full h-[6px] overflow-hidden">
-          <div
-            v-for="(score, i) in Array(3)"
-            :key="i"
-            class="choice-bg float-left h-full"
-            :style="{
-              width: `${(
-                (100 / proposal.scores_total) *
-                proposal[`scores_${i + 1}`]
-              ).toFixed(3)}%`
-            }"
-            :class="`_${i + 1}`"
-          />
-        </div>
+        <Vote :proposal="proposal">
+          <template #unsupported><div /></template>
+          <template #voted>
+            <div class="flex items-center h-full">
+              <div class="rounded-full w-[100px] h-[6px] overflow-hidden">
+                <div
+                  v-for="(score, i) in Array(3)"
+                  :key="i"
+                  class="choice-bg float-left h-full"
+                  :style="{
+                    width: `${(
+                      (100 / proposal.scores_total) *
+                      proposal[`scores_${i + 1}`]
+                    ).toFixed(3)}%`
+                  }"
+                  :class="`_${i + 1}`"
+                />
+              </div>
+            </div>
+          </template>
+          <div class="space-x-2 py-2">
+            <UiButton
+              class="w-full !text-green !border-green !w-[40px] !h-[40px] !px-0"
+              @click="vote(proposal.space.id, proposal.proposal_id, 1)"
+            >
+              <IH-check class="inline-block" />
+            </UiButton>
+            <UiButton
+              class="w-full !text-red !border-red !w-[40px] !h-[40px] !px-0"
+              @click="vote(proposal.space.id, proposal.proposal_id, 2)"
+            >
+              <IH-x class="inline-block" />
+            </UiButton>
+            <UiButton
+              class="w-full !text-gray-500 !border-gray-500 !w-[40px] !h-[40px] !px-0"
+              @click="vote(proposal.space.id, proposal.proposal_id, 3)"
+            >
+              <IH-arrow-sm-right class="inline-block" />
+            </UiButton>
+          </div>
+        </Vote>
       </div>
     </div>
     <teleport to="#modal">

--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -45,22 +45,7 @@ const modalOpenTimeline = ref(false);
         <Vote :proposal="proposal">
           <template #unsupported><div /></template>
           <template #voted>
-            <div class="flex items-center h-full">
-              <div class="rounded-full w-[100px] h-[6px] overflow-hidden">
-                <div
-                  v-for="(score, i) in Array(3)"
-                  :key="i"
-                  class="choice-bg float-left h-full"
-                  :style="{
-                    width: `${(
-                      (100 / proposal.scores_total) *
-                      proposal[`scores_${i + 1}`]
-                    ).toFixed(3)}%`
-                  }"
-                  :class="`_${i + 1}`"
-                />
-              </div>
-            </div>
+            <Results :proposal="proposal" />
           </template>
           <div class="space-x-2 py-2">
             <UiButton

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -10,6 +10,12 @@ withDefaults(
     width: 100
   }
 );
+
+const labels = {
+  0: 'For',
+  1: 'Against',
+  2: 'Abstain'
+};
 </script>
 
 <template>
@@ -22,11 +28,13 @@ withDefaults(
     >
       <div
         v-if="proposal.scores_total === 0"
+        title="No votes"
         class="choice-bg _3 float-left w-full h-full"
       />
       <div
         v-for="(score, i) in Array(3)"
         :key="i"
+        :title="labels[i]"
         class="choice-bg float-left h-full"
         :style="{
           width: `${(

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { Proposal as ProposalType } from '@/types';
+
+withDefaults(
+  defineProps<{
+    proposal: ProposalType;
+    width?: number | 'full';
+  }>(),
+  {
+    width: 100
+  }
+);
+</script>
+
+<template>
+  <div class="flex items-center h-full">
+    <div
+      class="rounded-full h-[6px] overflow-hidden"
+      :class="width === 'full' ? 'w-full' : `w-[${width}px]`"
+    >
+      <div
+        v-for="(score, i) in Array(3)"
+        :key="i"
+        class="choice-bg float-left h-full"
+        :style="{
+          width: `${(
+            (100 / proposal.scores_total) *
+            proposal[`scores_${i + 1}`]
+          ).toFixed(3)}%`
+        }"
+        :class="`_${i + 1}`"
+      />
+    </div>
+  </div>
+</template>

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -16,8 +16,14 @@ withDefaults(
   <div class="flex items-center h-full">
     <div
       class="rounded-full h-[6px] overflow-hidden"
-      :class="width === 'full' ? 'w-full' : `w-[${width}px]`"
+      :style="{
+        width: width === 'full' ? '100%' : `${width}px`
+      }"
     >
+      <div
+        v-if="proposal.scores_total === 0"
+        class="choice-bg _3 float-left w-full h-full"
+      />
       <div
         v-for="(score, i) in Array(3)"
         :key="i"

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -27,6 +27,11 @@ const isSupported = computed(() => {
   <slot v-if="voted.includes(proposal.id)" name="voted">
     You have already voted for this proposal
   </slot>
+
+  <slot v-else-if="proposal.max_end * 1000 <= Date.now()" name="ended">
+    Proposal voting window has ended
+  </slot>
+
   <slot v-else-if="!isSupported" name="unsupported">
     Voting for this proposal is not supported
   </slot>

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useAccount } from '@/composables/useAccount';
+import {
+  SUPPORTED_AUTHENTICATORS,
+  SUPPORTED_STRATEGIES
+} from '@/helpers/constants';
+import type { Proposal as ProposalType } from '@/types';
+
+const props = defineProps<{ proposal: ProposalType }>();
+
+const { voted } = useAccount();
+
+const isSupported = computed(() => {
+  const hasSupportedAuthenticator = props.proposal.space.authenticators.find(
+    authenticator => SUPPORTED_AUTHENTICATORS[authenticator]
+  );
+  const hasSupportedStrategies = props.proposal.strategies.find(
+    strategy => SUPPORTED_STRATEGIES[strategy]
+  );
+
+  return hasSupportedAuthenticator && hasSupportedStrategies;
+});
+</script>
+
+<template>
+  <slot v-if="voted.includes(proposal.id)" name="voted">
+    You have already voted for this proposal
+  </slot>
+  <slot v-else-if="!isSupported" name="unsupported">
+    Voting for this proposal is not supported
+  </slot>
+  <slot v-else></slot>
+</template>

--- a/src/composables/useAccount.ts
+++ b/src/composables/useAccount.ts
@@ -2,6 +2,7 @@ import { ref, Ref } from 'vue';
 import apollo from '@/helpers/apollo';
 import { VOTES_QUERY } from '@/helpers/queries';
 import { useWeb3 } from '@/composables/useWeb3';
+import type { Vote } from '@/types';
 
 const voted: Ref<string[]> = ref([]);
 
@@ -17,7 +18,9 @@ export function useAccount() {
         voter: account
       }
     });
-    voted.value = data.votes.map(vote => `${vote.space}/${vote.proposal}`);
+    voted.value = (data.votes as Vote[]).map(
+      vote => `${vote.space.id}/${vote.proposal}`
+    );
   }
 
   return { loadVotes, voted };

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -1,5 +1,14 @@
 export const ETH_CONTRACT = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
+export const SUPPORTED_AUTHENTICATORS = {
+  '0x6aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369': true
+};
+
+export const SUPPORTED_STRATEGIES = {
+  '0x515fbfa25bcf1e9419cdb8886cb8878d2705cdd2be8cf434675e19314b89d71': true,
+  '0x68da98d7798439f16b63b61644e7b27c932d5c051a455a978aa95488d5dcc9b': true
+};
+
 export const AUTHS = {
   '0xb32364e042cb948be62a09355595a4b80dfff4eb11a485c1950ace70b0e835': 'Vanilla',
   '0x6aac1e90da5df37bd59ac52b638a22de15231cbb78353b121df987873d0f369':

--- a/src/helpers/queries.ts
+++ b/src/helpers/queries.ts
@@ -7,6 +7,7 @@ export const PROPOSAL_QUERY = gql`
       proposal_id
       space {
         id
+        authenticators
       }
       author {
         id
@@ -25,6 +26,7 @@ export const PROPOSAL_QUERY = gql`
       scores_2
       scores_3
       scores_total
+      strategies
       created
       tx
       vote_count
@@ -44,6 +46,7 @@ export const PROPOSALS_QUERY = gql`
       proposal_id
       space {
         id
+        authenticators
       }
       author {
         id
@@ -62,6 +65,7 @@ export const PROPOSALS_QUERY = gql`
       scores_2
       scores_3
       scores_total
+      strategies
       created
       tx
       vote_count

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type Proposal = {
   proposal_id: number;
   space: {
     id: string;
+    authenticators: string[];
   };
   author: {
     id: string;
@@ -39,6 +40,7 @@ export type Proposal = {
   scores_2: number;
   scores_3: number;
   scores_total: number;
+  strategies: string[];
   created: number;
   tx: string;
   vote_count: number;

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -90,26 +90,28 @@ onMounted(() => {
         </a>
       </Container>
       <Container>
-        <div class="grid grid-cols-3 gap-2 mb-3">
-          <UiButton
-            class="w-full !text-white !bg-green !border-green"
-            @click="vote(space, proposal.proposal_id, 1)"
-          >
-            <IH-check class="inline-block" />
-          </UiButton>
-          <UiButton
-            class="w-full !text-white !bg-red !border-red"
-            @click="vote(space, proposal.proposal_id, 2)"
-          >
-            <IH-x class="inline-block" />
-          </UiButton>
-          <UiButton
-            class="w-full !text-white !bg-gray-500 !border-gray-500"
-            @click="vote(space, proposal.proposal_id, 3)"
-          >
-            <IH-arrow-right class="inline-block" />
-          </UiButton>
-        </div>
+        <Vote :proposal="proposal">
+          <div class="grid grid-cols-3 gap-2 mb-3">
+            <UiButton
+              class="w-full !text-white !bg-green !border-green"
+              @click="vote(space, proposal.proposal_id, 1)"
+            >
+              <IH-check class="inline-block" />
+            </UiButton>
+            <UiButton
+              class="w-full !text-white !bg-red !border-red"
+              @click="vote(space, proposal.proposal_id, 2)"
+            >
+              <IH-x class="inline-block" />
+            </UiButton>
+            <UiButton
+              class="w-full !text-white !bg-gray-500 !border-gray-500"
+              @click="vote(space, proposal.proposal_id, 3)"
+            >
+              <IH-arrow-right class="inline-block" />
+            </UiButton>
+          </div>
+        </Vote>
         <div>
           <a class="text-skin-text" @click="modalOpenVotes = true">
             {{ _n(proposal.vote_count) }} votes

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -91,7 +91,10 @@ onMounted(() => {
       </Container>
       <Container>
         <Vote :proposal="proposal">
-          <div class="grid grid-cols-3 gap-2 mb-3">
+          <template #voted>
+            <Results :proposal="proposal" width="full" />
+          </template>
+          <div class="grid grid-cols-3 gap-2">
             <UiButton
               class="w-full !text-white !bg-green !border-green"
               @click="vote(space, proposal.proposal_id, 1)"
@@ -112,7 +115,7 @@ onMounted(() => {
             </UiButton>
           </div>
         </Vote>
-        <div>
+        <div class="mt-3">
           <a class="text-skin-text" @click="modalOpenVotes = true">
             {{ _n(proposal.vote_count) }} votes
           </a>

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -92,6 +92,11 @@ onMounted(() => {
       <Container>
         <Vote :proposal="proposal">
           <template #voted>
+            <h4 class="mb-2">Results</h4>
+            <Results :proposal="proposal" width="full" />
+          </template>
+          <template #ended>
+            <h4 class="mb-2">Results</h4>
             <Results :proposal="proposal" width="full" />
           </template>
           <div class="grid grid-cols-3 gap-2">


### PR DESCRIPTION
This PR adds Vote component that unifies logic for handling voting edge cases:
- User already voted for proposal
- Proposal is not supported (unsupported authenticators/strategies).

With this component you just provide different UI for those cases so you don't have to worry that in some place you can vote when you shouldn't.

This PR also makes Vote ratio to show up again.

## Test plan

- In Space view, proposals that were already voted on have vote ratio displayed.
- In Space view, proposals that are unsupported (go to Tripod DAO) don't have buttons to vote.
- In Space view, other proposals have vote buttons visible.
- In Proposal view, proposals that were already voted have "You have already voted for this proposal" message.
- In Proposal view, proposals that are unsupported (go to Tripod DAO) have "Voting for this proposal is not supported" message.
- In Proposal view, other proposals have vote buttons visible.

## Screenshots

<img width="780" alt="image" src="https://user-images.githubusercontent.com/1968722/192160270-01446a72-165c-4647-9a3c-d6b4aa2f6952.png">
<img width="598" alt="image" src="https://user-images.githubusercontent.com/1968722/192160278-0eb30755-f21c-4d1e-a163-c7222db58ac2.png">
