### PR TITLE
feat: Add token price and 24h change in treasury page

### DIFF
--- a/src/composables/useBalances.ts
+++ b/src/composables/useBalances.ts
@@ -24,7 +24,15 @@ export function useBalances() {
             formatUnits(item.balance || 0, item.contract_decimals || 0)
           ) > 0.001 && item.contract_address !== ETH_CONTRACT
       )
-    ].sort((a, b) => b.quote - a.quote);
+    ]
+      .sort((a, b) => b.quote - a.quote)
+      .map(asset => {
+        if (asset.quote_rate && asset.quote_rate_24h)
+          asset.percent =
+            (100 / asset.quote_rate) *
+            (asset.quote_rate - asset.quote_rate_24h);
+        return asset;
+      });
     loading.value = false;
     loaded.value = true;
   }

--- a/src/helpers/space.json
+++ b/src/helpers/space.json
@@ -1,4 +1,4 @@
 {
   "network": "1",
-  "wallet": "0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f"
+  "wallet": "0xaf28bcb48c40dbc86f52d459a6562f658fc94b1e"
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -78,7 +78,7 @@ h3 {
 }
 
 h4 {
-  @apply text-md;
+  @apply text-[19px];
 }
 
 h5 {

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -5,7 +5,6 @@ import { sanitizeUrl } from '@braintree/sanitize-url';
 import { useProposalsStore } from '@/stores/proposals';
 import { _rt, _n, shortenAddress, getUrl } from '@/helpers/utils';
 import { useActions } from '@/composables/useActions';
-import txs from '@/helpers/execution.json';
 
 const route = useRoute();
 const proposalsStore = useProposalsStore();
@@ -33,118 +32,117 @@ onMounted(() => {
 
 <template>
   <div>
-    <Container v-if="!proposal" class="pt-5">
-      <UiLoading />
-    </Container>
-    <div v-else>
-      <Container class="pt-5">
-        <h1 class="mb-3">
-          {{ proposal.title || `Proposal #${proposal.proposal_id}` }}
-        </h1>
-        <div class="flex mb-4 items-center">
-          <div class="flex-auto space-x-2">
-            <router-link
-              :to="{
-                name: 'user',
-                params: { id: proposal.author.id }
-              }"
-            >
-              <Stamp :id="proposal.author.id" :size="24" class="mr-1" />
-              {{ shortenAddress(proposal.author.id) }}
-            </router-link>
-            <span
-              >·
-              <a
-                class="text-skin-text"
-                @click="modalOpenTimeline = true"
-                v-text="_rt(proposal.created)"
-              />
-            </span>
-          </div>
-          <a :href="sanitizeUrl(getUrl(proposal.metadata_uri))" target="_blank">
-            <UiButton class="!w-[46px] !h-[46px] !px-[12px]">
-              <IH-dots-horizontal />
-            </UiButton>
-          </a>
-        </div>
-        <div v-if="proposal.body" class="mb-4">
-          <p v-text="proposal.body" />
-        </div>
-      </Container>
-      <Container class="space-y-4 mb-4" slim>
-        <BlockExecution :txs="txs" />
-        <a
-          v-if="discussion"
-          :href="discussion"
-          target="_blank"
-          class="x-block block mb-5"
-        >
-          <h4 class="px-4 py-3">
-            <IH-chat-alt class="inline-block mr-2" /> Discussion
-            <IH-external-link class="float-right mt-1" />
-          </h4>
-          <Preview
-            :url="discussion"
-            class="!border-0 !border-t !rounded-none"
-          />
-        </a>
-      </Container>
-      <Container>
-        <Vote :proposal="proposal">
-          <template #voted="{ vote: userVote }">
-            <h4 class="mb-2">Results</h4>
-            <Results :proposal="proposal" width="full" />
-            <div class="mt-2">
-              <div v-if="userVote.choice === 1">
-                You already voted <strong>for</strong> this proposal
-              </div>
-              <div v-else-if="userVote.choice === 2">
-                You already voted <strong>against</strong> this proposal
-              </div>
-              <div v-else-if="userVote.choice === 3">
-                You already <strong>abstained</strong> from voting on this
-                proposal
-              </div>
+    <Container class="pt-5">
+      <UiLoading v-if="!proposal" />
+      <div v-else>
+        <div>
+          <h1 class="mb-3">
+            {{ proposal.title || `Proposal #${proposal.proposal_id}` }}
+          </h1>
+          <div class="flex mb-4 items-center">
+            <div class="flex-auto space-x-2">
+              <router-link
+                :to="{
+                  name: 'user',
+                  params: { id: proposal.author.id }
+                }"
+              >
+                <Stamp :id="proposal.author.id" :size="24" class="mr-1" />
+                {{ shortenAddress(proposal.author.id) }}
+              </router-link>
+              <span
+                >·
+                <a
+                  class="text-skin-text"
+                  @click="modalOpenTimeline = true"
+                  v-text="_rt(proposal.created)"
+                />
+              </span>
             </div>
-          </template>
-          <template #ended>
-            <h4 class="mb-2">Results</h4>
-            <Results :proposal="proposal" width="full" />
-          </template>
-          <div class="grid grid-cols-3 gap-2">
-            <UiButton
-              class="w-full !text-white !bg-green !border-green"
-              @click="vote(proposal, 1)"
+            <a
+              :href="sanitizeUrl(getUrl(proposal.metadata_uri))"
+              target="_blank"
             >
-              <IH-check class="inline-block" />
-            </UiButton>
-            <UiButton
-              class="w-full !text-white !bg-red !border-red"
-              @click="vote(proposal, 2)"
-            >
-              <IH-x class="inline-block" />
-            </UiButton>
-            <UiButton
-              class="w-full !text-white !bg-gray-500 !border-gray-500"
-              @click="vote(proposal, 3)"
-            >
-              <IH-arrow-right class="inline-block" />
-            </UiButton>
+              <UiButton class="!w-[46px] !h-[46px] !px-[12px]">
+                <IH-dots-horizontal />
+              </UiButton>
+            </a>
           </div>
-        </Vote>
-        <div class="mt-3">
-          <a class="text-skin-text" @click="modalOpenVotes = true">
-            {{ _n(proposal.vote_count) }} votes
-          </a>
-          ·
-          <a
-            class="text-skin-text"
-            @click="modalOpenTimeline = true"
-            v-text="_rt(proposal.max_end)"
-          />
+          <div v-if="proposal.body" class="mb-4">
+            <p v-text="proposal.body" />
+          </div>
         </div>
-      </Container>
-    </div>
+
+        <div v-if="discussion">
+          <h4 class="mb-3 eyebrow">
+            <IH-chat-alt class="inline-block mr-2" /> Discussion
+          </h4>
+          <a :href="discussion" target="_blank" class="block mb-5">
+            <Preview :url="discussion" />
+          </a>
+        </div>
+
+        <div>
+          <Vote :proposal="proposal">
+            <template #voted="{ vote: userVote }">
+              <h4 class="mb-3 eyebrow">
+                <IH-chart-bar class="inline-block mr-2" /> Results
+              </h4>
+              <Results :proposal="proposal" width="full" />
+              <div class="mt-2">
+                <div v-if="userVote.choice === 1">
+                  You already voted <strong>for</strong> this proposal
+                </div>
+                <div v-else-if="userVote.choice === 2">
+                  You already voted <strong>against</strong> this proposal
+                </div>
+                <div v-else-if="userVote.choice === 3">
+                  You already <strong>abstained</strong> from voting on this
+                  proposal
+                </div>
+              </div>
+            </template>
+            <template #ended>
+              <h4 class="mb-3 eyebrow">
+                <IH-chart-bar class="inline-block mr-2" /> Results
+              </h4>
+              <Results :proposal="proposal" width="full" />
+            </template>
+            <div class="grid grid-cols-3 gap-2">
+              <UiButton
+                class="w-full !text-white !bg-green !border-green"
+                @click="vote(proposal, 1)"
+              >
+                <IH-check class="inline-block" />
+              </UiButton>
+              <UiButton
+                class="w-full !text-white !bg-red !border-red"
+                @click="vote(proposal, 2)"
+              >
+                <IH-x class="inline-block" />
+              </UiButton>
+              <UiButton
+                class="w-full !text-white !bg-gray-500 !border-gray-500"
+                @click="vote(proposal, 3)"
+              >
+                <IH-arrow-right class="inline-block" />
+              </UiButton>
+            </div>
+          </Vote>
+          <div class="mt-3">
+            <a class="text-skin-text" @click="modalOpenVotes = true">
+              {{ _n(proposal.vote_count) }} votes
+            </a>
+            ·
+            <a
+              class="text-skin-text"
+              @click="modalOpenTimeline = true"
+              v-text="_rt(proposal.max_end)"
+            />
+          </div>
+        </div>
+      </div>
+    </Container>
     <teleport to="#modal">
       <ModalVotes
         :open="modalOpenVotes"

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -74,8 +74,9 @@ onMounted(() => {
         </div>
 
         <div v-if="discussion">
-          <h4 class="mb-3 eyebrow">
-            <IH-chat-alt class="inline-block mr-2" /> Discussion
+          <h4 class="mb-3 eyebrow flex items-center">
+            <IH-chat-alt class="inline-block mr-2" />
+            <span>Discussion</span>
           </h4>
           <a :href="discussion" target="_blank" class="block mb-5">
             <Preview :url="discussion" />
@@ -85,8 +86,9 @@ onMounted(() => {
         <div>
           <Vote :proposal="proposal">
             <template #voted="{ vote: userVote }">
-              <h4 class="mb-3 eyebrow">
-                <IH-chart-bar class="inline-block mr-2" /> Results
+              <h4 class="mb-3 eyebrow flex items-center">
+                <IH-chart-bar class="inline-block mr-2" />
+                <span>Results</span>
               </h4>
               <Results :proposal="proposal" width="full" />
               <div class="mt-2">
@@ -103,8 +105,9 @@ onMounted(() => {
               </div>
             </template>
             <template #ended>
-              <h4 class="mb-3 eyebrow">
-                <IH-chart-bar class="inline-block mr-2" /> Results
+              <h4 class="mb-3 eyebrow flex items-center">
+                <IH-chart-bar class="inline-block mr-2" />
+                <span>Results</span>
               </h4>
               <Results :proposal="proposal" width="full" />
             </template>

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -5,7 +5,6 @@ import { sanitizeUrl } from '@braintree/sanitize-url';
 import { useProposalsStore } from '@/stores/proposals';
 import { _rt, _n, shortenAddress, getUrl } from '@/helpers/utils';
 import { useActions } from '@/composables/useActions';
-import txs from '@/helpers/execution.json';
 
 const route = useRoute();
 const proposalsStore = useProposalsStore();
@@ -33,94 +32,95 @@ onMounted(() => {
 
 <template>
   <div>
-    <Container v-if="!proposal" class="pt-5">
-      <UiLoading />
-    </Container>
-    <div v-else>
-      <Container class="pt-5">
-        <h1 class="mb-3">
-          {{ proposal.title || `Proposal #${proposal.proposal_id}` }}
-        </h1>
-        <div class="flex mb-4 items-center">
-          <div class="flex-auto space-x-2">
-            <router-link
-              :to="{
-                name: 'user',
-                params: { id: proposal.author.id }
-              }"
+    <Container class="pt-5">
+      <UiLoading v-if="!proposal" />
+      <div v-else class="space-y-5">
+        <div>
+          <h1
+            class="mb-3"
+            v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
+          />
+          <div class="flex mb-4 items-center">
+            <div class="flex-auto space-x-2">
+              <router-link
+                :to="{
+                  name: 'user',
+                  params: { id: proposal.author.id }
+                }"
+              >
+                <Stamp :id="proposal.author.id" :size="24" class="mr-1" />
+                {{ shortenAddress(proposal.author.id) }}
+              </router-link>
+              <span
+                >·
+                <a
+                  class="text-skin-text"
+                  @click="modalOpenTimeline = true"
+                  v-text="_rt(proposal.created)"
+                />
+              </span>
+            </div>
+            <a
+              :href="sanitizeUrl(getUrl(proposal.metadata_uri))"
+              target="_blank"
             >
-              <Stamp :id="proposal.author.id" :size="24" class="mr-1" />
-              {{ shortenAddress(proposal.author.id) }}
-            </router-link>
-            <span
-              >·
-              <a
-                class="text-skin-text"
-                @click="modalOpenTimeline = true"
-                v-text="_rt(proposal.created)"
-              />
-            </span>
+              <UiButton class="!w-[46px] !h-[46px] !px-[12px]">
+                <IH-dots-horizontal />
+              </UiButton>
+            </a>
           </div>
-          <a :href="sanitizeUrl(getUrl(proposal.metadata_uri))" target="_blank">
-            <UiButton class="!w-[46px] !h-[46px] !px-[12px]">
-              <IH-dots-horizontal />
-            </UiButton>
+          <div v-if="proposal.body" class="mb-4">
+            <p v-text="proposal.body" />
+          </div>
+        </div>
+
+        <div v-if="discussion">
+          <h4 class="mb-3 eyebrow">
+            <IH-chat-alt class="inline-block mr-2" /> Discussion
+          </h4>
+          <a :href="discussion" target="_blank" class="block mb-5">
+            <Preview :url="discussion" />
           </a>
         </div>
-        <div v-if="proposal.body" class="mb-4">
-          <p v-text="proposal.body" />
+
+        <div>
+          <Vote :proposal="proposal">
+            <template #voted>
+              <h4 class="mb-3 eyebrow">
+                <IH-chart-bar class="inline-block mr-2" /> Results
+              </h4>
+              <Results :proposal="proposal" width="full" />
+            </template>
+            <template #ended>
+              <h4 class="mb-3 eyebrow">
+                <IH-chart-bar class="inline-block mr-2" /> Results
+              </h4>
+              <Results :proposal="proposal" width="full" />
+            </template>
+            <div class="grid grid-cols-3 gap-2">
+              <UiButton
+                class="w-full !text-white !bg-green !border-green"
+                @click="vote(proposal, 1)"
+              >
+                <IH-check class="inline-block" />
+              </UiButton>
+              <UiButton
+                class="w-full !text-white !bg-red !border-red"
+                @click="vote(proposal, 2)"
+              >
+                <IH-x class="inline-block" />
+              </UiButton>
+              <UiButton
+                class="w-full !text-white !bg-gray-500 !border-gray-500"
+                @click="vote(proposal, 3)"
+              >
+                <IH-arrow-right class="inline-block" />
+              </UiButton>
+            </div>
+          </Vote>
         </div>
-      </Container>
-      <Container class="space-y-4 mb-4" slim>
-        <BlockExecution :txs="txs" />
-        <a
-          v-if="discussion"
-          :href="discussion"
-          target="_blank"
-          class="x-block block mb-5"
-        >
-          <h4 class="px-4 py-3">
-            <IH-chat-alt class="inline-block mr-2" /> Discussion
-            <IH-external-link class="float-right mt-1" />
-          </h4>
-          <Preview
-            :url="discussion"
-            class="!border-0 !border-t !rounded-none"
-          />
-        </a>
-      </Container>
-      <Container>
-        <Vote :proposal="proposal">
-          <template #voted>
-            <h4 class="mb-2">Results</h4>
-            <Results :proposal="proposal" width="full" />
-          </template>
-          <template #ended>
-            <h4 class="mb-2">Results</h4>
-            <Results :proposal="proposal" width="full" />
-          </template>
-          <div class="grid grid-cols-3 gap-2">
-            <UiButton
-              class="w-full !text-white !bg-green !border-green"
-              @click="vote(proposal, 1)"
-            >
-              <IH-check class="inline-block" />
-            </UiButton>
-            <UiButton
-              class="w-full !text-white !bg-red !border-red"
-              @click="vote(proposal, 2)"
-            >
-              <IH-x class="inline-block" />
-            </UiButton>
-            <UiButton
-              class="w-full !text-white !bg-gray-500 !border-gray-500"
-              @click="vote(proposal, 3)"
-            >
-              <IH-arrow-right class="inline-block" />
-            </UiButton>
-          </div>
-        </Vote>
-        <div class="mt-3">
+
+        <div>
           <a class="text-skin-text" @click="modalOpenVotes = true">
             {{ _n(proposal.vote_count) }} votes
           </a>
@@ -131,8 +131,8 @@ onMounted(() => {
             v-text="_rt(proposal.max_end)"
           />
         </div>
-      </Container>
-    </div>
+      </div>
+    </Container>
     <teleport to="#modal">
       <ModalVotes
         :open="modalOpenVotes"

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -13,15 +13,15 @@ defineProps<{ space: Space }>();
       <div class="mx-4 pt-3">
         <div class="mb-3">
           <div class="s-label !mb-0">Name</div>
-          <div class="text-skin-link text-md" v-text="space.name" />
+          <h4 class="text-skin-link text-md" v-text="space.name" />
         </div>
         <div class="mb-3">
           <div class="s-label !mb-0">About</div>
-          <div class="text-skin-link text-md" v-text="space.about || '...'" />
+          <h4 class="text-skin-link text-md" v-text="space.about || '...'" />
         </div>
         <div class="mb-3">
           <div class="s-label !mb-0">Discussions</div>
-          <div
+          <h4
             class="text-skin-link text-md"
             v-text="space.discussions || '...'"
           />
@@ -34,35 +34,35 @@ defineProps<{ space: Space }>();
       <div class="mx-4 pt-3">
         <div class="mb-3">
           <div class="s-label !mb-0">Voting delay</div>
-          <div
+          <h4
             class="text-skin-link text-md"
             v-text="_d(space.voting_delay) || 'No delay'"
           />
         </div>
         <div class="mb-3">
           <div class="s-label !mb-0">Min. voting period</div>
-          <div
+          <h4
             class="text-skin-link text-md"
             v-text="_d(space.min_voting_period) || 'No min.'"
           />
         </div>
         <div class="mb-3">
           <div class="s-label !mb-0">Max. voting period</div>
-          <div
+          <h4
             class="text-skin-link text-md"
             v-text="_d(space.max_voting_period)"
           />
         </div>
         <div class="mb-3">
           <div class="s-label !mb-0" v-text="'Proposal threshold'" />
-          <div
+          <h4
             class="text-skin-link text-md"
             v-text="space.proposal_threshold"
           />
         </div>
         <div class="mb-3">
           <div class="s-label !mb-0" v-text="'Quorum'" />
-          <div class="text-skin-link text-md" v-text="space.quorum" />
+          <h4 class="text-skin-link text-md" v-text="space.quorum" />
         </div>
       </div>
     </div>

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -36,11 +36,11 @@ onMounted(() => loadBalances(space.wallet));
         <IH-duplicate class="inline-block" />
       </UiButton>
     </a>
-    <a>
+    <router-link :to="{ name: 'editor' }">
       <UiButton class="!px-0 w-[46px]">
         <IH-arrow-sm-right class="inline-block -rotate-45" />
       </UiButton>
-    </a>
+    </router-link>
   </div>
   <div class="space-y-3">
     <div>
@@ -51,12 +51,11 @@ onMounted(() => loadBalances(space.wallet));
         class="flex justify-between items-center mx-4 py-3 block border-b"
       >
         <Stamp :id="space.wallet" type="avatar" :size="32" class="mr-3" />
-        <div class="flex-1 leading-[20px]">
-          <div class="text-skin-link" v-text="shorten(space.wallet)" />
-          <div class="text-skin-text text-sm">
-            ${{ _n(totalQuote.toFixed()) }}
-          </div>
+        <div class="flex-1 leading-[22px]">
+          <h4 class="text-skin-link" v-text="shorten(space.wallet)" />
+          <div class="text-skin-text text-sm" v-text="shorten(space.wallet)" />
         </div>
+        <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
       </a>
     </div>
     <div>
@@ -69,22 +68,46 @@ onMounted(() => loadBalances(space.wallet));
       >
         <div class="flex-auto flex items-center">
           <Stamp :id="asset.contract_address" type="token" :size="32" />
-          <div class="flex flex-col ml-3 leading-[20px]">
-            <div
+          <div class="flex flex-col ml-3 leading-[22px]">
+            <h4
               class="text-skin-link"
               v-text="shorten(asset.contract_ticker_symbol, 12)"
             />
             <div class="text-sm" v-text="shorten(asset.contract_name, 24)" />
           </div>
         </div>
-        <div class="flex-col items-end text-right leading-[20px]">
-          <div
+        <div
+          v-if="asset.quote_rate"
+          class="flex-col items-end text-right leading-[22px] w-[180px] invisible md:visible"
+        >
+          <h4 class="text-skin-link" v-text="`$${_n(asset.quote_rate)}`" />
+          <div v-if="asset.percent" class="text-sm">
+            <div
+              v-if="asset.percent > 0"
+              class="text-green"
+              v-text="`+${_n(asset.percent)}%`"
+            />
+            <div
+              v-if="asset.percent < 0"
+              class="text-red"
+              v-text="`${_n(asset.percent)}%`"
+            />
+          </div>
+        </div>
+        <div
+          class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px]"
+        >
+          <h4
             class="text-skin-link"
             v-text="
               _n(formatUnits(asset.balance || 0, asset.contract_decimals || 0))
             "
           />
-          <div class="text-sm" v-text="`$${_n(asset.quote)}`" />
+          <div
+            v-if="asset.quote"
+            class="text-sm"
+            v-text="`$${_n(asset.quote)}`"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
This are some small improvement on treasury page, adding the tokens price and 24h % change along with improving the proposal page and settings style.

Treasury looks like this:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/16245250/194699254-afdfe36e-93eb-4d67-bbb4-d52e8209e397.png">
(ETH was working previously, might be something wrong with Covalent atm as it doesn't return the price quote)

Proposal page:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/16245250/194699304-0c7523e4-9516-4d13-ad39-b483c3f67ab1.png">
