### PR TITLE
refactor: Change treasury address to Goerli owned Safe

### DIFF
--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -145,6 +145,7 @@ function editTx(index: number) {
       <ModalSendToken
         :open="modalOpen.sendToken"
         :address="space.wallet"
+        :network="space.network"
         :initial-state="modalState.sendToken"
         @close="modalOpen.sendToken = false"
         @add="addTx"

--- a/src/components/Modal/SendToken.vue
+++ b/src/components/Modal/SendToken.vue
@@ -19,6 +19,10 @@ const props = defineProps({
     type: String,
     required: true
   },
+  network: {
+    type: String,
+    required: true
+  },
   initialState: Object
 });
 
@@ -55,7 +59,7 @@ const formValid = computed(
 );
 
 onMounted(() => {
-  loadBalances(props.address);
+  loadBalances(props.address, props.network);
 });
 
 function handlePickerClick() {

--- a/src/composables/useBalances.ts
+++ b/src/composables/useBalances.ts
@@ -8,10 +8,10 @@ const loading = ref(true);
 const loaded = ref(false);
 
 export function useBalances() {
-  async function loadBalances(address) {
+  async function loadBalances(address, network) {
     loading.value = true;
     const key = 'ckey_2d082caf47f04a46947f4f212a8';
-    const url = `https://api.covalenthq.com/v1/1/address/${address}/balances_v2/?quote-currency=USD&format=JSON&nft=false&no-nft-fetch=true&key=${key}`;
+    const url = `https://api.covalenthq.com/v1/${network}/address/${address}/balances_v2/?quote-currency=USD&format=JSON&nft=false&no-nft-fetch=true&key=${key}`;
     const results = await snapshot.utils.getJSON(url);
     const etherItem = results.data.items.find(
       item => item.contract_address === ETH_CONTRACT

--- a/src/composables/useNfts.ts
+++ b/src/composables/useNfts.ts
@@ -11,8 +11,7 @@ export function useNfts() {
   async function loadNfts(address) {
     loading.value = true;
 
-    const url =
-      'https://testnets-api.opensea.io/api/v1/assets?owner=0x0000000000000000000000000000000000000000&order_direction=desc&offset=0&limit=20&include_orders=false';
+    const url = `https://testnets-api.opensea.io/api/v1/assets?owner=${address}&order_direction=desc&offset=0&limit=20&include_orders=false`;
     const { assets } = await snapshot.utils.getJSON(url);
 
     nfts.value = assets

--- a/src/helpers/space.json
+++ b/src/helpers/space.json
@@ -1,4 +1,4 @@
 {
-  "network": "1",
-  "wallet": "0xaf28bcb48c40dbc86f52d459a6562f658fc94b1e"
+  "network": "5",
+  "wallet": "0x11455A53117B5142A8Bf5E6DcaFcD504eb633Ae1"
 }

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -31,7 +31,7 @@ const sortedAssets = computed(() =>
 );
 
 onMounted(() => {
-  loadBalances(space.wallet);
+  loadBalances(space.wallet, space.network);
   loadNfts(space.wallet);
 });
 </script>
@@ -88,16 +88,9 @@ onMounted(() => {
             <div class="flex flex-col ml-3 leading-[22px]">
               <h4
                 class="text-skin-link"
-                v-text="
-                  _n(
-                    formatUnits(
-                      asset.balance || 0,
-                      asset.contract_decimals || 0
-                    )
-                  )
-                "
+                v-text="asset.contract_ticker_symbol"
               />
-              <div class="text-sm" v-text="`$${_n(asset.quote)}`" />
+              <div class="text-sm" v-text="asset.contract_name" />
             </div>
           </div>
           <div


### PR DESCRIPTION
Changing the hardcoded treasury address to the space L1 controlled Safe, this is to make it easier to test execution later.