### PR TITLE
fix: convert mixed ESM

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,9 @@ export default defineConfig({
     }
   },
   build: {
+    commonjsOptions: {
+      transformMixedEsModules: true
+    },
     rollupOptions: {
       plugins: [
         // @ts-ignore


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/sx-ui/issues/343


Starting from https://github.com/snapshot-labs/sx-ui/commit/f71b654b89525eeb74cadc79523f786d254ed57f we are using `@walletconnect/web3-provider` in newer version that added ESM module, but it has mixed syntax (both import and require) and it needs to be converted before it can be used.

## Test plan

- Click Connect -> WalletConnect.
- WalletConnect window should open.
- Test both in `yarn dev` and `yarn build` if possible.