### PR TITLE
chore: update API and Mana endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-VITE_API_URL=https://goerli-api-1.snapshotx.xyz
+VITE_API_URL=https://testnet-api-1.snapshotx.xyz
 VITE_ETH_RPC_URL=https://rpc.brovider.xyz/5
-VITE_MANA_URL=https://mana.pizza
+VITE_MANA_URL=https://testnet.mana.pizza
 VITE_IPFS_GATEWAY=snapshot.mypinata.cloud


### PR DESCRIPTION
Update default API and Mana endpoint to use testnet prefix.