### PR TITLE
feat: compute ethRelayer execution

### DIFF
--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -5,7 +5,7 @@ import { useWeb3 } from '@/composables/useWeb3';
 import { useTxStatus } from '@/composables/useTxStatus';
 import { useAccount } from '@/composables/useAccount';
 import { useModal } from '@/composables/useModal';
-import type { Transaction, TransactionData, Proposal, Space } from '@/types';
+import type { Transaction, Proposal, Space } from '@/types';
 
 export function useActions() {
   const { web3 } = useWeb3();
@@ -50,19 +50,17 @@ export function useActions() {
     if (!web3.value.account) return await forceLogin();
     if (web3.value.type === 'argentx') throw new Error('ArgentX is not supported');
 
-    const executionData = execution.map(
-      (tx: Transaction, i: number): TransactionData => ({
-        ...tx,
-        nonce: i,
-        operation: '0'
-      })
-    );
+    const transactions = execution.map((tx: Transaction, i: number) => ({
+      ...tx,
+      nonce: i,
+      operation: 0
+    }));
 
     const pinned = await pin({
       title,
       body,
       discussion,
-      execution: executionData
+      execution: transactions
     });
     if (!pinned || !pinned.cid) return;
     console.log('IPFS', pinned);
@@ -71,7 +69,8 @@ export function useActions() {
       auth.web3,
       web3.value.account,
       space,
-      pinned.cid
+      pinned.cid,
+      transactions
     );
 
     console.log('Envelope', envelope);

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -52,8 +52,8 @@ export function useActions() {
 
     const transactions = execution.map((tx: Transaction, i: number) => ({
       ...tx,
-      nonce: i,
-      operation: 0
+      nonce: 0,
+      operation: i
     }));
 
     const pinned = await pin({

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -50,10 +50,10 @@ export function useActions() {
     if (!web3.value.account) return await forceLogin();
     if (web3.value.type === 'argentx') throw new Error('ArgentX is not supported');
 
-    const transactions = execution.map((tx: Transaction, i: number) => ({
+    const transactions = execution.map((tx: Transaction) => ({
       ...tx,
       nonce: 0,
-      operation: i
+      operation: 0
     }));
 
     const pinned = await pin({

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,11 +92,6 @@ export type BaseTransaction = {
   value: string;
 };
 
-export type TransactionData = BaseTransaction & {
-  nonce: number;
-  operation: '0';
-};
-
 export type SendTokenTransaction = BaseTransaction & {
   _type: 'sendToken';
   _form: {


### PR DESCRIPTION
## Summary

This PR makes execution through ethRelayer functional. As of now I only tested sending ETH out.

## Test plan

- Create proposal with ETH transfer as execution.

For full test plan with execution check https://github.com/snapshot-labs/sx.js/pull/115 as finalizing and executing proposal isn't part of the UI.

## Further comments

There seems to be something wrong with Vite setup after previous PRs, if you have issues opening the app you can copy `dist` instead of linking.