### PR TITLE
fix: separate summary from main proposals

### DIFF
--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -14,8 +14,8 @@ type SpaceRecord = {
 
 export const useProposalsStore = defineStore('proposals', {
   state: () => ({
-    proposals: {} as Record<string, SpaceRecord | undefined>,
-    summaryProposals: {} as Record<string, SpaceRecord | undefined>
+    proposals: {} as Partial<Record<string, SpaceRecord>>,
+    summaryProposals: {} as Partial<Record<string, SpaceRecord>>
   }),
   getters: {
     getProposal: state => {

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -23,7 +23,7 @@ const grouped = computed(() => {
 
   if (!proposalsRecord.value) return initialValue;
 
-  return proposalsRecord.value.proposals.reduce((v, proposal) => {
+  return proposalsRecord.value.summaryProposals.reduce((v, proposal) => {
     if (proposal.has_ended) v.ended.push(proposal);
     else v.active.push(proposal);
 


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/sx-ui/issues/353

Summary has its own logic how it's fetched so using main proposals as substitute for summary won't work as we won't have enough old proposals in the end. Trying to handle it somehow will be mess so I'm just separating them into two different properties.

## Test plan
- Go to http://127.0.0.1:8080/#/0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28/proposals
- Click Overview - it fetches as expected.
- Go back to Proposals - no duplicates (but doesn't fetch again).
- Click on Proposal from Summary/Proposals page - it doesn't refetch it.