### PR TITLE
feat: add infinite scroll to proposals

### DIFF
--- a/src/components/Block/InfiniteScroller.vue
+++ b/src/components/Block/InfiniteScroller.vue
@@ -11,11 +11,20 @@ const emit = defineEmits<{
 
 const container: Ref<HTMLElement | null> = ref(null);
 
-const observer = new IntersectionObserver(
+function updateIntersectionObserver() {
+  if (!container.value) return;
+  if (container.value.children.length === 0) return;
+
+  const lastElement = container.value.children[container.value.children.length - 1];
+
+  intersectionObserver.observe(lastElement);
+}
+
+const intersectionObserver = new IntersectionObserver(
   ([entry]) => {
     if (!entry.isIntersecting) return;
 
-    observer.unobserve(entry.target);
+    intersectionObserver.unobserve(entry.target);
     emit('endReached');
   },
   {
@@ -24,28 +33,19 @@ const observer = new IntersectionObserver(
 );
 
 const mutationObserver = new MutationObserver(() => {
-  if (!container.value) return;
-  if (container.value.children.length === 0) return;
-
-  const lastElement = container.value.children[container.value.children.length - 1];
-
-  observer.observe(lastElement);
+  updateIntersectionObserver();
 });
 
 watch(container, v => {
   if (!v) return;
 
   mutationObserver.observe(v, { childList: true });
-
-  if (v.children.length === 0) return;
-
-  const lastElement = v.children[v.children.length - 1];
-  observer.observe(lastElement);
+  updateIntersectionObserver();
 });
 
 onBeforeUnmount(() => {
   mutationObserver.disconnect();
-  observer.disconnect();
+  intersectionObserver.disconnect();
 });
 </script>
 

--- a/src/components/Block/InfiniteScroller.vue
+++ b/src/components/Block/InfiniteScroller.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount, Ref } from 'vue';
+
+defineProps<{
+  loadingMore?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'endReached');
+}>();
+
+const container: Ref<HTMLElement | null> = ref(null);
+
+const observer = new IntersectionObserver(
+  ([entry]) => {
+    if (!entry.isIntersecting) return;
+
+    observer.unobserve(entry.target);
+    emit('endReached');
+  },
+  {
+    rootMargin: '200px'
+  }
+);
+
+const mutationObserver = new MutationObserver(() => {
+  if (!container.value) return;
+  if (container.value.children.length === 0) return;
+
+  const lastElement = container.value.children[container.value.children.length - 1];
+
+  observer.observe(lastElement);
+});
+
+watch(container, v => {
+  if (!v) return;
+
+  mutationObserver.observe(v, { childList: true });
+
+  if (v.children.length === 0) return;
+
+  const lastElement = v.children[v.children.length - 1];
+  observer.observe(lastElement);
+});
+
+onBeforeUnmount(() => {
+  mutationObserver.disconnect();
+  observer.disconnect();
+});
+</script>
+
+<template>
+  <div>
+    <div ref="container">
+      <slot />
+    </div>
+    <slot v-if="loadingMore" name="loading">
+      <div class="flex justify-center">
+        <UiLoading class="block px-4 py-3" />
+      </div>
+    </slot>
+  </div>
+</template>

--- a/src/components/ProposalsList.vue
+++ b/src/components/ProposalsList.vue
@@ -5,12 +5,17 @@ import type { Proposal as ProposalType } from '@/types';
 const props = defineProps<{
   title: string;
   loading?: boolean;
+  loadingMore?: boolean;
   limit?: number | 'off';
   proposals: ProposalType[];
   route?: {
     name: string;
     linkTitle: string;
   };
+}>();
+
+const emit = defineEmits<{
+  (e: 'endReached');
 }>();
 
 const currentLimit = computed(() => {
@@ -25,11 +30,13 @@ const currentLimit = computed(() => {
     <Label :label="title" />
     <UiLoading v-if="loading" class="block px-4 py-3" />
     <div v-else>
-      <Proposal
-        v-for="(proposal, i) in proposals.slice(0, currentLimit)"
-        :key="i"
-        :proposal="proposal"
-      />
+      <BlockInfiniteScroller :loading-more="loadingMore" @end-reached="emit('endReached')">
+        <Proposal
+          v-for="(proposal, i) in proposals.slice(0, currentLimit)"
+          :key="i"
+          :proposal="proposal"
+        />
+      </BlockInfiniteScroller>
       <div v-if="!proposals.length" class="px-4 py-3 text-skin-link">
         <IH-exclamation-circle class="inline-block mr-2" />
         <span v-text="'There are no proposals here.'" />

--- a/src/networks/starknet/api.ts
+++ b/src/networks/starknet/api.ts
@@ -10,6 +10,8 @@ import {
 } from './queries';
 import type { Space, Proposal, Vote, User } from '@/types';
 
+type PaginationOpts = { limit: number; skip?: number };
+
 function formatProposal(proposal: Omit<Proposal, 'has_ended'>, now: number = Date.now()): Proposal {
   return {
     ...proposal,
@@ -42,12 +44,16 @@ export function createApi() {
         (data.votes as Vote[]).map(vote => [`${vote.space.id}/${vote.proposal}`, vote])
       );
     },
-    loadProposals: async (spaceId: string, limit: number): Promise<Proposal[]> => {
+    loadProposals: async (
+      spaceId: string,
+      { limit, skip = 0 }: PaginationOpts
+    ): Promise<Proposal[]> => {
       const { data } = await apollo.query({
         query: PROPOSALS_QUERY,
         variables: {
+          space: spaceId,
           first: limit,
-          space: spaceId
+          skip
         }
       });
 

--- a/src/networks/starknet/queries.ts
+++ b/src/networks/starknet/queries.ts
@@ -36,8 +36,14 @@ export const PROPOSAL_QUERY = gql`
 `;
 
 export const PROPOSALS_QUERY = gql`
-  query ($first: Int!, $space: String!) {
-    proposals(first: $first, where: { space: $space }, orderBy: created, orderDirection: desc) {
+  query ($first: Int!, $skip: Int!, $space: String!) {
+    proposals(
+      first: $first
+      skip: $skip
+      where: { space: $space }
+      orderBy: created
+      orderDirection: desc
+    ) {
       id
       proposal_id
       space {

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -7,11 +7,17 @@ const props = defineProps<{ space: Space }>();
 
 const proposalsStore = useProposalsStore();
 
-onMounted(() => {
-  proposalsStore.fetchAll(props.space.id);
-});
-
 const proposalsRecord = computed(() => proposalsStore.proposals[props.space.id]);
+
+async function handleEndReached() {
+  if (!proposalsRecord.value?.hasMoreProposals) return;
+
+  proposalsStore.fetchMore(props.space.id);
+}
+
+onMounted(() => {
+  proposalsStore.fetch(props.space.id);
+});
 </script>
 
 <template>
@@ -35,7 +41,9 @@ const proposalsRecord = computed(() => proposalsStore.proposals[props.space.id])
       title="Proposals"
       limit="off"
       :loading="!proposalsRecord?.loaded"
+      :loading-more="proposalsRecord?.loadingMore"
       :proposals="proposalsRecord?.proposals || []"
+      @end-reached="handleEndReached"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Add `InfiniteScroller` component.
- Split `fetchAll` into `fetch` and `fetchMore` (a bit more code repeating, but putting all logic for both first call and more fetches in single function was making it a bit hard to understand).
- Convert proposals page to be infinite scrollable.

## Test plan

- Go to http://127.0.0.1:8080/#/0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28/proposals
- You can fetch whole list.
- Nothing else breaks.