### PR TITLE
feat: add infinite scroll to spaces

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -4,7 +4,7 @@ import { onMounted } from 'vue';
 
 const spacesStore = useSpacesStore();
 
-onMounted(() => spacesStore.fetchAll());
+onMounted(() => spacesStore.fetch());
 </script>
 
 <template>
@@ -15,7 +15,7 @@ onMounted(() => spacesStore.fetchAll());
     <UiLoading v-if="!spacesStore.loaded" class="block py-2" />
     <div v-else class="space-y-3 p-2">
       <router-link
-        v-for="(space, i) in spacesStore.spaces"
+        v-for="(space, i) in spacesStore.spaces.slice(0, 5)"
         :key="i"
         :to="{ name: 'overview', params: { id: space.id } }"
         class="block"

--- a/src/networks/starknet/api.ts
+++ b/src/networks/starknet/api.ts
@@ -81,8 +81,14 @@ export function createApi() {
 
       return formatProposal(data.proposal);
     },
-    loadSpaces: async (): Promise<Space[]> => {
-      const { data } = await apollo.query({ query: SPACES_QUERY });
+    loadSpaces: async ({ limit, skip = 0 }: PaginationOpts): Promise<Space[]> => {
+      const { data } = await apollo.query({
+        query: SPACES_QUERY,
+        variables: {
+          first: limit,
+          skip
+        }
+      });
 
       return data.spaces;
     },

--- a/src/networks/starknet/queries.ts
+++ b/src/networks/starknet/queries.ts
@@ -170,8 +170,8 @@ export const SPACE_QUERY = gql`
 `;
 
 export const SPACES_QUERY = gql`
-  query {
-    spaces {
+  query ($first: Int!, $skip: Int!) {
+    spaces(first: $first, skip: $skip, orderBy: created, orderDirection: desc) {
       id
       name
       about

--- a/src/networks/starknet/queries.ts
+++ b/src/networks/starknet/queries.ts
@@ -171,7 +171,7 @@ export const SPACE_QUERY = gql`
 
 export const SPACES_QUERY = gql`
   query ($first: Int!, $skip: Int!) {
-    spaces(first: $first, skip: $skip, orderBy: created, orderDirection: desc) {
+    spaces(first: $first, skip: $skip, orderBy: vote_count, orderDirection: desc) {
       id
       name
       about

--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -56,7 +56,7 @@ export const useProposalsStore = defineStore('proposals', {
       const proposals = await currentNetwork.api.loadProposals(spaceId, { limit: PROPOSALS_LIMIT });
 
       record.value.proposals = proposals;
-      record.value.hasMoreProposals = proposals.length !== 0;
+      record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT;
       record.value.loaded = true;
       record.value.loading = false;
     },

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -2,23 +2,46 @@ import { defineStore } from 'pinia';
 import { currentNetwork } from '@/networks';
 import type { Space } from '@/types';
 
+const SPACES_LIMIT = 10;
+
 export const useSpacesStore = defineStore('spaces', {
   state: () => ({
     loading: false,
+    loadingMore: false,
     loaded: false,
+    hasMoreSpaces: true,
     spaces: [] as Space[]
   }),
   getters: {
     spacesMap: state => new Map(state.spaces.map(space => [space.id, space]))
   },
   actions: {
-    async fetchAll() {
+    async fetch() {
       if (this.loading) return;
       this.loading = true;
 
-      this.spaces = await currentNetwork.api.loadSpaces();
+      const spaces = await currentNetwork.api.loadSpaces({
+        skip: 0,
+        limit: SPACES_LIMIT
+      });
+
+      this.spaces = spaces;
+      this.hasMoreSpaces = spaces.length === SPACES_LIMIT;
       this.loaded = true;
       this.loading = false;
+    },
+    async fetchMore() {
+      if (this.loading || !this.loaded) return;
+      this.loadingMore = true;
+
+      const spaces = await currentNetwork.api.loadSpaces({
+        skip: this.spaces.length,
+        limit: SPACES_LIMIT
+      });
+
+      this.spaces = [...this.spaces, ...spaces];
+      this.hasMoreSpaces = spaces.length === SPACES_LIMIT;
+      this.loadingMore = false;
     },
     async fetchSpace(id: string) {
       if (this.spacesMap.get(id)) return;


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/sx-ui/issues/357

This PR adds infinite scroll to spaces on front page. It's disabled by default and triggers only when user presses "Load more" button, similar as on Snapshot.org

## Test plan
- No Button to "Load more" is visible.
- Change `SPACES_LIMIT` to 2.
- Go to homepage
- Button shows up, click it.
- New elements are loaded.