### PR TITLE
feat: add responsive sidebar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,15 @@
 <script setup>
 import { computed, onMounted, provide, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import { useUiStore } from '@/stores/ui';
 import { useModal } from '@/composables/useModal';
 import { useUserSkin } from '@/composables/useUserSkin';
 import { useApp } from '@/composables/useApp';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useAccount } from '@/composables/useAccount';
 
+const route = useRoute();
+const uiStore = useUiStore();
 const { modalOpen } = useModal();
 const { userSkin } = useUserSkin();
 const { init, app } = useApp();
@@ -15,10 +19,11 @@ const { loadVotes, votes } = useAccount();
 provide('web3', web3);
 
 const skin = computed(() => userSkin.value);
+const scrollDisabled = computed(() => modalOpen.value || uiStore.sidebarOpen);
 
 onMounted(async () => await init());
 
-watch(modalOpen, val => {
+watch(scrollDisabled, val => {
   const el = document.body;
   el.classList[val ? 'add' : 'remove']('overflow-hidden');
 });
@@ -26,6 +31,10 @@ watch(modalOpen, val => {
 watch(web3Account, async () => {
   if (web3Account.value) return await loadVotes();
   votes.value = {};
+});
+
+watch(route, () => {
+  uiStore.sidebarOpen = false;
 });
 </script>
 
@@ -36,12 +45,38 @@ watch(web3Account, async () => {
   >
     <UiLoading v-if="app.loading || !app.init" class="overlay big" />
     <div v-else class="pb-6 flex">
-      <Sidebar class="invisible md:visible" />
-      <div class="flex-auto w-full">
-        <Topnav />
-        <router-view :key="$route.path" class="flex-auto mt-[72px] ml-0 md:ml-[72px]" />
+      <Sidebar class="lg:visible" :class="{ invisible: !uiStore.sidebarOpen }" />
+      <Topnav @toggle="uiStore.toggleSidebar" />
+      <Nav />
+      <div
+        v-if="uiStore.sidebarOpen"
+        class="backdrop lg:hidden"
+        :style="{
+          left: `${72 + (route.matched[0]?.name === 'space' ? 240 : 0)}px`
+        }"
+        @click="uiStore.toggleSidebar"
+      />
+      <div
+        class="flex-auto w-full"
+        :class="{
+          'translate-x-[72px] lg:translate-x-0': uiStore.sidebarOpen
+        }"
+      >
+        <router-view :key="route.path" class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
       </div>
     </div>
     <div id="modal" />
   </div>
 </template>
+
+<style>
+.backdrop {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 99;
+  background: rgba(0, 0, 0, 0.4);
+}
+</style>

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -1,7 +1,9 @@
 <script setup>
 import { useRoute } from 'vue-router';
+import { useUiStore } from '@/stores/ui';
 
 const route = useRoute();
+const uiStore = useUiStore();
 
 const items = {
   overview: {
@@ -19,19 +21,28 @@ const items = {
 };
 </script>
 <template>
-  <div class="py-4">
-    <router-link
-      v-for="(item, i) in items"
-      :key="i"
-      :to="{ name: i }"
-      class="px-4 py-2 block space-x-2 text-skin-text flex items-center"
-      :class="route.name === i && 'text-skin-link'"
-    >
-      <IH-globe-alt v-if="i === 'overview'" class="inline-block" />
-      <IH-newspaper v-if="i === 'proposals'" class="inline-block" />
-      <IH-cash v-if="i === 'treasury'" class="inline-block" />
-      <IH-cog v-if="i === 'settings'" class="inline-block" />
-      <span v-text="item.name" />
-    </router-link>
+  <div
+    v-if="route.matched[0]?.name === 'space'"
+    class="lg:visible fixed w-[240px] border-r left-[72px] top-0 bottom-0 z-10 bg-skin-bg"
+    :class="{
+      invisible: !uiStore.sidebarOpen
+    }"
+  >
+    <div class="h-[72px] border-b" />
+    <div class="py-4">
+      <router-link
+        v-for="(item, i) in items"
+        :key="i"
+        :to="{ name: i }"
+        class="px-4 py-2 block space-x-2 text-skin-text flex items-center"
+        :class="route.name === i && 'text-skin-link'"
+      >
+        <IH-globe-alt v-if="i === 'overview'" class="inline-block" />
+        <IH-newspaper v-if="i === 'proposals'" class="inline-block" />
+        <IH-cash v-if="i === 'treasury'" class="inline-block" />
+        <IH-cog v-if="i === 'settings'" class="inline-block" />
+        <span v-text="item.name" />
+      </router-link>
+    </div>
   </div>
 </template>

--- a/src/components/Topnav.vue
+++ b/src/components/Topnav.vue
@@ -1,11 +1,18 @@
 <script setup>
 import { ref } from 'vue';
+import { useRoute } from 'vue-router';
 import { shorten } from '@/helpers/utils';
+import { useUiStore } from '@/stores/ui';
 import { useModal } from '@/composables/useModal';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useTxStatus } from '@/composables/useTxStatus';
 import { useUserSkin } from '@/composables/useUserSkin';
 
+const emit = defineEmits(['toggle']);
+
+const route = useRoute();
+
+const uiStore = useUiStore();
 const { pendingCount } = useTxStatus();
 const { modalAccountOpen } = useModal();
 
@@ -23,12 +30,29 @@ async function handleLogin(connector) {
 </script>
 
 <template>
-  <nav class="border-b fixed top-0 right-0 z-10 bg-skin-bg left-0 md:left-[72px]">
-    <div class="flex items-center h-[71px] mx-4">
+  <nav
+    class="border-b fixed top-0 right-0 z-10 left-0 lg:left-[72px]"
+    :class="{
+      'translate-x-[72px]': uiStore.sidebarOpen
+    }"
+  >
+    <div
+      class="flex items-center h-[71px] px-4 bg-skin-bg"
+      :class="{
+        'lg:translate-x-[240px]': route.matched[0]?.name === 'space',
+        'translate-x-[240px]': uiStore.sidebarOpen && route.matched[0]?.name === 'space'
+      }"
+    >
       <div class="flex-auto">
-        <router-link :to="{ path: '/' }" class="flex items-center" style="font-size: 24px">
-          snapshot x
-        </router-link>
+        <div class="flex items-center">
+          <IH-menu-alt-2
+            class="inline-block text-skin-link mr-3 cursor-pointer lg:hidden"
+            @click="emit('toggle')"
+          />
+          <router-link :to="{ path: '/' }" class="flex items-center" style="font-size: 24px">
+            snapshot x
+          </router-link>
+        </div>
       </div>
       <div :key="web3.account">
         <UiButton v-if="loading || web3.authLoading" loading class="!px-0 w-[46px]" />

--- a/src/router.ts
+++ b/src/router.ts
@@ -14,6 +14,7 @@ const routes: any[] = [
   { path: '/', name: 'home', component: Home },
   {
     path: '/:id',
+    name: 'space',
     component: Space,
     children: [
       { path: '', name: 'overview', component: Overview },

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia';
+
+export const useUiStore = defineStore('ui', {
+  state: () => ({
+    sidebarOpen: false
+  }),
+  actions: {
+    async toggleSidebar() {
+      this.sidebarOpen = !this.sidebarOpen;
+    }
+  }
+});

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
+import { useUiStore } from '@/stores/ui';
 import { useSpacesStore } from '@/stores/spaces';
 
+const uiStore = useUiStore();
 const route = useRoute();
 const spacesStore = useSpacesStore();
 const id = route.params.id as string;
@@ -14,12 +16,11 @@ onMounted(() => {
 
 <template>
   <div>
-    <div class="invisible lg:visible fixed w-[240px] border-r top-0 bottom-0 z-10 bg-skin-bg">
-      <div class="h-[72px] border-b" />
-      <Nav />
-    </div>
     <div>
-      <div class="ml-0 lg:ml-[240px] mr-0 xl:mr-[240px]">
+      <div
+        class="ml-0 lg:ml-[240px] mr-0 xl:mr-[240px]"
+        :class="{ 'translate-x-[240px] lg:translate-x-0': uiStore.sidebarOpen }"
+      >
         <UiLoading v-if="!spacesStore.spacesMap.has(id)" class="block p-4" />
         <router-view v-else :space="spacesStore.spacesMap.get(id)" />
       </div>


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/sx-ui/issues/365

With our quite complex structure of sidebars (we have 3 fixed elements, that all need to be shifted in different way) it ended up with a bit ugly set up as each of those has to contain logic for how it's going to be shifted (can't be shifted at parent level as transform modifies origin and `fixed` positioning no longer works.

Overall it should work as it used to on bigger screen (with exception of sidebar and nav now collapsing at once to have consistent experience). When on smaller screens those are assumptions that should be the case:
- You can use backdrop to dismiss.
- When picking element from sidebars sidebar closes.
- With sidebar open page is not scrollable.
- Content is translated right, instead of shrunk down (so it should look as before, but just moved out of the view).
- There is no swipe left-to-right to pull up the menu (so it doesn't break native swipe to go back gestures).

## Video


https://user-images.githubusercontent.com/1968722/211068094-6256e504-f6e9-4c2b-8c66-49b91885d84e.mp4


