### PR TITLE
fix: update Create page navbar position

### DIFF
--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -34,7 +34,7 @@ const space = computed(() => spacesStore.spacesMap.get(id));
 </script>
 <template>
   <div>
-    <nav class="border-b bg-skin-bg fixed top-0 z-10 right-0 left-0 md:left-[72px]">
+    <nav class="border-b bg-skin-bg fixed top-0 z-10 right-0 left-0 lg:left-[72px]">
       <div class="flex items-center h-[71px] mx-4">
         <div class="flex-auto space-x-2">
           <router-link :to="{ name: 'overview', params: { id } }" class="mr-2">


### PR DESCRIPTION
## Summary

Create page navbar currently displays incorrectly at certain breakpoints. This PR adjust this behavior.

## Test plan

- Go to Create page
- Resize it from small to big, no weird stuff happens.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/1968722/211336546-375b78d7-4712-4c0c-8d4e-326c9028eb3d.png)

After:
![image](https://user-images.githubusercontent.com/1968722/211336584-e0d485da-4b5a-44c6-b230-e48b555726f3.png)

## Further notes

This screen doesn't show menu icon at the moment. I don't think it's a big deal, because you have back button still, but if we want to make menu accessible on this screen as well we might need to consider some design changes (right now showing both hamburger icon and back icon will look weird I think).