### PR TITLE
feat: add proposal actions UI

### DIFF
--- a/src/components/Block/Actions.vue
+++ b/src/components/Block/Actions.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+const state: 'WAITING' | 'FINALIZED' | 'RECEIVED' | 'EXECUTED' = 'WAITING';
+</script>
+
+<template>
+  <div class="x-block !border-x rounded-lg p-3">
+    <UiButton
+      :disabled="state !== 'WAITING'"
+      class="block mb-2 w-full flex justify-center items-center"
+    >
+      <IH-check-circle class="inline-block mr-2" />
+      Finalize proposal
+    </UiButton>
+    <UiButton
+      :disabled="state !== 'FINALIZED'"
+      class="block mb-2 w-full flex justify-center items-center"
+    >
+      <IH-database class="inline-block mr-2" />
+      Receive proposal
+    </UiButton>
+    <UiButton
+      :disabled="state !== 'RECEIVED'"
+      class="block mb-2 w-full flex justify-center items-center"
+    >
+      <IH-play class="inline-block mr-2" />
+      Execute transactions
+    </UiButton>
+  </div>
+</template>

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -105,6 +105,17 @@ onMounted(() => {
             <BlockExecution :txs="execution" />
           </div>
         </div>
+        <div
+          v-if="execution && execution.length > 0 && proposal.scores_total >= proposal.space.quorum"
+        >
+          <h4 class="mb-3 eyebrow flex items-center">
+            <IH-play class="inline-block mr-2" />
+            <span>Actions</span>
+          </h4>
+          <div class="mb-4">
+            <BlockActions />
+          </div>
+        </div>
         <div>
           <Vote :proposal="proposal">
             <template #voted="{ vote: userVote }">


### PR DESCRIPTION
## Summary

Just the UI for actions UI.

Towards https://github.com/snapshot-labs/sx-ui/issues/366

## Test plan

Proposal with quorum met has actions UI:
http://127.0.0.1:8080/#/0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28/proposal/38

Proposal without quorum met doesn't:
http://127.0.0.1:8080/#/0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28/proposal/44

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/211387402-2bcfe177-7a1d-4c21-900a-11b47d61ae7a.png" width="600" />
