### PR TITLE
fix: properly display topnav in space screen

### DIFF
--- a/src/components/Topnav.vue
+++ b/src/components/Topnav.vue
@@ -33,14 +33,15 @@ async function handleLogin(connector) {
   <nav
     class="border-b fixed top-0 right-0 z-10 left-0 lg:left-[72px]"
     :class="{
-      'translate-x-[72px]': uiStore.sidebarOpen
+      'translate-x-[72px] lg:translate-x-0': uiStore.sidebarOpen
     }"
   >
     <div
       class="flex items-center h-[71px] px-4 bg-skin-bg"
       :class="{
-        'lg:translate-x-[240px]': route.matched[0]?.name === 'space',
-        'translate-x-[240px]': uiStore.sidebarOpen && route.matched[0]?.name === 'space'
+        'lg:ml-[240px]': route.matched[0]?.name === 'space',
+        'translate-x-[240px] lg:translate-x-0':
+          uiStore.sidebarOpen && route.matched[0]?.name === 'space'
       }"
     >
       <div class="flex-auto">


### PR DESCRIPTION
## Summary

There were some issues with topnav 1) being translated on large screen causing button on right side to be off-screen 2) misaligned if sidebar was opened and the window was later resized to large size.

## Screenshots

After:

https://user-images.githubusercontent.com/1968722/211562700-582e59cb-88e1-4588-9cfc-8d474e776496.mp4

Before:


https://user-images.githubusercontent.com/1968722/211562901-239c3909-0ec3-4756-9896-aa7d51505ba0.mp4

