### PR TITLE
feat: add finalize and Zodiac actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@snapshot-labs/pineapple": "^0.1.0-beta.1",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
     "@snapshot-labs/snapshot.js": "^0.4.11",
-    "@snapshot-labs/sx": "^0.1.0-beta.16",
+    "@snapshot-labs/sx": "^0.1.0-beta.17",
     "@vueuse/core": "^9.4.0",
     "@walletconnect/client": "^1.7.8",
     "ajv": "^8.11.0",

--- a/src/components/Block/Actions.vue
+++ b/src/components/Block/Actions.vue
@@ -1,26 +1,36 @@
 <script setup lang="ts">
-const state: 'WAITING' | 'FINALIZED' | 'RECEIVED' | 'EXECUTED' = 'WAITING';
+import { useActions } from '@/composables/useActions';
+import type { Proposal as ProposalType } from '@/types';
+
+const props = defineProps<{ proposal: ProposalType }>();
+
+const { receiveProposal, executeTransactions } = useActions();
+
+async function handleReceiveProposalClick() {
+  return receiveProposal(props.proposal);
+}
+
+async function handleExecuteTransactionsClick() {
+  return executeTransactions(props.proposal);
+}
 </script>
 
 <template>
   <div class="x-block !border-x rounded-lg p-3">
-    <UiButton
-      :disabled="state !== 'WAITING'"
-      class="block mb-2 w-full flex justify-center items-center"
-    >
+    <UiButton :disabled="true" class="block mb-2 w-full flex justify-center items-center">
       <IH-check-circle class="inline-block mr-2" />
       Finalize proposal
     </UiButton>
     <UiButton
-      :disabled="state !== 'FINALIZED'"
       class="block mb-2 w-full flex justify-center items-center"
+      @click="handleReceiveProposalClick"
     >
       <IH-database class="inline-block mr-2" />
       Receive proposal
     </UiButton>
     <UiButton
-      :disabled="state !== 'RECEIVED'"
       class="block mb-2 w-full flex justify-center items-center"
+      @click="handleExecuteTransactionsClick"
     >
       <IH-play class="inline-block mr-2" />
       Execute transactions

--- a/src/components/Block/Actions.vue
+++ b/src/components/Block/Actions.vue
@@ -4,7 +4,11 @@ import type { Proposal as ProposalType } from '@/types';
 
 const props = defineProps<{ proposal: ProposalType }>();
 
-const { receiveProposal, executeTransactions } = useActions();
+const { finalizeProposal, receiveProposal, executeTransactions } = useActions();
+
+async function handleFinalizeProposalClick() {
+  return finalizeProposal(props.proposal);
+}
 
 async function handleReceiveProposalClick() {
   return receiveProposal(props.proposal);
@@ -17,7 +21,10 @@ async function handleExecuteTransactionsClick() {
 
 <template>
   <div class="x-block !border-x rounded-lg p-3">
-    <UiButton :disabled="true" class="block mb-2 w-full flex justify-center items-center">
+    <UiButton
+      class="block mb-2 w-full flex justify-center items-center"
+      @click="handleFinalizeProposalClick"
+    >
       <IH-check-circle class="inline-block mr-2" />
       Finalize proposal
     </UiButton>

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -84,6 +84,16 @@ export function useActions() {
     uiStore.addPendingTransaction(receipt.transaction_hash);
   }
 
+  async function finalizeProposal(proposal: Proposal) {
+    uiStore.broadcastingTransactionsCount++;
+
+    const receipt = await currentNetwork.actions.finalizeProposal(proposal);
+
+    console.log('Receipt', receipt);
+    uiStore.broadcastingTransactionsCount--;
+    uiStore.addPendingTransaction(receipt.transaction_hash);
+  }
+
   async function receiveProposal(proposal: Proposal) {
     if (!web3.value.account) return await forceLogin();
     if (web3.value.type === 'argentx') throw new Error('ArgentX is not supported');
@@ -103,6 +113,7 @@ export function useActions() {
   return {
     vote,
     propose,
+    finalizeProposal,
     receiveProposal,
     executeTransactions
   };

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -84,8 +84,26 @@ export function useActions() {
     uiStore.addPendingTransaction(receipt.transaction_hash);
   }
 
+  async function receiveProposal(proposal: Proposal) {
+    if (!web3.value.account) return await forceLogin();
+    if (web3.value.type === 'argentx') throw new Error('ArgentX is not supported');
+
+    const receipt = await currentNetwork.actions.receiveProposal(auth.web3, proposal);
+    console.log('Receipt', receipt);
+  }
+
+  async function executeTransactions(proposal: Proposal) {
+    if (!web3.value.account) return await forceLogin();
+    if (web3.value.type === 'argentx') throw new Error('ArgentX is not supported');
+
+    const receipt = await currentNetwork.actions.executeTransactions(auth.web3, proposal);
+    console.log('Receipt', receipt);
+  }
+
   return {
     vote,
-    propose
+    propose,
+    receiveProposal,
+    executeTransactions
   };
 }

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -9,6 +9,10 @@ export const SUPPORTED_STRATEGIES = {
   '0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b': true
 };
 
+export const SUPPORTED_EXECUTORS = {
+  '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81': true
+};
+
 export const AUTHS = {
   '0x5e1f273ca9a11f78bfb291cbe1b49294cf3c76dd48951e7ab7db6d9fb1e7d62': 'Vanilla',
   '0x64cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14': 'Ethereum signature',

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -1,12 +1,24 @@
+import { Wallet } from '@ethersproject/wallet';
 import { clients as Clients, getExecutionData, defaultNetwork } from '@snapshot-labs/sx';
-import { SUPPORTED_AUTHENTICATORS, SUPPORTED_STRATEGIES } from '@/helpers/constants';
+import {
+  SUPPORTED_AUTHENTICATORS,
+  SUPPORTED_EXECUTORS,
+  SUPPORTED_STRATEGIES
+} from '@/helpers/constants';
 import type { Provider } from 'starknet';
 import type { Web3Provider } from '@ethersproject/providers';
-import type { Wallet } from '@ethersproject/wallet';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
-import type { Space, Proposal } from '@/types';
+import type { Space, Proposal, Transaction } from '@/types';
 
 const EXECUTOR = '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81';
+
+function convertToMetaTransactions(transactions: Transaction[]): MetaTransaction[] {
+  return transactions.map((tx: Transaction) => ({
+    ...tx,
+    nonce: 0,
+    operation: 0
+  }));
+}
 
 function pickAuthenticatorAndStrategies(authenticators: string[], strategies: string[]) {
   const authenticator = authenticators.find(
@@ -71,6 +83,35 @@ export function createActions(starkProvider: Provider) {
         proposal: proposal.proposal_id,
         choice
       });
+    },
+    receiveProposal: (web3: Web3Provider | Wallet, proposal: Proposal) => {
+      const signer = Wallet.isSigner(web3) ? web3 : web3.getSigner();
+
+      const zodiac = new Clients.Zodiac({ signer });
+
+      const executor = proposal.space.executors.find(executor => SUPPORTED_EXECUTORS[executor]);
+      if (!executor) throw new Error('Unsupported space');
+
+      return zodiac.receiveProposal(proposal.space.id, executor, {
+        transactions: convertToMetaTransactions(proposal.execution)
+      });
+    },
+    executeTransactions: (web3: Web3Provider | Wallet, proposal: Proposal) => {
+      // TODO: make it dynamic once we have way to fetch it somehow
+      const proposalIndex = 3;
+
+      const signer = Wallet.isSigner(web3) ? web3 : web3.getSigner();
+
+      const zodiac = new Clients.Zodiac({ signer });
+
+      const executor = proposal.space.executors.find(executor => SUPPORTED_EXECUTORS[executor]);
+      if (!executor) throw new Error('Unsupported space');
+
+      return zodiac.executeProposalTxBatch(
+        proposalIndex,
+        executor,
+        convertToMetaTransactions(proposal.execution)
+      );
     },
     send: (envelope: any) => client.send(envelope)
   };

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -84,6 +84,26 @@ export function createActions(starkProvider: Provider) {
         choice
       });
     },
+    finalizeProposal: async (proposal: Proposal) => {
+      const res = await fetch(
+        `${manaUrl}/space/${proposal.space.id}/${proposal.proposal_id}/finalize`,
+        {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({
+            transactions: convertToMetaTransactions(proposal.execution)
+          })
+        }
+      );
+
+      const { error, receipt } = await res.json();
+      if (error) throw new Error('Finalization failed');
+
+      return receipt;
+    },
     receiveProposal: (web3: Web3Provider | Wallet, proposal: Proposal) => {
       const signer = Wallet.isSigner(web3) ? web3 : web3.getSigner();
 

--- a/src/networks/starknet/api.ts
+++ b/src/networks/starknet/api.ts
@@ -8,13 +8,29 @@ import {
   SPACE_QUERY,
   USER_QUERY
 } from './queries';
-import type { Space, Proposal, Vote, User } from '@/types';
+import type { Space, Proposal, Vote, User, Transaction } from '@/types';
+
+type ApiProposal = Omit<Proposal, 'has_ended' | 'execution'> & { execution: string };
 
 type PaginationOpts = { limit: number; skip?: number };
 
-function formatProposal(proposal: Omit<Proposal, 'has_ended'>, now: number = Date.now()): Proposal {
+function formatExecution(execution: string): Transaction[] {
+  if (execution === '') return [];
+
+  try {
+    const result = JSON.parse(execution);
+
+    return Array.isArray(result) ? result : [];
+  } catch (err) {
+    console.log('failed to parse execution');
+    return [];
+  }
+}
+
+function formatProposal(proposal: ApiProposal, now: number = Date.now()): Proposal {
   return {
     ...proposal,
+    execution: formatExecution(proposal.execution),
     has_ended: proposal.max_end * 1000 <= now
   };
 }

--- a/src/networks/starknet/queries.ts
+++ b/src/networks/starknet/queries.ts
@@ -9,6 +9,7 @@ export const PROPOSAL_QUERY = gql`
         id
         quorum
         authenticators
+        executors
       }
       author {
         id
@@ -50,6 +51,7 @@ export const PROPOSALS_QUERY = gql`
         id
         quorum
         authenticators
+        executors
       }
       author {
         id
@@ -104,6 +106,7 @@ export const PROPOSALS_SUMMARY_QUERY = gql`
       id
       quorum
       authenticators
+      executors
     }
     author {
       id

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type Proposal = {
     id: string;
     quorum: number;
     authenticators: string[];
+    executors: string[];
   };
   author: {
     id: string;
@@ -32,7 +33,7 @@ export type Proposal = {
   title: string;
   body: string;
   discussion: string;
-  execution: string;
+  execution: Transaction[];
   start: number;
   min_end: number;
   max_end: number;

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -5,7 +5,6 @@ import { sanitizeUrl } from '@braintree/sanitize-url';
 import { useProposalsStore } from '@/stores/proposals';
 import { _rt, _n, shortenAddress, getUrl } from '@/helpers/utils';
 import { useActions } from '@/composables/useActions';
-import type { Transaction } from '@/types';
 
 const route = useRoute();
 const proposalsStore = useProposalsStore();
@@ -24,22 +23,6 @@ const discussion = computed(() => {
   if (output === 'about:blank') return null;
 
   return output;
-});
-
-const execution = computed(() => {
-  const rawExecution = proposal.value?.execution;
-  if (!rawExecution) return null;
-
-  let parsed = null;
-  try {
-    parsed = JSON.parse(rawExecution);
-  } catch (err) {
-    console.log('failed to parse execution');
-  }
-
-  if (!parsed || !Array.isArray(parsed)) return null;
-
-  return parsed as Transaction[];
 });
 
 onMounted(() => {
@@ -96,24 +79,28 @@ onMounted(() => {
             <Preview :url="discussion" />
           </a>
         </div>
-        <div v-if="execution && execution.length > 0">
+        <div v-if="proposal.execution && proposal.execution.length > 0">
           <h4 class="mb-3 eyebrow flex items-center">
             <IH-play class="inline-block mr-2" />
             <span>Execution</span>
           </h4>
           <div class="mb-4">
-            <BlockExecution :txs="execution" />
+            <BlockExecution :txs="proposal.execution" />
           </div>
         </div>
         <div
-          v-if="execution && execution.length > 0 && proposal.scores_total >= proposal.space.quorum"
+          v-if="
+            proposal.execution &&
+            proposal.execution.length > 0 &&
+            proposal.scores_total >= proposal.space.quorum
+          "
         >
           <h4 class="mb-3 eyebrow flex items-center">
             <IH-play class="inline-block mr-2" />
             <span>Actions</span>
           </h4>
           <div class="mb-4">
-            <BlockActions />
+            <BlockActions :proposal="proposal" />
           </div>
         </div>
         <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,14 +1181,15 @@
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
 
-"@snapshot-labs/sx@^0.1.0-beta.16":
-  version "0.1.0-beta.16"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.16.tgz#22fe46f06788e912defe4cbd11ee3b37100ac129"
-  integrity sha512-kLXk4YtVZSA3JqHB9iW5JjxGkimqt1oFVzrCZzbI1pYxV8Md+bT/6LibgvhurUI+R9YZ8hi6Xx9Vxys1H45bjw==
+"@snapshot-labs/sx@^0.1.0-beta.17":
+  version "0.1.0-beta.17"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.17.tgz#6309ac8e69b1bf83d61e85578cad2eb8ab3ecbed"
+  integrity sha512-JQPxq63QqHolGUS8Tw2nArSMq6EuQc9C2qyDZWl99d3Y/HJzt3frjtP1tseg96kuzSuRS6eLAmO6kb7w2mNhkA==
   dependencies:
     "@ethereumjs/block" "^3.6.3"
     "@ethereumjs/common" "^2.6.5"
     "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
     "@ethersproject/contracts" "^5.7.0"
     "@ethersproject/hash" "^5.6.1"
     "@ethersproject/keccak256" "^5.7.0"


### PR DESCRIPTION
## Summary

Depends on https://github.com/snapshot-labs/sx-ui/pull/370

Towards https://github.com/snapshot-labs/sx-ui/issues/366

This PR makes finalize proposal and Zodiac actions (receive proposal + execute transactions) functional (you still need to update hardcoded proposalIndex as it's impossible to compute it).

## Test plan

- Create proposal with execution, vote for it until quorum is met.
- Click **Finalize proposal** button.
- **Wait for your transaction to arrive to become RECEIVED_ON_L1 (takes around an hour).**
- Once it has arrived update proposalIndex [here](https://github.com/snapshot-labs/sx-ui/blob/bdf8f2d8d65d17400c5a7495418590cade088e20/src/networks/starknet/actions.ts#L107-L108). It will be `proposalIndex - 1` from there: https://goerli.etherscan.io/address/0x196F0548E3140D2C7f6532a206dd54FbC12232a4#readContract
- Click on **Receive Proposal** button, confirm with Metamask, transaction should confirm.
- Click on **Execute Transactions** button, confirm with Metamask, transaction should confirm and execute.