### PR TITLE
fix: only show drafts from same space

### DIFF
--- a/src/components/Modal/Drafts.vue
+++ b/src/components/Modal/Drafts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { toRefs } from 'vue';
+import { toRefs, computed } from 'vue';
 import { useEditor } from '@/composables/useEditor';
 
 const props = defineProps<{
@@ -13,6 +13,8 @@ defineEmits<{
 
 const { drafts, removeDraft } = useEditor();
 const { open } = toRefs(props);
+
+const spaceDrafts = computed(() => drafts.value.filter(draft => draft.space === props.space));
 </script>
 
 <template>
@@ -21,9 +23,9 @@ const { open } = toRefs(props);
       <h3 v-text="'Drafts'" />
     </template>
     <div>
-      <div v-if="drafts.length > 0">
+      <div v-if="spaceDrafts.length > 0">
         <div
-          v-for="proposal in drafts"
+          v-for="proposal in spaceDrafts"
           :key="proposal.id"
           class="py-3 px-4 border-b last:border-b-0 flex justify-between items-center"
         >

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -25,11 +25,16 @@ export function useEditor() {
 
   const drafts = computed(() => {
     return Object.entries(removeEmpty(proposals))
-      .map(([k, value]) => ({
-        id: k,
-        key: k.split(':')[1],
-        ...value
-      }))
+      .map(([k, value]) => {
+        const [space, key] = k.split(':');
+
+        return {
+          id: k,
+          space,
+          key,
+          ...value
+        };
+      })
       .sort((a, b) => b.updatedAt - a.updatedAt);
   });
 


### PR DESCRIPTION
## Summary

Currently we show drafts from all spaces, but if you try to open draft from different space it won't work (data won't be loaded).

We have two ways of fixing this:
- Show all drafts in any space, just navigate to different space when selected - I started with this solution initially, but thought it will be confusing to suddenly end up in different space. I think it makes sense that drafts are space-scoped.
- Only show drafts from current space (this PR does that)

## Test plan

- Remove all drafts
- Go to A space, create a draft
- Go to B space, no drafts in drafts modal, create some draft in space B.
- Go back to A space, you can only see draft created for space A, space B's drafts are not visible.