### PR TITLE
fix: properly connect with ArgentX

### DIFF
--- a/src/helpers/argentx.ts
+++ b/src/helpers/argentx.ts
@@ -6,14 +6,24 @@ export default class Connector extends LockConnector {
     let provider;
     try {
       const argentx = await get();
-      const starknet = argentx.getStarknet();
+      const starknet = await argentx.connect();
+
+      if (!starknet) {
+        throw Error('User rejected wallet selection or silent connect found nothing');
+      }
+
       await starknet.enable({ showModal: true });
-      if (!starknet.isConnected) return false;
+
+      if (!starknet.isConnected) {
+        throw new Error('Connector was not connected');
+      }
+
       provider = starknet;
+      provider.connectorName = 'argentx';
+      return provider;
     } catch (e) {
       console.error(e);
+      return false;
     }
-    provider.connectorName = 'argentx';
-    return provider;
   }
 }


### PR DESCRIPTION
## Summary

ArgentX wasn't working for me. On first connect nothing would happen, on second attempt it might work. Looks like it's because we don't actually call `connect`, but deprecated `getStarknet()`.

## Test plan

- Connect with ArgentX.
- It works.