### PR TITLE
chore: upgrade to starknet v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "graphql-tag": "^2.12.6",
     "pinia": "^2.0.23",
     "scrollmonitor": "^1.2.9",
-    "starknet": "^4.14.0",
+    "starknet": "^5.0.0-beta.4",
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5",
     "vue": "^3.2.41",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,8 @@ import inject from '@rollup/plugin-inject';
 
 const ELECTRON = process.env.ELECTRON || false;
 
+const target = ['esnext'];
+
 export default defineConfig({
   base: ELECTRON ? path.resolve(__dirname, './dist') : undefined,
   define: {
@@ -43,6 +45,7 @@ export default defineConfig({
   optimizeDeps: {
     include: ['@snapshot-labs/sx'],
     esbuildOptions: {
+      target,
       plugins: [
         GlobalPolyFill({
           buffer: true
@@ -51,6 +54,7 @@ export default defineConfig({
     }
   },
   build: {
+    target,
     commonjsOptions: {
       include: [/sx.js/, /node_modules/],
       transformMixedEsModules: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,10 +1026,22 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
+"@noble/curves@^0.5.1":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-0.5.2.tgz#77aaecc6575d34ecfa1144f7ce47a91b2b242f6c"
+  integrity sha512-syLs2/gUz6qnuK/kaO4qeWie3LHtRLglOWRn08ZHQTBJqvj7qD30RZ3TTiYbTRxDM6lVY6cmc83ToXz8LsuX3w==
+  dependencies:
+    "@noble/hashes" "1.1.5"
+
 "@noble/hashes@1.1.2", "@noble/hashes@~1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
   integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
+"@noble/hashes@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.5.tgz#1a0377f3b9020efe2fae03290bd2a12140c95c11"
+  integrity sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==
 
 "@noble/secp256k1@1.6.3", "@noble/secp256k1@~1.6.0":
   version "1.6.3"
@@ -6661,6 +6673,21 @@ starknet@^4.14.0:
     ts-custom-error "^3.2.0"
     url-join "^4.0.1"
 
+starknet@^5.0.0-beta.4:
+  version "5.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/starknet/-/starknet-5.0.0-beta.4.tgz#b51d4031dfb902c1e13e990063a1d98da5de76b2"
+  integrity sha512-pn2wS1HJNL8f8/58s6g2pnFbwJBAE296CMe1foNlszGfiUcZSKhWGoqoNJjMN4cdv1dUqTeF1JmYjsigcoeb2A==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.1"
+    "@noble/curves" "^0.5.1"
+    ethereum-cryptography "^1.0.3"
+    isomorphic-fetch "^3.0.0"
+    json-bigint "^1.0.0"
+    minimalistic-assert "^1.0.1"
+    pako "^2.0.4"
+    ts-custom-error "^3.3.1"
+    url-join "^4.0.1"
+
 stream-browserify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
@@ -6915,6 +6942,11 @@ ts-custom-error@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.2.0.tgz#ff8f80a3812bab9dc448536312da52dce1b720fb"
   integrity sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A==
+
+ts-custom-error@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.3.1.tgz#8bd3c8fc6b8dc8e1cb329267c45200f1e17a65d1"
+  integrity sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==
 
 ts-invariant@^0.10.3:
   version "0.10.3"


### PR DESCRIPTION
## Summary

Support starknet v5 to make singing txs faster.

## Test plan

Link this PR: https://github.com/snapshot-labs/sx.js/pull/125