### PR TITLE
fix: show days left in _d formatter

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -84,9 +84,11 @@ export function lsRemove(key: string) {
 }
 
 export function _d(s: number) {
-  return dayjs
-    .duration(s, 'seconds')
-    .format('H[h] m[m] s[s]')
+  const duration = dayjs.duration(s, 'seconds');
+  const daysLeft = Math.floor(duration.asDays());
+
+  return duration
+    .format(`[${daysLeft}d] H[h] m[m] s[s]`)
     .replace(/\b0+[a-z]+\s*/gi, '')
     .trim();
 }


### PR DESCRIPTION
## Summary

Right now we only format durations up to a day - because of that voting duration is missing there because it's exactly one day (https://testnet.snapshotx.xyz/#/sn-tn2:0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28/settings). We can't just use `D` format to show dates as if value is longer than a month it will ignore months. In this all time that didn't fit in H/m/s will be calculated as days (for example 60 days).

## Test plan

https://testnet.snapshotx.xyz/#/sn-tn2:0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28/settings space looks good.
EVM spaces have super high max voting duration because that's the value API returns (because it uses timestamps from proposal instead of true durations).

## Screenshots

![image](https://user-images.githubusercontent.com/1968722/216284434-dca52731-1ce1-453f-84be-731a65f61a4e.png)
