### PR TITLE
fix: overfetch spaces and proposals for better infinite loading

### DIFF
--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -58,11 +58,11 @@ export const useProposalsStore = defineStore('proposals', {
       record.value.loading = true;
 
       const proposals = await getNetwork(networkId).api.loadProposals(spaceId, {
-        limit: PROPOSALS_LIMIT
+        limit: PROPOSALS_LIMIT + 1
       });
 
-      record.value.proposals = proposals;
-      record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT;
+      record.value.proposals = proposals.slice(0, PROPOSALS_LIMIT);
+      record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT + 1;
       record.value.loaded = true;
       record.value.loading = false;
     },
@@ -88,13 +88,13 @@ export const useProposalsStore = defineStore('proposals', {
       record.value.loadingMore = true;
 
       const proposals = await getNetwork(networkId).api.loadProposals(spaceId, {
-        limit: PROPOSALS_LIMIT,
+        limit: PROPOSALS_LIMIT + 1,
         skip: record.value.proposals.length
       });
 
-      record.value.proposals = [...record.value.proposals, ...proposals];
+      record.value.proposals = [...record.value.proposals, ...proposals.slice(0, PROPOSALS_LIMIT)];
 
-      record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT;
+      record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT + 1;
       record.value.loadingMore = false;
     },
     async fetchSummary(spaceId: string, networkId: NetworkID, limit = 3) {

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -49,13 +49,13 @@ export const useSpacesStore = defineStore('spaces', {
 
           const spaces = await network.api.loadSpaces({
             skip: overwrite ? 0 : record.spaces.length,
-            limit: SPACES_LIMIT
+            limit: SPACES_LIMIT + 1
           });
 
           return {
             id,
-            spaces,
-            hasMoreSpaces: spaces.length === SPACES_LIMIT
+            spaces: spaces.slice(0, SPACES_LIMIT),
+            hasMoreSpaces: spaces.length === SPACES_LIMIT + 1
           };
         })
       );


### PR DESCRIPTION
## Summary

Currently we have an issue if we have exactly `LIMIT` (or `n * LIMIT`) results in database. We will assume that there are more results to be fetched, but there might be none. Without server telling us (`hasMore` property), we can workaround it by fetching one result more and checking if there are more using this extra element. This causes more data to be transfered (could be solved by caching that extra result, but it might not be worth complexity), but provides better UX.

## Test plan

Fetching spaces/proposals works.