### PR TITLE
feat: use networks explorer url in Settings

### DIFF
--- a/src/components/Modal/PendingTransactions.vue
+++ b/src/components/Modal/PendingTransactions.vue
@@ -26,7 +26,9 @@ const uiStore = useUiStore();
         <a
           v-for="pendingTx in uiStore.pendingTransactions"
           :key="pendingTx.txId"
-          :href="getNetwork(pendingTx.networkId).helpers.getTransactionLink(pendingTx.txId)"
+          :href="
+            getNetwork(pendingTx.networkId).helpers.getExplorerUrl(pendingTx.txId, 'transaction')
+          "
           target="_blank"
           class="border rounded-lg px-3 py-2 flex items-center w-full mb-2 last:mb-0"
         >

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -1,3 +1,4 @@
+import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { createApi } from '../common/graphqlApi';
 import { createActions } from './actions';
 import { createProvider } from './provider';
@@ -7,7 +8,9 @@ import type { Network } from '@/networks/types';
 import type { NetworkID } from '@/types';
 
 export function createEvmNetwork(networkId: NetworkID): Network {
-  const provider = createProvider('https://rpc.brovider.xyz/5');
+  const chainId = 5;
+
+  const provider = createProvider(`https://rpc.brovider.xyz/${chainId}`);
 
   return {
     hasRelayer: false,
@@ -18,8 +21,13 @@ export function createEvmNetwork(networkId: NetworkID): Network {
     constants,
     helpers: {
       pin: pinGraph,
-      waitForTransaction: txId => provider.waitForTransaction(txId),
-      getTransactionLink: txId => `https://goerli.etherscan.io/tx/${txId}`
+      waitForTransaction: (txId: string) => provider.waitForTransaction(txId),
+      getExplorerUrl: (id, type) => {
+        let dataType: 'tx' | 'address' = 'tx';
+        if (['address', 'contract'].includes(type)) dataType = 'address';
+
+        return `${networks[chainId].explorer}/${dataType}/${id}`;
+      }
     }
   };
 }

--- a/src/networks/starknet/index.ts
+++ b/src/networks/starknet/index.ts
@@ -28,7 +28,12 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
       },
       waitForTransaction: txId =>
         provider.waitForTransaction(txId, undefined, ['ACCEPTED_ON_L1', 'ACCEPTED_ON_L2']),
-      getTransactionLink: txId => `https://testnet-2.starkscan.co/tx/${txId}`
+      getExplorerUrl: (id, type) => {
+        let dataType: 'tx' | 'contract' = 'tx';
+        if (['address', 'contract'].includes(type)) dataType = 'contract';
+
+        return `https://testnet-2.starkscan.co/${dataType}/${id}`;
+      }
     }
   };
 }

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -59,6 +59,6 @@ export type Network = {
   helpers: {
     pin: (content: any) => Promise<{ cid: string; provider: string }>;
     waitForTransaction(txId: string): Promise<any>;
-    getTransactionLink(txId: string): string;
+    getExplorerUrl(id: string, type: 'transaction' | 'address' | 'contract'): string;
   };
 };

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -40,7 +40,7 @@ const network = computed(() => getNetwork(props.space.network));
     <div>
       <Label :label="'Controller'" />
       <div class="py-3 mx-4">
-        <a :href="`https://goerli.voyager.online/contract/${space.controller}`" target="_blank">
+        <a :href="network.helpers.getExplorerUrl(space.controller, 'contract')" target="_blank">
           <Stamp :id="space.controller" type="avatar" :size="18" class="mr-2 rounded-sm" />
           {{ shorten(space.controller) }}
           <IH-external-link class="inline-block" />
@@ -51,7 +51,7 @@ const network = computed(() => getNetwork(props.space.network));
     <div>
       <Label :label="'Auth(s)'" />
       <div v-for="(auth, i) in space.authenticators" :key="i" class="mx-4 py-3 border-b">
-        <a :href="`https://goerli.voyager.online/contract/${auth}`" target="_blank" class="flex">
+        <a :href="network.helpers.getExplorerUrl(auth, 'contract')" target="_blank" class="flex">
           <h4 class="flex-auto" v-text="network.constants.AUTHS[auth]" />
           <div>
             <Stamp :id="auth" type="avatar" :size="18" class="mr-2 rounded-sm" />
@@ -65,7 +65,7 @@ const network = computed(() => getNetwork(props.space.network));
       <Label :label="'Strategie(s)'" />
       <div v-for="(strategy, i) in space.strategies" :key="i" class="mx-4 py-3 border-b">
         <a
-          :href="`https://goerli.voyager.online/contract/${strategy}`"
+          :href="network.helpers.getExplorerUrl(strategy, 'contract')"
           target="_blank"
           class="flex"
         >
@@ -82,7 +82,7 @@ const network = computed(() => getNetwork(props.space.network));
       <Label :label="'Execution(s)'" />
       <div v-for="(executor, i) in space.executors" :key="i" class="mx-4 py-3 border-b">
         <a
-          :href="`https://goerli.voyager.online/contract/${executor}`"
+          :href="network.helpers.getExplorerUrl(executor, 'contract')"
           target="_blank"
           class="flex"
         >


### PR DESCRIPTION
## Summary

This PR adds explorer URL from network for Space settigns page.

There is old `explorerUrl` still being used, but this will need some refactoring to improve network -> networkID mapping so leaving it out for now.