### PR TITLE
feat: add strategies editor

### DIFF
--- a/src/components/Block/StrategiesConfig.vue
+++ b/src/components/Block/StrategiesConfig.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { ref, computed, Ref } from 'vue';
+import type { StrategyConfig, StrategyTemplate } from '@/networks/types';
+
+const props = defineProps<{
+  modelValue: StrategyConfig[];
+  title: string;
+  description: string;
+  availableStrategies: StrategyTemplate[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: StrategyConfig[]);
+}>();
+
+const activeStrategies = computed({
+  get: () => props.modelValue,
+  set: newValue => emit('update:modelValue', newValue)
+});
+
+const editedStrategy: Ref<StrategyConfig | null> = ref(null);
+const editStrategyModalOpen = ref(false);
+
+function addStrategy(strategy: StrategyTemplate) {
+  const strategyConfig = {
+    id: crypto.randomUUID(),
+    params: {},
+    ...strategy
+  };
+
+  if (strategy.paramsDefinition) {
+    editStrategy(strategyConfig);
+  } else {
+    activeStrategies.value = [...activeStrategies.value, strategyConfig];
+  }
+}
+
+function editStrategy(strategy: StrategyConfig) {
+  editedStrategy.value = strategy;
+  editStrategyModalOpen.value = true;
+}
+
+function removeStrategy(strategy: StrategyConfig) {
+  activeStrategies.value = activeStrategies.value.filter(s => s.id !== strategy.id);
+}
+
+function handleStrategySave(value: Record<string, any>) {
+  editStrategyModalOpen.value = false;
+
+  let allStrategies = [...activeStrategies.value];
+  if (editedStrategy.value && !allStrategies.find(s => s.id === editedStrategy.value?.id)) {
+    allStrategies.push(editedStrategy.value);
+  }
+
+  activeStrategies.value = allStrategies.map(strategy => {
+    if (strategy.id !== editedStrategy.value?.id) return strategy;
+
+    return {
+      ...strategy,
+      params: value
+    };
+  });
+}
+</script>
+
+<template>
+  <div>
+    <div class="mb-4">
+      <h3 class="mb-2">{{ title }}</h3>
+      <span class="mb-3 inline-block">
+        {{ description }}
+      </span>
+      <h4 class="eyebrow mb-2">Active</h4>
+      <div class="mb-3">
+        <div v-if="activeStrategies.length === 0">No strategies selected</div>
+        <div
+          v-for="strategy in activeStrategies"
+          v-else
+          :key="strategy.id"
+          class="flex justify-between items-center rounded-lg border px-4 py-3 mb-3 text-skin-link"
+        >
+          <div class="flex min-w-0">
+            <div class="whitespace-nowrap">{{ strategy.name }}</div>
+            <div v-if="strategy.generateSummary" class="ml-2 pr-2 text-skin-text truncate">
+              {{ strategy.generateSummary(strategy.params) }}
+            </div>
+          </div>
+          <div class="flex gap-3">
+            <a v-if="strategy.paramsDefinition" @click="editStrategy(strategy)">
+              <IH-pencil />
+            </a>
+            <a @click="removeStrategy(strategy)">
+              <IH-trash />
+            </a>
+          </div>
+        </div>
+      </div>
+      <h4 class="eyebrow mb-2">Available</h4>
+      <div v-if="availableStrategies.length === 0">No strategies available</div>
+      <div v-else class="flex flex-wrap gap-2">
+        <button
+          v-for="strategy in availableStrategies"
+          :key="strategy.address"
+          class="flex items-center rounded-lg border cursor-pointer px-3 py-2 text-skin-link"
+          @click="addStrategy(strategy)"
+        >
+          <IH-plus-circle />
+          <div class="ml-2">{{ strategy.name }}</div>
+        </button>
+      </div>
+    </div>
+    <teleport to="#modal">
+      <ModalEditStrategy
+        :open="editStrategyModalOpen"
+        :definition="editedStrategy?.paramsDefinition"
+        :initial-state="editedStrategy?.params"
+        @close="editStrategyModalOpen = false"
+        @save="handleStrategySave"
+      />
+    </teleport>
+  </div>
+</template>

--- a/src/components/Modal/EditStrategy.vue
+++ b/src/components/Modal/EditStrategy.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { ref, computed, watch, Ref } from 'vue';
+import { validateForm } from '@/helpers/validation';
+
+const props = defineProps<{
+  open: boolean;
+  initialState?: any;
+  definition: any;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close');
+  (e: 'save', value: Record<string, any>);
+}>();
+
+const showPicker = ref(false);
+const pickerField: Ref<string | null> = ref(null);
+const searchValue = ref('');
+const form: Ref<Record<string, any>> = ref({});
+
+const formErrors = computed(() => validateForm(props.definition, form.value));
+
+function handlePickerClick(field: string) {
+  showPicker.value = true;
+  pickerField.value = field;
+}
+
+function handlePickerSelect(value: string) {
+  showPicker.value = false;
+
+  if (!pickerField.value) return;
+
+  form.value[pickerField.value] = value;
+}
+
+async function handleSubmit() {
+  emit('save', form.value);
+}
+
+watch(
+  () => props.open,
+  () => {
+    if (!props.initialState) return;
+
+    form.value = props.initialState;
+  }
+);
+</script>
+
+<template>
+  <UiModal :open="open" @close="$emit('close')">
+    <template #header>
+      <h3>Edit strategy</h3>
+      <template v-if="showPicker">
+        <a class="absolute left-0 -top-1 p-4 text-color" @click="showPicker = false">
+          <IH-arrow-narrow-left class="mr-2" />
+        </a>
+        <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
+          <IH-search class="mx-2" />
+          <input
+            ref="searchInput"
+            v-model="searchValue"
+            type="text"
+            placeholder="Search"
+            class="flex-auto bg-transparent text-skin-link"
+          />
+        </div>
+      </template>
+    </template>
+    <BlockContactPicker
+      v-if="showPicker"
+      :loading="false"
+      :search-value="searchValue"
+      @pick="handlePickerSelect"
+    />
+    <div v-else class="s-box p-4">
+      <SIObject
+        v-model="form"
+        :error="formErrors"
+        :definition="definition"
+        @pick="handlePickerClick"
+      />
+    </div>
+    <template v-if="!showPicker" #footer>
+      <UiButton class="w-full" :disabled="Object.keys(formErrors).length > 0" @click="handleSubmit">
+        Confirm
+      </UiButton>
+    </template>
+  </UiModal>
+</template>

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -12,7 +12,7 @@ import type {
   Choice,
   NetworkID
 } from '@/types';
-import type { Connector } from '@/networks/types';
+import type { Connector, StrategyConfig } from '@/networks/types';
 
 export function useActions() {
   const uiStore = useUiStore();
@@ -44,7 +44,10 @@ export function useActions() {
   async function createSpace(
     networkId: NetworkID,
     metadata: SpaceMetadata,
-    settings: SpaceSettings
+    settings: SpaceSettings,
+    authenticators: StrategyConfig[],
+    votingStrategies: StrategyConfig[],
+    executionStrategies: StrategyConfig[]
   ) {
     if (!web3.value.account) {
       forceLogin();
@@ -65,10 +68,12 @@ export function useActions() {
       maxVotingDuration: settings.maxVotingDuration,
       proposalThreshold: BigInt(settings.proposalThreshold),
       qorum: BigInt(settings.quorum),
-      authenticators: ['0x64cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14'],
-      votingStrategies: ['0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b'],
-      votingStrategiesParams: [['0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6', '0x3']],
-      executionStrategies: ['0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81'],
+      authenticators: authenticators.map(config => config.address),
+      votingStrategies: votingStrategies.map(config => config.address),
+      votingStrategiesParams: votingStrategies.map(config =>
+        config.generateParams ? config.generateParams(config.params) : []
+      ),
+      executionStrategies: executionStrategies.map(config => config.address),
       metadataUri: `ipfs://${pinned.cid}`
     });
 

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -23,3 +23,9 @@ export const STRATEGIES = {
 export const EXECUTORS = {
   '0x81519c29621ba131ea398c15b17391f53e8b9a94': 'Vanilla'
 };
+
+export const EDITOR_AUTHENTICATORS = [];
+
+export const EDITOR_VOTING_STRATEGIES = [];
+
+export const EDITOR_EXECUTION_STRATEGIES = [];

--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -1,3 +1,5 @@
+import { shorten } from '@/helpers/utils';
+
 export const API_URL = 'https://testnet-api-1.snapshotx.xyz';
 
 export const SUPPORTED_AUTHENTICATORS = {
@@ -33,3 +35,65 @@ export const EXECUTORS = {
   '0x4ecc83848a519cc22b0d0ffb70e65ec8dde85d3d13439eff7145d4063cf6b4d': 'Vanilla',
   '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81': 'Zodiac'
 };
+
+export const EDITOR_AUTHENTICATORS = [
+  {
+    address: '0x5e1f273ca9a11f78bfb291cbe1b49294cf3c76dd48951e7ab7db6d9fb1e7d62',
+    name: 'Vanilla',
+    paramsDefinition: null
+  },
+  {
+    address: '0x64cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14',
+    name: 'Ethereum signature',
+    paramsDefinition: null
+  }
+];
+
+export const EDITOR_VOTING_STRATEGIES = [
+  {
+    address: '0x58623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48',
+    name: 'Vanilla',
+    paramsDefinition: null
+  },
+  {
+    address: '0xd1b81feff3095ca9517fdfc7427e742ce96f7ca8f3b2664a21b2fba552493b',
+    name: 'Single slot proof',
+    generateSummary: (params: Record<string, any>) =>
+      `(${shorten(params.contractAddress)}, ${params.slotIndex})`,
+    generateParams: (params: Record<string, any>) => {
+      return [params.contractAddress, `0x${params.slotIndex.toString(16)}`];
+    },
+    paramsDefinition: {
+      type: 'object',
+      title: 'Params',
+      additionalProperties: false,
+      required: ['contractAddress', 'slotIndex'],
+      properties: {
+        contractAddress: {
+          type: 'string',
+          format: 'address',
+          title: 'Contract address',
+          examples: ['0x0000…']
+        },
+        slotIndex: {
+          type: 'string',
+          title: 'Storage slot',
+          examples: ['e.g. 1']
+        }
+      }
+    }
+  }
+];
+
+export const EDITOR_EXECUTION_STRATEGIES = [
+  {
+    address: '0x4ecc83848a519cc22b0d0ffb70e65ec8dde85d3d13439eff7145d4063cf6b4d',
+    name: 'Vanilla',
+    paramsDefinition: null
+  },
+  {
+    address: '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81',
+    name: 'Zodiac',
+    paramsDefinition: null
+  }
+];

--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -60,9 +60,10 @@ export const EDITOR_VOTING_STRATEGIES = [
     name: 'Single slot proof',
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.slotIndex})`,
-    generateParams: (params: Record<string, any>) => {
-      return [params.contractAddress, `0x${params.slotIndex.toString(16)}`];
-    },
+    generateParams: (params: Record<string, any>) => [
+      params.contractAddress,
+      `0x${params.slotIndex.toString(16)}`
+    ],
     paramsDefinition: {
       type: 'object',
       title: 'Params',

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -11,6 +11,19 @@ export type Connector =
   | 'portis'
   | 'gnosis';
 
+export type StrategyTemplate = {
+  address: string;
+  name: string;
+  paramsDefinition: any;
+  generateSummary?: (params: Record<string, any>) => string;
+  generateParams?: (params: Record<string, any>) => any[];
+};
+
+export type StrategyConfig = StrategyTemplate & {
+  id: string;
+  params: Record<string, any>;
+};
+
 // TODO: make sx.js accept Signer instead of Web3Provider | Wallet
 
 export type NetworkActions = {
@@ -71,6 +84,9 @@ export type Network = {
     AUTHS: { [key: string]: string };
     STRATEGIES: { [key: string]: string };
     EXECUTORS: { [key: string]: string };
+    EDITOR_AUTHENTICATORS: StrategyTemplate[];
+    EDITOR_VOTING_STRATEGIES: StrategyTemplate[];
+    EDITOR_EXECUTION_STRATEGIES: StrategyTemplate[];
   };
   helpers: {
     pin: (content: any) => Promise<{ cid: string; provider: string }>;

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -153,7 +153,7 @@ watch(selectedNetworkId, () => {
 <template>
   <div>
     <Container class="pt-5">
-      <h2 class="mb-2">Deploy space</h2>
+      <h2>Deploy space</h2>
       <div class="s-box pt-4">
         <SIObject
           v-model="metadataForm"

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { ref, reactive, computed, Ref } from 'vue';
+import { ref, reactive, computed, watch, Ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useActions } from '@/composables/useActions';
 import { clone } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';
 import { enabledNetworks, getNetwork } from '@/networks';
+import type { StrategyConfig } from '@/networks/types';
 import type { NetworkID, SpaceSettings } from '@/types';
 
 type MetadataState = { name: string; about?: string; website?: string };
@@ -103,11 +104,18 @@ const settingsForm: SpaceSettings = reactive(
     quorum: '1'
   })
 );
+const authenticators = ref([] as StrategyConfig[]);
+const votingStrategies = ref([] as StrategyConfig[]);
+const executionStrategies = ref([] as StrategyConfig[]);
 
+const selectedNetwork = computed(() => getNetwork(selectedNetworkId.value));
 const metadataFormErrors = computed(() => validateForm(metadataDefinition, metadataForm));
 const settingsFormErrors = computed(() => validateForm(settingsDefinition, settingsForm));
 const disabled = computed(
   () =>
+    authenticators.value.length === 0 ||
+    votingStrategies.value.length === 0 ||
+    executionStrategies.value.length === 0 ||
     Object.keys(metadataFormErrors.value).length > 0 ||
     Object.keys(settingsFormErrors.value).length > 0
 );
@@ -123,7 +131,10 @@ async function handleSubmit() {
         description: metadataForm.about || '',
         external_url: metadataForm.website || ''
       },
-      settingsForm
+      settingsForm,
+      authenticators.value,
+      votingStrategies.value,
+      executionStrategies.value
     );
 
     if (result) router.back();
@@ -131,12 +142,18 @@ async function handleSubmit() {
     sending.value = false;
   }
 }
+
+watch(selectedNetworkId, () => {
+  authenticators.value = [];
+  votingStrategies.value = [];
+  executionStrategies.value = [];
+});
 </script>
 
 <template>
   <div>
     <Container class="pt-5">
-      <h2>Deploy space</h2>
+      <h2 class="mb-2">Deploy space</h2>
       <div class="s-box pt-4">
         <SIObject
           v-model="metadataForm"
@@ -162,6 +179,31 @@ async function handleSubmit() {
           :definition="settingsDefinition"
         />
       </div>
+
+      <BlockStrategiesConfig
+        v-model="authenticators"
+        :available-strategies="selectedNetwork.constants.EDITOR_AUTHENTICATORS"
+        title="Authenticators"
+        description="Lorem ipsum..."
+        class="mt-6"
+      />
+
+      <BlockStrategiesConfig
+        v-model="votingStrategies"
+        :available-strategies="selectedNetwork.constants.EDITOR_VOTING_STRATEGIES"
+        title="Voting strategies"
+        description="Lorem ipsum..."
+        class="mt-6"
+      />
+
+      <BlockStrategiesConfig
+        v-model="executionStrategies"
+        :available-strategies="selectedNetwork.constants.EDITOR_EXECUTION_STRATEGIES"
+        title="Execution strategies"
+        description="Lorem ipsum..."
+        class="mt-6"
+      />
+
       <UiButton class="w-full" :loading="sending" :disabled="disabled" @click="handleSubmit">
         Create
       </UiButton>


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/407

This PR adds strategy editor to create space page. Available strategies are defined per network and can specify if additional params are required.

Currently available strategies are displayed inline, to save some space.

It looks super busy in current form, but should be solved when we split creator into multiple steps.

## Test plan
- Sign in with ArgentX.
- Go to space creator.
- Create some spaces, play with editor.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/217329349-b3869b53-15f6-4cdb-a5a3-92b205b0d9e9.png" width="600" />