### PR TITLE
fix: remove fetching spaces in Sidebar

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import { useSpacesStore } from '@/stores/spaces';
-import { onMounted } from 'vue';
 import draggable from 'vuedraggable';
 
 const spacesStore = useSpacesStore();
-
-onMounted(() => spacesStore.fetch());
 </script>
 
 <template>
@@ -13,13 +10,7 @@ onMounted(() => spacesStore.fetch());
     <router-link :to="{ name: 'home' }" class="h-[72px] block">
       <IH-stop class="inline-block my-4 w-[32px] h-[32px] text-skin-link" />
     </router-link>
-    <UiLoading v-if="!spacesStore.loaded" class="py-2 block" />
-    <draggable
-      v-else
-      v-model="spacesStore.starredSpacesIds"
-      :item-key="i => i"
-      class="space-y-3 p-2"
-    >
+    <draggable v-model="spacesStore.starredSpacesIds" :item-key="i => i" class="space-y-3 p-2">
       <template #item="{ element }">
         <router-link :to="{ name: 'overview', params: { id: element } }" class="block">
           <Stamp :id="element.split(':')[1]" :size="32" class="!rounded-[4px]" />


### PR DESCRIPTION
It's no longer needed as spaces in sidebar now come from storage only.

This will fix issue with https://github.com/snapshot-labs/sx-ui/issues/435, but proper fix is still needed.