### PR TITLE
refactor: separate data from lists in spaces/proposals

### DIFF
--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -7,8 +7,8 @@ type SpaceRecord = {
   loading: boolean;
   loadingMore: boolean;
   loaded: boolean;
-  proposalsList: number[];
-  proposalsMap: Record<number, Proposal>;
+  proposalsIdsList: number[];
+  proposals: Record<number, Proposal>;
   hasMoreProposals: boolean;
   summaryLoading: boolean;
   summaryLoaded: boolean;
@@ -30,7 +30,7 @@ export const useProposalsStore = defineStore('proposals', {
         const record = state.proposals[getUniqueSpaceId(spaceId, networkId)];
         if (!record) return [];
 
-        return record.proposalsList.map(proposalId => record.proposalsMap[proposalId]);
+        return record.proposalsIdsList.map(proposalId => record.proposals[proposalId]);
       };
     },
     getProposal: state => {
@@ -38,7 +38,7 @@ export const useProposalsStore = defineStore('proposals', {
         const record = state.proposals[getUniqueSpaceId(spaceId, networkId)];
         if (!record) return undefined;
 
-        return record.proposalsMap[proposalId];
+        return record.proposals[proposalId];
       };
     }
   },
@@ -51,8 +51,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposalsList: [],
-          proposalsMap: {},
+          proposalsIdsList: [],
+          proposals: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -69,9 +69,9 @@ export const useProposalsStore = defineStore('proposals', {
         limit: PROPOSALS_LIMIT
       });
 
-      record.value.proposalsList = proposals.map(proposal => proposal.proposal_id);
-      record.value.proposalsMap = {
-        ...record.value.proposalsMap,
+      record.value.proposalsIdsList = proposals.map(proposal => proposal.proposal_id);
+      record.value.proposals = {
+        ...record.value.proposals,
         ...Object.fromEntries(proposals.map(proposal => [proposal.proposal_id, proposal]))
       };
       record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT;
@@ -86,8 +86,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposalsList: [],
-          proposalsMap: {},
+          proposalsIdsList: [],
+          proposals: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -102,15 +102,15 @@ export const useProposalsStore = defineStore('proposals', {
 
       const proposals = await getNetwork(networkId).api.loadProposals(spaceId, {
         limit: PROPOSALS_LIMIT,
-        skip: record.value.proposalsList.length
+        skip: record.value.proposalsIdsList.length
       });
 
-      record.value.proposalsList = [
-        ...record.value.proposalsList,
+      record.value.proposalsIdsList = [
+        ...record.value.proposalsIdsList,
         ...proposals.map(proposal => proposal.proposal_id)
       ];
-      record.value.proposalsMap = {
-        ...record.value.proposalsMap,
+      record.value.proposals = {
+        ...record.value.proposals,
         ...Object.fromEntries(proposals.map(proposal => [proposal.proposal_id, proposal]))
       };
 
@@ -125,8 +125,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposalsList: [],
-          proposalsMap: {},
+          proposalsIdsList: [],
+          proposals: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -155,8 +155,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposalsList: [],
-          proposalsMap: {},
+          proposalsIdsList: [],
+          proposals: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -168,8 +168,8 @@ export const useProposalsStore = defineStore('proposals', {
 
       const proposal = await getNetwork(networkId).api.loadProposal(spaceId, proposalId);
 
-      record.value.proposalsMap = {
-        ...record.value.proposalsMap,
+      record.value.proposals = {
+        ...record.value.proposals,
         [proposalId]: proposal
       };
     }

--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -7,7 +7,8 @@ type SpaceRecord = {
   loading: boolean;
   loadingMore: boolean;
   loaded: boolean;
-  proposals: Proposal[];
+  proposalsList: number[];
+  proposalsMap: Record<number, Proposal>;
   hasMoreProposals: boolean;
   summaryLoading: boolean;
   summaryLoaded: boolean;
@@ -24,14 +25,20 @@ export const useProposalsStore = defineStore('proposals', {
     proposals: {} as Partial<Record<string, SpaceRecord>>
   }),
   getters: {
+    getSpaceProposals: state => {
+      return (spaceId: string, networkId: NetworkID) => {
+        const record = state.proposals[getUniqueSpaceId(spaceId, networkId)];
+        if (!record) return [];
+
+        return record.proposalsList.map(proposalId => record.proposalsMap[proposalId]);
+      };
+    },
     getProposal: state => {
       return (spaceId: string, proposalId: number, networkId: NetworkID) => {
         const record = state.proposals[getUniqueSpaceId(spaceId, networkId)];
         if (!record) return undefined;
 
-        return [...record.proposals, ...record.summaryProposals].find(
-          proposal => proposal.proposal_id === proposalId
-        );
+        return record.proposalsMap[proposalId];
       };
     }
   },
@@ -44,7 +51,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposals: [],
+          proposalsList: [],
+          proposalsMap: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -61,7 +69,11 @@ export const useProposalsStore = defineStore('proposals', {
         limit: PROPOSALS_LIMIT
       });
 
-      record.value.proposals = proposals;
+      record.value.proposalsList = proposals.map(proposal => proposal.proposal_id);
+      record.value.proposalsMap = {
+        ...record.value.proposalsMap,
+        ...Object.fromEntries(proposals.map(proposal => [proposal.proposal_id, proposal]))
+      };
       record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT;
       record.value.loaded = true;
       record.value.loading = false;
@@ -74,7 +86,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposals: [],
+          proposalsList: [],
+          proposalsMap: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -89,10 +102,17 @@ export const useProposalsStore = defineStore('proposals', {
 
       const proposals = await getNetwork(networkId).api.loadProposals(spaceId, {
         limit: PROPOSALS_LIMIT,
-        skip: record.value.proposals.length
+        skip: record.value.proposalsList.length
       });
 
-      record.value.proposals = [...record.value.proposals, ...proposals];
+      record.value.proposalsList = [
+        ...record.value.proposalsList,
+        ...proposals.map(proposal => proposal.proposal_id)
+      ];
+      record.value.proposalsMap = {
+        ...record.value.proposalsMap,
+        ...Object.fromEntries(proposals.map(proposal => [proposal.proposal_id, proposal]))
+      };
 
       record.value.hasMoreProposals = proposals.length === PROPOSALS_LIMIT;
       record.value.loadingMore = false;
@@ -105,7 +125,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposals: [],
+          proposalsList: [],
+          proposalsMap: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -134,7 +155,8 @@ export const useProposalsStore = defineStore('proposals', {
           loading: false,
           loadingMore: false,
           loaded: false,
-          proposals: [],
+          proposalsList: [],
+          proposalsMap: {},
           hasMoreProposals: true,
           summaryLoading: false,
           summaryLoaded: false,
@@ -143,12 +165,13 @@ export const useProposalsStore = defineStore('proposals', {
       }
 
       const record = toRef(this.proposals, uniqueSpaceId) as Ref<SpaceRecord>;
-      if (this.getProposal(spaceId, proposalId, networkId)) return;
 
       const proposal = await getNetwork(networkId).api.loadProposal(spaceId, proposalId);
 
-      if (this.getProposal(spaceId, proposalId, networkId)) return;
-      record.value.proposals.push(proposal);
+      record.value.proposalsMap = {
+        ...record.value.proposalsMap,
+        [proposalId]: proposal
+      };
     }
   }
 });

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -73,13 +73,14 @@ export const useSpacesStore = defineStore('spaces', {
 
       this.networksMap = Object.fromEntries(
         results.map(result => {
+          const spacesIds = result.spaces.map(space => space.id);
+
           return [
             result.id,
             {
-              spacesIdsList: [
-                ...this.networksMap[result.id].spacesIdsList,
-                ...result.spaces.map(space => space.id)
-              ],
+              spacesIdsList: overwrite
+                ? spacesIds
+                : [...this.networksMap[result.id].spacesIdsList, ...spacesIds],
               spaces: {
                 ...this.networksMap[result.id].spaces,
                 ...Object.fromEntries(result.spaces.map(space => [space.id, space]))

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -7,8 +7,8 @@ import pkg from '../../package.json';
 const SPACES_LIMIT = 10;
 
 type NetworkRecord = {
-  spacesMap: Record<string, Space>;
-  spacesList: string[];
+  spaces: Record<string, Space>;
+  spacesIdsList: string[];
   hasMoreSpaces: boolean;
 };
 
@@ -21,8 +21,8 @@ export const useSpacesStore = defineStore('spaces', {
       enabledNetworks.map(network => [
         network,
         {
-          spacesMap: {},
-          spacesList: [],
+          spaces: {},
+          spacesIdsList: [],
           hasMoreSpaces: true
         } as NetworkRecord
       ])
@@ -32,12 +32,12 @@ export const useSpacesStore = defineStore('spaces', {
   getters: {
     spaces: state =>
       Object.values(state.networksMap).flatMap(record =>
-        record.spacesList.map(spaceId => record.spacesMap[spaceId])
+        record.spacesIdsList.map(spaceId => record.spaces[spaceId])
       ),
     spacesMap: state =>
       new Map(
         Object.values(state.networksMap).flatMap(record =>
-          Object.values(record.spacesMap).map(space => [`${space.network}:${space.id}`, space])
+          Object.values(record.spaces).map(space => [`${space.network}:${space.id}`, space])
         )
       ),
     hasMoreSpaces: state =>
@@ -59,7 +59,7 @@ export const useSpacesStore = defineStore('spaces', {
           }
 
           const spaces = await network.api.loadSpaces({
-            skip: overwrite ? 0 : record.spacesList.length,
+            skip: overwrite ? 0 : record.spacesIdsList.length,
             limit: SPACES_LIMIT
           });
 
@@ -76,12 +76,12 @@ export const useSpacesStore = defineStore('spaces', {
           return [
             result.id,
             {
-              spacesList: [
-                ...this.networksMap[result.id].spacesList,
+              spacesIdsList: [
+                ...this.networksMap[result.id].spacesIdsList,
                 ...result.spaces.map(space => space.id)
               ],
-              spacesMap: {
-                ...this.networksMap[result.id].spacesMap,
+              spaces: {
+                ...this.networksMap[result.id].spaces,
                 ...Object.fromEntries(result.spaces.map(space => [space.id, space]))
               },
               hasMoreSpaces: result.hasMoreSpaces
@@ -112,8 +112,8 @@ export const useSpacesStore = defineStore('spaces', {
 
       const space = await network.api.loadSpace(spaceId);
 
-      this.networksMap[networkId].spacesMap = {
-        ...this.networksMap[networkId].spacesMap,
+      this.networksMap[networkId].spaces = {
+        ...this.networksMap[networkId].spaces,
         [spaceId]: space
       };
     },

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -44,7 +44,7 @@ onMounted(() => {
       limit="off"
       :loading="!proposalsRecord?.loaded"
       :loading-more="proposalsRecord?.loadingMore"
-      :proposals="proposalsRecord?.proposals || []"
+      :proposals="proposalsStore.getSpaceProposals(props.space.id, props.space.network)"
       @end-reached="handleEndReached"
     />
   </div>


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/sx-ui/issues/435

This PR separates data stored in store into two properties:
- `entitiesIdsList` - array of IDs of entities list on UI (list of spaces, list of proposals)
- `entities` - map of IDs -> Entity that is used when rendering lists of rendering single entity (outside of a list).

This solves few issues:
- Potential race conditions when fetching results and single entity at the same time (eg. proposal might be added twice in the list if we fetch single proposal and proposal list).
- Already fetched single entity might disappear if we fetch list later.

