### PR TITLE
feat: move space list to explore page

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -9,6 +9,7 @@ import Treasury from '@/views/Space/Treasury.vue';
 import Proposal from '@/views/Proposal.vue';
 import User from '@/views/User.vue';
 import Create from '@/views/Create.vue';
+import Explore from '@/views/Explore.vue';
 
 const routes: any[] = [
   { path: '/', name: 'home', component: Home },
@@ -30,7 +31,8 @@ const routes: any[] = [
   },
   { path: '/:space/proposal/:id?', name: 'proposal', component: Proposal },
   { path: '/profile/:id', name: 'user', component: User },
-  { path: '/create', name: 'create', component: Create }
+  { path: '/create', name: 'create', component: Create },
+  { path: '/explore', name: 'explore', component: Explore }
 ];
 
 const router = createRouter({

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -4,7 +4,7 @@ import { enabledNetworks, getNetwork } from '@/networks';
 import type { Space, NetworkID } from '@/types';
 import pkg from '../../package.json';
 
-const SPACES_LIMIT = 10;
+const SPACES_LIMIT = 1000;
 
 type NetworkRecord = {
   spaces: Space[];

--- a/src/views/Explore.vue
+++ b/src/views/Explore.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useSpacesStore } from '@/stores/spaces';
+
+const spacesStore = useSpacesStore();
+
+onMounted(() => spacesStore.fetch());
+</script>
+
+<template>
+  <div>
+    <Container class="max-w-screen-md pt-5">
+      <h2 class="mb-4 mono !text-xl" v-text="'Explore'" />
+      <UiLoading v-if="!spacesStore.loaded" class="block mb-2" />
+      <div v-if="spacesStore.loaded" class="max-w-screen-md">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 mb-3">
+          <router-link
+            v-for="space in spacesStore.spaces"
+            :key="space.id"
+            :to="{ name: 'overview', params: { id: `${space.network}:${space.id}` } }"
+            class="p-4 text-skin-text border rounded-lg block h-[240px] relative"
+          >
+            <Stamp
+              :id="space.id"
+              :size="32"
+              class="border-skin-bg !bg-skin-border rounded-sm mb-2"
+            />
+            <h3 v-text="space.name" />
+            <h5 class="absolute bottom-4">
+              <b class="text-skin-link" v-text="space.proposal_count" /> proposals ·
+              <b class="text-skin-link" v-text="space.vote_count" /> votes
+            </h5>
+            <h5 v-text="space.about" />
+          </router-link>
+        </div>
+      </div>
+    </Container>
+  </div>
+</template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,77 +1,57 @@
-<script setup lang="ts">
-import { ref, onMounted } from 'vue';
-import { useSpacesStore } from '@/stores/spaces';
-
-const spacesStore = useSpacesStore();
-
-const infiniteScrollEnabled = ref(false);
-
-function handleEndReached() {
-  if (!spacesStore.hasMoreSpaces) return;
-
-  spacesStore.fetchMore();
-}
-
-onMounted(() => spacesStore.fetch());
-</script>
-
 <template>
   <div>
     <div class="py-8 mb-6 border-b hero">
       <Container class="max-w-screen-md">
         <div class="eyebrow mb-3" v-text="'Snapshot X'" />
         <h1 class="mb-5 mono">Where decisions<br />get made.</h1>
-        <router-link :to="{ name: 'create' }">
-          <UiButton>Create new space</UiButton>
-        </router-link>
       </Container>
     </div>
-    <Container class="max-w-screen-md">
-      <h3 class="mb-2" v-text="'Spaces'" />
-      <UiLoading v-if="!spacesStore.loaded" class="block mb-2" />
-    </Container>
-    <Container v-if="spacesStore.loaded" class="max-w-screen-md" slim>
-      <div class="x-block mb-3">
-        <BlockInfiniteScroller
-          :enabled="infiniteScrollEnabled"
-          :loading-more="spacesStore.loadingMore"
-          @end-reached="handleEndReached"
-        >
-          <router-link
-            v-for="space in spacesStore.spaces"
-            :key="space.id"
-            :to="{ name: 'overview', params: { id: `${space.network}:${space.id}` } }"
-            class="p-4 text-skin-text border-b last-of-type:border-b-0 block"
-          >
-            <div class="mb-2 flex items-center space-x-2">
-              <Stamp
-                :id="space.id"
-                :size="24"
-                class="inline-block border-skin-bg !bg-skin-bg rounded-sm"
-              />
-              <h4 class="inline-block" v-text="space.name" />
-              <span class="font-mono bg-neutral-600 text-white text-xs rounded px-2">{{
-                space.network
-              }}</span>
-            </div>
-            <div>
-              <b class="text-skin-link" v-text="space.proposal_count" /> proposals ·
-              <b class="text-skin-link" v-text="space.vote_count" /> votes
-            </div>
-          </router-link>
-          <template #loading>
-            <div class="flex justify-center border-t">
-              <UiLoading class="block px-4 py-3" />
-            </div>
-          </template>
-        </BlockInfiniteScroller>
+    <Container class="max-w-screen-md mb-4" slim>
+      <div class="x-block overflow-hidden text-skin-link">
+        <div class="flex">
+          <div class="px-4 bg-[color:var(--border-color)] flex justify-center items-center">
+            <IH-exclamation class="my-1" />
+          </div>
+          <div class="px-4 py-3">
+            The contracts have not yet undergone an audit. Use at your own risk.
+          </div>
+        </div>
       </div>
-      <UiButton
-        v-if="!infiniteScrollEnabled && spacesStore.hasMoreSpaces"
-        class="w-full"
-        @click="infiniteScrollEnabled = true"
-        >Load more</UiButton
-      >
+    </Container>
+    <Container class="max-w-screen-md space-y-4">
+      <div class="space-y-2">
+        <h3>Getting started</h3>
+        <div class="space-x-2">
+          <router-link :to="{ name: 'explore' }">
+            <UiButton>Explore spaces</UiButton>
+          </router-link>
+          <router-link :to="{ name: 'create' }">
+            <UiButton>Create space</UiButton>
+          </router-link>
+        </div>
+      </div>
+      <div class="space-y-2">
+        <h3>Learn more</h3>
+        <div class="space-y-2 flex flex-col sm:block sm:space-x-2 mb-4">
+          <a href="https://docs.snapshotx.xyz" target="_blank">
+            <UiButton>Documentation</UiButton>
+          </a>
+        </div>
+      </div>
+      <div class="space-y-2">
+        <h3>Join the community</h3>
+        <div class="space-x-2">
+          <a href="https://twitter.com/SnapshotLabs" target="_blank">
+            <img src="~@/assets/twitter.svg" class="w-[28px] h-[28px] inline-block" />
+          </a>
+          <a href="https://discord.gg/snapshot" target="_blank">
+            <img src="~@/assets/discord.svg" class="w-[28px] h-[28px] inline-block" />
+          </a>
+          <a href="https://github.com/snapshot-labs" target="_blank">
+            <img src="~@/assets/github.svg" class="w-[28px] h-[28px] inline-block" />
+          </a>
+        </div>
+      </div>
     </Container>
   </div>
 </template>

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -64,7 +64,7 @@ const grouped = computed(() => {
           <Stamp
             :id="space.id"
             :size="90"
-            class="mb-2 border-[4px] border-skin-bg !bg-skin-bg !rounded-lg"
+            class="mb-2 border-[4px] border-skin-bg !bg-skin-border !rounded-lg"
           />
         </router-link>
         <h1 v-text="space.name" />

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -25,7 +25,7 @@ const user = computed(() => {
     <div class="relative bg-skin-border h-[140px] -mb-[70px]" />
     <Container slim>
       <div class="text-center mb-4 relative">
-        <Stamp :id="userId" :size="90" class="mb-2 border-[4px] border-skin-bg !bg-skin-bg" />
+        <Stamp :id="userId" :size="90" class="mb-2 border-[4px] border-skin-bg !bg-skin-border" />
         <h1>{{ shortenAddress(userId) }}</h1>
         <div>
           <b class="text-skin-link">{{ user.proposal_count }}</b> proposals ·


### PR DESCRIPTION
This PR move the list of space to a new page "Explore". This also remove the pagination for spaces to load all of them at once, this avoid the issue of item count being inconsistent cuz we loading data from 2 different sources.

<img width="1468" alt="image" src="https://user-images.githubusercontent.com/16245250/219493699-581ff825-a646-45f9-b0f1-73f1dc450d94.png">
