### PR TITLE
feat: add social urls and treasury address to space profile

### DIFF
--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -15,6 +15,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'errors', value: any);
+  (e: 'pick', field: any);
 }>();
 
 const definition = {
@@ -62,7 +63,7 @@ const definition = {
     },
     walletAddress: {
       type: 'string',
-      minLength: 1,
+      format: 'address',
       title: 'Treasury address',
       examples: ['0x0000…']
     }
@@ -81,6 +82,11 @@ onMounted(() => {
 <template>
   <h3 v-if="showTitle" class="mb-4">Space profile</h3>
   <div class="s-box">
-    <SIObject :model-value="form" :error="formErrors" :definition="definition" />
+    <SIObject
+      :model-value="form"
+      :error="formErrors"
+      :definition="definition"
+      @pick="field => emit('pick', field)"
+    />
   </div>
 </template>

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, watch, onMounted } from 'vue';
 import { validateForm } from '@/helpers/validation';
+import { enabledNetworks } from '@/networks';
 
 const props = withDefaults(
   defineProps<{
@@ -20,7 +21,7 @@ const definition = {
   type: 'object',
   title: 'Space',
   additionalProperties: false,
-  required: ['name', 'wallet'],
+  required: ['name', 'walletNetwork', 'walletAddress'],
   properties: {
     name: {
       type: 'string',
@@ -54,11 +55,16 @@ const definition = {
       title: 'Discord',
       examples: ['Discord handle']
     },
-    wallet: {
+    walletNetwork: {
+      type: 'string',
+      enum: enabledNetworks,
+      title: 'Treasury network'
+    },
+    walletAddress: {
       type: 'string',
       minLength: 1,
       title: 'Treasury address',
-      examples: ['gor:0x0000…']
+      examples: ['0x0000…']
     }
   }
 };

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed, watch, onMounted } from 'vue';
 import { validateForm } from '@/helpers/validation';
 
-const props = defineProps<{
-  form: any;
-}>();
+const props = withDefaults(
+  defineProps<{
+    showTitle?: boolean;
+    form: any;
+  }>(),
+  {
+    showTitle: true
+  }
+);
 
 const emit = defineEmits<{
   (e: 'errors', value: any);
@@ -14,7 +20,7 @@ const definition = {
   type: 'object',
   title: 'Space',
   additionalProperties: false,
-  required: ['name'],
+  required: ['name', 'treasuryAddress'],
   properties: {
     name: {
       type: 'string',
@@ -22,16 +28,37 @@ const definition = {
       minLength: 1,
       examples: ['Space name']
     },
-    about: {
+    description: {
       type: 'string',
       format: 'long',
       title: 'About',
       examples: ['Space description']
     },
-    website: {
+    externalUrl: {
       type: 'string',
       title: 'Website',
-      examples: ['Space website URL']
+      examples: ['Website URL']
+    },
+    githubUrl: {
+      type: 'string',
+      title: 'Github',
+      examples: ['Github URL']
+    },
+    twitterUrl: {
+      type: 'string',
+      title: 'Twitter',
+      examples: ['Twitter URL']
+    },
+    discordUrl: {
+      type: 'string',
+      title: 'Discord',
+      examples: ['Discord URL']
+    },
+    treasuryAddress: {
+      type: 'string',
+      minLength: 1,
+      title: 'Treasury address',
+      examples: ['0x0000…']
     }
   }
 };
@@ -39,11 +66,15 @@ const definition = {
 const formErrors = computed(() => validateForm(definition, props.form));
 
 watch(formErrors, value => emit('errors', value));
+
+onMounted(() => {
+  emit('errors', formErrors.value);
+});
 </script>
 
 <template>
-  <h3>Space profile</h3>
-  <div class="s-box pt-4">
+  <h3 v-if="showTitle" class="mb-4">Space profile</h3>
+  <div class="s-box">
     <SIObject :model-value="form" :error="formErrors" :definition="definition" />
   </div>
 </template>

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -20,7 +20,7 @@ const definition = {
   type: 'object',
   title: 'Space',
   additionalProperties: false,
-  required: ['name', 'treasuryAddress'],
+  required: ['name', 'wallet'],
   properties: {
     name: {
       type: 'string',
@@ -39,26 +39,26 @@ const definition = {
       title: 'Website',
       examples: ['Website URL']
     },
-    githubUrl: {
+    github: {
       type: 'string',
-      title: 'Github',
-      examples: ['Github URL']
+      title: 'GitHub',
+      examples: ['GitHub handle']
     },
-    twitterUrl: {
+    twitter: {
       type: 'string',
       title: 'Twitter',
-      examples: ['Twitter URL']
+      examples: ['Twitter handle']
     },
-    discordUrl: {
+    discord: {
       type: 'string',
       title: 'Discord',
-      examples: ['Discord URL']
+      examples: ['Discord handle']
     },
-    treasuryAddress: {
+    wallet: {
       type: 'string',
       minLength: 1,
       title: 'Treasury address',
-      examples: ['0x0000…']
+      examples: ['gor:0x0000…']
     }
   }
 };

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -8,10 +8,10 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   name: '',
   description: '',
   externalUrl: '',
-  twitterUrl: '',
-  githubUrl: '',
-  discordUrl: '',
-  treasuryAddress: ''
+  twitter: '',
+  github: '',
+  discord: '',
+  wallet: ''
 };
 
 const props = defineProps<{
@@ -42,10 +42,10 @@ onMounted(() => {
   form.name = props.space.name;
   form.description = props.space.about || '';
   form.externalUrl = '';
-  form.githubUrl = '';
-  form.discordUrl = '';
-  form.twitterUrl = '';
-  form.treasuryAddress = '';
+  form.github = '';
+  form.discord = '';
+  form.twitter = '';
+  form.wallet = '';
 });
 </script>
 

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, watch } from 'vue';
 import { useActions } from '@/composables/useActions';
 import { clone } from '@/helpers/utils';
-import type { Space, SpaceMetadata } from '@/types';
+import type { Space, SpaceMetadata, NetworkID } from '@/types';
 
 const DEFAULT_FORM_STATE: SpaceMetadata = {
   name: '',
@@ -53,12 +53,14 @@ watch(
 
     form.name = props.space.name;
     form.description = props.space.about || '';
-    form.externalUrl = '';
-    form.github = '';
-    form.discord = '';
-    form.twitter = '';
-    form.walletNetwork = 'gor';
-    form.walletAddress = '';
+    form.externalUrl = props.space.external_url;
+    form.github = props.space.github;
+    form.discord = props.space.discord;
+    form.twitter = props.space.twitter;
+
+    const [walletNetwork, walletAddress] = props.space.wallet.split(':');
+    form.walletNetwork = walletNetwork as NetworkID;
+    form.walletAddress = walletAddress;
   }
 );
 </script>

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -11,7 +11,8 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   twitter: '',
   github: '',
   discord: '',
-  wallet: ''
+  walletNetwork: 'gor',
+  walletAddress: ''
 };
 
 const props = defineProps<{
@@ -45,7 +46,8 @@ onMounted(() => {
   form.github = '';
   form.discord = '';
   form.twitter = '';
-  form.wallet = '';
+  form.walletNetwork = 'gor';
+  form.walletAddress = '';
 });
 </script>
 

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue';
+import { ref, reactive, watch } from 'vue';
 import { useActions } from '@/composables/useActions';
 import { clone } from '@/helpers/utils';
 import type { Space, SpaceMetadata } from '@/types';
@@ -24,9 +24,16 @@ const emit = defineEmits(['add', 'close']);
 
 const { updateMetadata } = useActions();
 
+const showPicker = ref(false);
+const searchValue = ref('');
 const sending = ref(false);
 const formErrors = ref({} as Record<string, string>);
 const form: SpaceMetadata = reactive(clone(DEFAULT_FORM_STATE));
+
+function handlePickerSelect(value: string) {
+  showPicker.value = false;
+  form.walletAddress = value;
+}
 
 async function handleSubmit() {
   sending.value = true;
@@ -39,27 +46,59 @@ async function handleSubmit() {
   }
 }
 
-onMounted(() => {
-  form.name = props.space.name;
-  form.description = props.space.about || '';
-  form.externalUrl = '';
-  form.github = '';
-  form.discord = '';
-  form.twitter = '';
-  form.walletNetwork = 'gor';
-  form.walletAddress = '';
-});
+watch(
+  () => props.open,
+  () => {
+    showPicker.value = false;
+
+    form.name = props.space.name;
+    form.description = props.space.about || '';
+    form.externalUrl = '';
+    form.github = '';
+    form.discord = '';
+    form.twitter = '';
+    form.walletNetwork = 'gor';
+    form.walletAddress = '';
+  }
+);
 </script>
 
 <template>
   <UiModal :open="open" @close="$emit('close')">
     <template #header>
-      <h3>Edit profile</h3>
+      <h3 v-if="!showPicker">Edit profile</h3>
+      <template v-else>
+        <h3>Select contact</h3>
+        <a class="absolute left-0 -top-1 p-4 text-color" @click="showPicker = false">
+          <IH-arrow-narrow-left class="mr-2" />
+        </a>
+        <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
+          <IH-search class="mx-2" />
+          <input
+            ref="searchInput"
+            v-model="searchValue"
+            type="text"
+            placeholder="Search"
+            class="flex-auto bg-transparent text-skin-link"
+          />
+        </div>
+      </template>
     </template>
-    <div class="p-4">
-      <BlockSpaceFormProfile :show-title="false" :form="form" @errors="v => (formErrors = v)" />
+    <BlockContactPicker
+      v-if="showPicker"
+      :loading="false"
+      :search-value="searchValue"
+      @pick="handlePickerSelect"
+    />
+    <div v-else class="p-4">
+      <BlockSpaceFormProfile
+        :show-title="false"
+        :form="form"
+        @pick="showPicker = true"
+        @errors="v => (formErrors = v)"
+      />
     </div>
-    <template #footer>
+    <template v-if="!showPicker" #footer>
       <UiButton
         class="w-full"
         :loading="sending"

--- a/src/components/S/IObject.vue
+++ b/src/components/S/IObject.vue
@@ -14,6 +14,7 @@ import IText from './IText.vue';
 import IAddress from './IAddress.vue';
 import INumber from './INumber.vue';
 import IBoolean from './IBoolean.vue';
+import ISelect from './ISelect.vue';
 
 const props = defineProps<{
   modelValue: any;
@@ -43,15 +44,16 @@ const inputValue = computed({
   }
 });
 
-const getComponent = (name: string, format: string) => {
-  switch (name) {
+const getComponent = (property: { type: string; format: string; enum?: string[] }) => {
+  switch (property.type) {
     case 'object':
       return IObject;
     case 'array':
       return IArray;
     case 'string':
-      if (format === 'long') return IText;
-      if (format === 'address') return IAddress;
+      if (property.format === 'long') return IText;
+      if (property.format === 'address') return IAddress;
+      if (property.enum) return ISelect;
       return IString;
     case 'number':
       return INumber;
@@ -65,7 +67,7 @@ const getComponent = (name: string, format: string) => {
 
 <template>
   <component
-    :is="getComponent(property.type, property.format)"
+    :is="getComponent(property)"
     v-for="(property, i) in definition.properties"
     :key="i"
     v-bind="$attrs"

--- a/src/components/S/ISelect.vue
+++ b/src/components/S/ISelect.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+export default {
+  inheritAttrs: false
+};
+</script>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+
+const props = defineProps<{
+  modelValue?: string;
+  error?: string;
+  definition: any;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string);
+}>();
+
+const dirty = ref(false);
+
+const inputValue = computed({
+  get() {
+    if (!props.modelValue && !dirty.value && props.definition.default) {
+      return props.definition.default;
+    }
+
+    return props.modelValue;
+  },
+  set(newValue: string) {
+    dirty.value = true;
+
+    emit('update:modelValue', newValue);
+  }
+});
+</script>
+
+<template>
+  <SBase :definition="definition" :error="error" :dirty="dirty">
+    <select v-model="inputValue" class="s-input">
+      <option disabled value="">Please select one</option>
+      <option v-for="option in definition.enum" :key="option" :value="option">
+        {{ option }}
+      </option>
+    </select>
+  </SBase>
+</template>

--- a/src/components/Ui/Modal.vue
+++ b/src/components/Ui/Modal.vue
@@ -102,7 +102,6 @@ watch(open, (val, prev) => {
     }
 
     .modal-body {
-      max-height: 420px;
       flex: auto;
       text-align: initial;
       overflow-y: auto;

--- a/src/components/Ui/Modal.vue
+++ b/src/components/Ui/Modal.vue
@@ -102,6 +102,7 @@ watch(open, (val, prev) => {
     }
 
     .modal-body {
+      max-height: 420px;
       flex: auto;
       text-align: initial;
       overflow-y: auto;

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -3,6 +3,7 @@ import { getNetwork } from '@/networks';
 import { useUiStore } from '@/stores/ui';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useModal } from '@/composables/useModal';
+import { createErc1155Metadata } from '@/helpers/utils';
 import type {
   Transaction,
   Proposal,
@@ -59,7 +60,7 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const pinned = await network.helpers.pin(metadata);
+    const pinned = await network.helpers.pin(createErc1155Metadata(metadata));
 
     const receipt = await network.actions.createSpace(auth.web3, {
       controller: web3.value.account,
@@ -92,7 +93,7 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const pinned = await network.helpers.pin(metadata);
+    const pinned = await network.helpers.pin(createErc1155Metadata(metadata));
 
     const receipt = await network.actions.setMetadataUri(
       auth.web3,

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -12,7 +12,8 @@ describe('utils', () => {
         github: 'snapshot-labs',
         twitter: 'SnapshotLabs',
         discord: 'snapshot',
-        wallet: 'gor:0x000000000000000000000000000000000000dead'
+        walletNetwork: 'gor',
+        walletAddress: '0x000000000000000000000000000000000000dead'
       });
 
       expect(metadata).toEqual({

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { createErc1155Metadata } from '../utils';
+
+describe('utils', () => {
+  describe('createErc1155Metadata', () => {
+    it('should create metadata', () => {
+      const metadata = createErc1155Metadata({
+        name: 'Test',
+        description: 'Test description',
+        externalUrl: 'https://test.com',
+        githubUrl: 'https://github.com',
+        twitterUrl: 'https://twitter.com',
+        discordUrl: 'https://discord.com',
+        treasuryAddress: '0x000000000000000000000000000000000000dead'
+      });
+
+      expect(metadata).toEqual({
+        name: 'Test',
+        description: 'Test description',
+        external_url: 'https://test.com',
+        properties: {
+          github_url: 'https://github.com',
+          twitter_url: 'https://twitter.com',
+          discord_url: 'https://discord.com',
+          treasury_address: '0x000000000000000000000000000000000000dead'
+        }
+      });
+    });
+  });
+});

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -9,10 +9,10 @@ describe('utils', () => {
         name: 'Test',
         description: 'Test description',
         externalUrl: 'https://test.com',
-        githubUrl: 'https://github.com',
-        twitterUrl: 'https://twitter.com',
-        discordUrl: 'https://discord.com',
-        treasuryAddress: '0x000000000000000000000000000000000000dead'
+        github: 'snapshot-labs',
+        twitter: 'SnapshotLabs',
+        discord: 'snapshot',
+        wallet: 'gor:0x000000000000000000000000000000000000dead'
       });
 
       expect(metadata).toEqual({
@@ -20,10 +20,10 @@ describe('utils', () => {
         description: 'Test description',
         external_url: 'https://test.com',
         properties: {
-          github_url: 'https://github.com',
-          twitter_url: 'https://twitter.com',
-          discord_url: 'https://discord.com',
-          treasury_address: '0x000000000000000000000000000000000000dead'
+          github: 'snapshot-labs',
+          twitter: 'SnapshotLabs',
+          discord: 'snapshot',
+          wallets: ['gor:0x000000000000000000000000000000000000dead']
         }
       });
     });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -180,10 +180,10 @@ export function createErc1155Metadata(metadata: SpaceMetadata) {
     description: metadata.description,
     external_url: metadata.externalUrl,
     properties: {
-      twitter_url: metadata.twitterUrl,
-      github_url: metadata.githubUrl,
-      discord_url: metadata.discordUrl,
-      treasury_address: metadata.treasuryAddress
+      github: metadata.github,
+      twitter: metadata.twitter,
+      discord: metadata.discord,
+      wallets: [metadata.wallet]
     }
   };
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -183,7 +183,7 @@ export function createErc1155Metadata(metadata: SpaceMetadata) {
       github: metadata.github,
       twitter: metadata.twitter,
       discord: metadata.discord,
-      wallets: [metadata.wallet]
+      wallets: [`${metadata.walletNetwork}:${metadata.walletAddress}`]
     }
   };
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -6,6 +6,7 @@ import networks from '@snapshot-labs/snapshot.js/src/networks.json';
 import { getUrl as snapshotGetUrl } from '@snapshot-labs/snapshot.js/src/utils';
 import pkg from '@/../package.json';
 import type { Web3Provider } from '@ethersproject/providers';
+import type { SpaceMetadata } from '@/types';
 
 const IPFS_GATEWAY: string = import.meta.env.VITE_IPFS_GATEWAY || 'https://cloudflare-ipfs.com';
 
@@ -164,4 +165,25 @@ export async function verifyNetwork(web3Provider: Web3Provider, chainId: number)
     method: 'wallet_switchEthereumChain',
     params: [{ chainId: `0x${chainId.toString(16)}` }]
   });
+}
+
+/**
+ * This function creates ERC1155 metadata object for space. external_url is stored
+ * at top level same as OpenSea, other extra properties are stored in the
+ * properties object per ERC1155 spec.
+ * @param metadata space metadata
+ * @returns ERC1155 metadata object
+ */
+export function createErc1155Metadata(metadata: SpaceMetadata) {
+  return {
+    name: metadata.name,
+    description: metadata.description,
+    external_url: metadata.externalUrl,
+    properties: {
+      twitter_url: metadata.twitterUrl,
+      github_url: metadata.githubUrl,
+      discord_url: metadata.discordUrl,
+      treasury_address: metadata.treasuryAddress
+    }
+  };
 }

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,4 +1,5 @@
 import Ajv from 'ajv';
+import { validateAndParseAddress } from 'starknet';
 import { isAddress } from '@ethersproject/address';
 import { parseUnits } from '@ethersproject/units';
 import { Zero, MinInt256, MaxInt256, MaxUint256 } from '@ethersproject/constants';
@@ -8,7 +9,13 @@ export function validateForm(schema, form): Record<string, string> {
   const ajv = new Ajv({ allErrors: true });
 
   ajv.addFormat('address', {
-    validate: isAddress
+    validate: (value: string) => {
+      try {
+        return !!validateAndParseAddress(value);
+      } catch (err) {
+        return isAddress(value);
+      }
+    }
   });
 
   ajv.addFormat('long', {

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -174,6 +174,11 @@ export const SPACE_QUERY = gql`
       id
       name
       about
+      external_url
+      github
+      twitter
+      discord
+      wallet
       controller
       voting_delay
       min_voting_period
@@ -196,6 +201,11 @@ export const SPACES_QUERY = gql`
       id
       name
       about
+      external_url
+      github
+      twitter
+      discord
+      wallet
       controller
       voting_delay
       min_voting_period

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,8 @@ export type SpaceMetadata = {
   twitter: string;
   github: string;
   discord: string;
-  wallet: string;
+  walletNetwork: NetworkID;
+  walletAddress: string;
 };
 
 export type SpaceSettings = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,10 +5,10 @@ export type SpaceMetadata = {
   name: string;
   description: string;
   externalUrl: string;
-  twitterUrl: string;
-  githubUrl: string;
-  discordUrl: string;
-  treasuryAddress: string;
+  twitter: string;
+  github: string;
+  discord: string;
+  wallet: string;
 };
 
 export type SpaceSettings = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,11 @@ export type Space = {
   network: NetworkID;
   name: string;
   about?: string;
+  external_url: string;
+  twitter: string;
+  github: string;
+  discord: string;
+  wallet: string;
   controller: string;
   voting_delay: number;
   min_voting_period: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,14 @@
 export type NetworkID = 'gor' | 'sn-tn2';
 export type Choice = 1 | 2 | 3;
 
-// TODO: would be nice for API to use the same format
 export type SpaceMetadata = {
   name: string;
   description: string;
-  external_url: string;
+  externalUrl: string;
+  twitterUrl: string;
+  githubUrl: string;
+  discordUrl: string;
+  treasuryAddress: string;
 };
 
 export type SpaceSettings = {

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -62,10 +62,10 @@ const metadataForm: SpaceMetadata = reactive(
     name: '',
     description: '',
     externalUrl: '',
-    twitterUrl: '',
-    githubUrl: '',
-    discordUrl: '',
-    treasuryAddress: ''
+    twitter: '',
+    github: '',
+    discord: '',
+    wallet: ''
   })
 );
 const selectedNetworkId: Ref<NetworkID> = ref('sn-tn2');

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -46,6 +46,8 @@ const { createSpace } = useActions();
 const { web3 } = useWeb3();
 
 const pagesRefs = ref([] as HTMLElement[]);
+const showPicker = ref(false);
+const searchValue = ref('');
 const sending = ref(false);
 const currentPage: Ref<PageID> = ref('profile');
 const pagesErrors: Ref<Record<PageID, Record<string, string>>> = ref({
@@ -118,6 +120,11 @@ function handleNextClick() {
   pagesRefs.value[currentIndex + 1].scrollIntoView();
 }
 
+function handlePickerSelect(value: string) {
+  showPicker.value = false;
+  metadataForm.walletAddress = value;
+}
+
 async function handleSubmit() {
   sending.value = true;
 
@@ -179,6 +186,7 @@ watch(selectedNetworkId, () => {
           <BlockSpaceFormProfile
             v-if="currentPage === 'profile'"
             :form="metadataForm"
+            @pick="showPicker = true"
             @errors="v => handleErrors('profile', v)"
           />
           <BlockSpaceFormNetwork
@@ -232,5 +240,30 @@ watch(selectedNetworkId, () => {
         </UiButton>
       </div>
     </div>
+    <teleport to="#modal">
+      <UiModal :open="showPicker" @close="showPicker = false">
+        <template #header>
+          <h3>Select contact</h3>
+          <a class="absolute left-0 -top-1 p-4 text-color" @click="showPicker = false">
+            <IH-arrow-narrow-left class="mr-2" />
+          </a>
+          <div class="flex items-center border-t px-2 py-3 mt-3 -mb-3">
+            <IH-search class="mx-2" />
+            <input
+              ref="searchInput"
+              v-model="searchValue"
+              type="text"
+              placeholder="Search"
+              class="flex-auto bg-transparent text-skin-link"
+            />
+          </div>
+        </template>
+        <BlockContactPicker
+          :loading="false"
+          :search-value="searchValue"
+          @pick="handlePickerSelect"
+        />
+      </UiModal>
+    </teleport>
   </div>
 </template>

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -65,7 +65,8 @@ const metadataForm: SpaceMetadata = reactive(
     twitter: '',
     github: '',
     discord: '',
-    wallet: ''
+    walletNetwork: 'gor',
+    walletAddress: ''
   })
 );
 const selectedNetworkId: Ref<NetworkID> = ref('sn-tn2');

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -6,7 +6,7 @@ import { useWeb3 } from '@/composables/useWeb3';
 import { clone } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import type { StrategyConfig } from '@/networks/types';
-import type { NetworkID, SpaceSettings } from '@/types';
+import type { NetworkID, SpaceMetadata, SpaceSettings } from '@/types';
 
 const PAGES = [
   {
@@ -40,7 +40,6 @@ const PAGES = [
 ] as const;
 
 type PageID = typeof PAGES[number]['id'];
-type MetadataState = { name: string; about?: string; website?: string };
 
 const router = useRouter();
 const { createSpace } = useActions();
@@ -58,11 +57,15 @@ const pagesErrors: Ref<Record<PageID, Record<string, string>>> = ref({
   voting: {},
   controller: {}
 });
-const metadataForm: MetadataState = reactive(
+const metadataForm: SpaceMetadata = reactive(
   clone({
     name: '',
-    about: '',
-    website: ''
+    description: '',
+    externalUrl: '',
+    twitterUrl: '',
+    githubUrl: '',
+    discordUrl: '',
+    treasuryAddress: ''
   })
 );
 const selectedNetworkId: Ref<NetworkID> = ref('sn-tn2');
@@ -120,11 +123,7 @@ async function handleSubmit() {
   try {
     const result = await createSpace(
       selectedNetworkId.value,
-      {
-        name: metadataForm.name,
-        description: metadataForm.about || '',
-        external_url: metadataForm.website || ''
-      },
+      metadataForm,
       settingsForm,
       authenticators.value,
       votingStrategies.value,

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -78,9 +78,19 @@ const grouped = computed(() => {
           </span>
         </div>
         <div class="space-x-2">
-          <img src="~@/assets/twitter.svg" class="w-[28px] h-[28px] inline-block" />
-          <img src="~@/assets/discord.svg" class="w-[28px] h-[28px] inline-block" />
-          <img src="~@/assets/github.svg" class="w-[28px] h-[28px] inline-block" />
+          <a v-if="space.twitter" :href="`https://twitter.com/${space.twitter}`" target="_blank">
+            <img src="~@/assets/twitter.svg" class="w-[28px] h-[28px] inline-block" />
+          </a>
+          <a
+            v-if="space.discord"
+            :href="`https://discord.com/invite/${space.discord}`"
+            target="_blank"
+          >
+            <img src="~@/assets/discord.svg" class="w-[28px] h-[28px] inline-block" />
+          </a>
+          <a v-if="space.github" :href="`https://github.com/${space.github}`" target="_blank">
+            <img src="~@/assets/github.svg" class="w-[28px] h-[28px] inline-block" />
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/409
Closes: https://github.com/snapshot-labs/sx-ui/issues/413

This PR adds social urls and treasury address to space profile editor.

**Currently treasury address in execution/treasury page is still hardcoded as we don't support Starknet there. Can be solved in other PR.**

## Test plan

- Use local deployment from https://github.com/snapshot-labs/sx-api/pull/173 or wait for it to be merged.
- Create space/edit space.
- Overview shows correct profile icons.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/220890238-26f586f1-9098-46ff-b82b-70784deee95f.png" width="500" />
<img src="https://user-images.githubusercontent.com/1968722/220890260-d8abd083-1c96-4c96-bb2f-dbf59333fb9b.png" width="500" />
