### PR TITLE
feat: display voting scores

### DIFF
--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { ref, computed } from 'vue';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
@@ -18,13 +18,50 @@ const labels = {
   2: 'Abstain'
 };
 
+const showAlternatives = ref(false);
+
 const progress = computed(() =>
   Math.min(props.proposal.scores_total / props.proposal.space.quorum, 1)
+);
+
+const adjustedScores = computed(() =>
+  [props.proposal.scores_1, props.proposal.scores_2, props.proposal.scores_3].map(score => {
+    // TODO: sx-api returns number, sx-subgraph returns string
+    const parsedTotal = parseFloat(props.proposal.scores_total as unknown as string);
+
+    return parsedTotal !== 0 ? (score / parsedTotal) * 100 * progress.value : 0;
+  })
+);
+
+const results = computed(() =>
+  adjustedScores.value
+    .map((score, i) => ({
+      choice: i + 1,
+      score: props.proposal[`scores_${i + 1}`],
+      progress: score
+    }))
+    .sort((a, b) => b.progress - a.progress)
+);
+const visibleResults = computed(() =>
+  showAlternatives.value ? results.value : results.value.slice(0, 1)
 );
 </script>
 
 <template>
-  <div class="flex items-center h-full">
+  <div class="h-full">
+    <div
+      v-if="width === 'full'"
+      class="inline-block text-skin-link mb-2 cursor-pointer hover:opacity-80"
+      @click="showAlternatives = !showAlternatives"
+    >
+      <div v-for="result in visibleResults" :key="result.choice" class="inline-block mr-4">
+        <span class="choice-text" :class="`_${result.choice}`">
+          {{ result.progress.toFixed(0) }}%
+        </span>
+        <IH-lightning-bolt class="inline-block ml-1" />
+        {{ result.score }}
+      </div>
+    </div>
     <div
       class="rounded-full h-[6px] overflow-hidden"
       :style="{
@@ -32,18 +69,14 @@ const progress = computed(() =>
       }"
     >
       <div
-        v-for="(score, i) in Array(3)"
-        :key="i"
-        :title="labels[i]"
+        v-for="result in results"
+        :key="result.choice"
+        :title="labels[result.choice - 1]"
         class="choice-bg float-left h-full"
         :style="{
-          width: `${(
-            (100 / proposal.scores_total) *
-            proposal[`scores_${i + 1}`] *
-            progress
-          ).toFixed(3)}%`
+          width: `${result.progress.toFixed(3)}%`
         }"
-        :class="`_${i + 1}`"
+        :class="`_${result.choice}`"
       />
       <div
         title="Quorum left"

--- a/src/style.scss
+++ b/src/style.scss
@@ -129,6 +129,21 @@ a,
   }
 }
 
+.choice-text {
+  &._1 {
+    @apply text-green;
+  }
+  &._2 {
+    @apply text-red;
+  }
+  &._3 {
+    @apply text-gray-500;
+  }
+  &._quorum {
+    @apply text-skin-border;
+  }
+}
+
 #app {
   height: 100%;
 }


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/434

Display voting scores in UI.

Changes:
- Sort results bar based on most votes (if there are more votes against, red bar will be first, otherwise showing green bar and red text is super weird).
- You can click (instead of hover, to make mobile UX better) to get all results displayed.

## Test plan

http://localhost:8080/#/sn-tn2:0x07e6e9047eb910f84f7e3b86cea7b1d7779c109c970a39b54379c1f4fa395b28/proposal/56

## Screen shots

<img src="https://user-images.githubusercontent.com/1968722/221940264-6b30bc20-1a83-4438-80d8-5873948ac21c.png" width="500" />
<img src="https://user-images.githubusercontent.com/1968722/221940310-70520c73-2ba6-4ceb-ab0f-df40c10db82c.png" width="500" />