### PR TITLE
fix(evm): use regular client for ethTx/vanilla authenticator

### DIFF
--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -28,7 +28,7 @@ export function useActions() {
     console.log('envelope', envelope);
 
     // TODO: unify send/soc to both return txHash under same property
-    if (network.hasRelayer) {
+    if (envelope.signatureData || envelope.sig) {
       const receipt = await network.actions.send(envelope);
 
       console.log('Receipt', receipt);

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -19,6 +19,10 @@ export const SUPPORTED_EXECUTORS = {
   '0x6241b5c89350bb3c465179706cf26050ea32444f': true
 };
 
+export const RELAYER_AUTHENTICATORS = {
+  '0x277f388b77cd36fff1c0e976c49a7c54413a449a': true
+};
+
 export const AUTHS = {
   '0xdd66652e93293c32aa3288509d9a46c785e3f786': 'Vanilla',
   '0x277f388b77cd36fff1c0e976c49a7c54413a449a': 'Ethereum signature',

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -14,7 +14,6 @@ export function createEvmNetwork(networkId: NetworkID): Network {
 
   return {
     name: 'Ethereum (goerli)',
-    hasRelayer: true,
     hasReceive: false,
     managerConnectors: ['injected', 'walletconnect', 'walletlink', 'portis', 'gnosis'],
     actions: createActions(chainId),

--- a/src/networks/starknet/index.ts
+++ b/src/networks/starknet/index.ts
@@ -14,7 +14,6 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
 
   return {
     name: 'Starknet (testnet2)',
-    hasRelayer: true,
     hasReceive: true,
     managerConnectors: ['argentx'],
     actions: createActions(provider, { l1ChainId }),

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -85,7 +85,6 @@ export type NetworkApi = {
 
 export type Network = {
   name: string;
-  hasRelayer: boolean;
   hasReceive: boolean;
   managerConnectors: Connector[];
   actions: NetworkActions;


### PR DESCRIPTION
## Summary

Forgot that routing all votes/proposals through mana would mean that those that use ethTx or vanilla authenticator would make Mana's account proposer/voter in all of them, this also made it impossible for multiple people to vote for proposal, because all other person would seemingly already voted.

## Test plan

- Propose here: http://localhost:8080/#/gor:0xb3782e21cedaf9183da9c472f810cc2fd337c6a2
- Signature request shows up
- Propose here: http://localhost:8080/#/gor:0xd381e6be943e254ab992cbc8698fc95b215109ea
- Transaction request shows up