### PR TITLE
fix(evm): only convert Date.now() timestamp for VP calculation

### DIFF
--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -220,7 +220,7 @@ export function createActions(chainId: number): NetworkActions {
           return strategy.getVotingPower(
             address,
             voterAddress,
-            Math.floor(timestamp / 1000), // TODO: unify
+            timestamp,
             strategiesParams[i],
             web3
           );

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -42,7 +42,7 @@ async function getVotingPower() {
       props.space.strategies,
       props.space.strategies_params,
       web3.value.account,
-      Date.now()
+      Math.floor(Date.now() / 1000)
     );
   } catch (err) {
     console.warn('err', err);


### PR DESCRIPTION
## Summary

We should only convert `Date.now()`, `snapshot` timestamp is already in proper format.

## Test plan

- Go to proposal before you had delegated funds in space with CompToken strategy, you have 0 VP.
- Go to proposal after you had funds delegated, you have more VP.

## Screenshots


https://user-images.githubusercontent.com/1968722/222683649-b6cb99b4-9f92-4cd4-b8b1-71308f095218.mp4

