### PR TITLE
fix: do not add ago to now time

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -16,8 +16,14 @@ dayjs.extend(duration);
 
 dayjs.updateLocale('en', {
   relativeTime: {
-    future: '%s ago',
-    past: '%s left',
+    future: value => {
+      if (value === 'now') return 'in few seconds';
+      return `${value} left`;
+    },
+    past: value => {
+      if (value === 'now') return 'just now';
+      return `${value} ago`;
+    },
     s: 'now',
     m: '1m',
     mm: '%dm',
@@ -106,7 +112,7 @@ export function _t(number) {
 
 export function _rt(number) {
   try {
-    return dayjs(number * 1e3).toNow(false);
+    return dayjs(number * 1e3).fromNow(false);
   } catch (e) {
     console.log(e);
     return '';


### PR DESCRIPTION
## Summary

Changes:
- use `fromNow` instead of `toNow` to make it more natural (right now `future` uses `ago` and `past` uses `left`).
- add custom cases for now: for future use `in few seconds`, for past `just now`.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/222688773-565d242a-54fb-446d-b1d7-a270e358e05b.png" width="600" />