### PR TITLE
chore: remove snapshot-oc package from config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
     })
   ],
   optimizeDeps: {
-    include: ['@snapshot-labs/sx', '@snapshot-labs/snapshot-oc'],
+    include: ['@snapshot-labs/sx'],
     esbuildOptions: {
       target,
       plugins: [
@@ -57,7 +57,7 @@ export default defineConfig({
   build: {
     target,
     commonjsOptions: {
-      include: [/sx.js/, /soc.js/, /node_modules/],
+      include: [/sx.js/, /node_modules/],
       transformMixedEsModules: true
     },
     rollupOptions: {


### PR DESCRIPTION
We no longer use this package (it was merged into sx.js)