### PR TITLE
feat(evm): remove vanilla authenticator support

### DIFF
--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -4,7 +4,6 @@ import type { Signer } from '@ethersproject/abstract-signer';
 export const API_URL = 'https://api.thegraph.com/subgraphs/name/snapshot-labs/sx-goerli';
 
 export const SUPPORTED_AUTHENTICATORS = {
-  '0xdd66652e93293c32aa3288509d9a46c785e3f786': true,
   '0xcc3fb327de5428d182ba2e739aea5978c0e2ce35': true,
   '0x277f388b77cd36fff1c0e976c49a7c54413a449a': true
 };
@@ -36,11 +35,6 @@ export const EXECUTORS = {
 };
 
 export const EDITOR_AUTHENTICATORS = [
-  {
-    address: '0xdd66652e93293c32aa3288509d9a46c785e3f786',
-    name: 'Vanilla',
-    paramsDefinition: null
-  },
   {
     address: '0xcc3fb327de5428d182ba2e739aea5978c0e2ce35',
     name: 'Ethereum transaction',


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/sx-ui/issues/453

This PR disabled vanilla authenticator from supported list (no longer possible to vote and propose with it) and editor (no longer possible to create space with it). Still left it in UI, so in old spaces it will show up as Vanilla.