### PR TITLE
fix: display Results centered

### DIFF
--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -5,9 +5,11 @@ import { Proposal as ProposalType } from '@/types';
 const props = withDefaults(
   defineProps<{
     proposal: ProposalType;
-    width?: number | 'full';
+    withDetails: boolean;
+    width?: number;
   }>(),
   {
+    withDetails: false,
     width: 100
   }
 );
@@ -46,9 +48,14 @@ const visibleResults = computed(() =>
 </script>
 
 <template>
-  <div class="h-full">
+  <div
+    class="h-full"
+    :class="{
+      'flex items-center': !withDetails
+    }"
+  >
     <div
-      v-if="width === 'full'"
+      v-if="withDetails"
       class="inline-block text-skin-link mb-2 cursor-pointer hover:opacity-80"
       @click="showAlternatives = !showAlternatives"
     >
@@ -63,7 +70,7 @@ const visibleResults = computed(() =>
     <div
       class="rounded-full h-[6px] overflow-hidden"
       :style="{
-        width: width === 'full' ? '100%' : `${width}px`
+        width: withDetails ? '100%' : `${width}px`
       }"
     >
       <div

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -111,13 +111,13 @@ export const PROPOSALS_SUMMARY_QUERY = gql`
     proposal_id
     space {
       id
-      quorum
       authenticators
       executors
     }
     author {
       id
     }
+    quorum
     execution_hash
     metadata_uri
     title

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -172,7 +172,7 @@ watch([() => web3.value.account, proposal], () => getVotingPower());
                 <IH-chart-bar class="inline-block mr-2" />
                 <span>Results</span>
               </h4>
-              <Results :proposal="proposal" width="full" />
+              <Results :proposal="proposal" with-details />
               <div class="mt-2">
                 <div v-if="userVote.choice === 1">
                   You already voted <strong>for</strong> this proposal
@@ -190,7 +190,7 @@ watch([() => web3.value.account, proposal], () => getVotingPower());
                 <IH-chart-bar class="inline-block mr-2" />
                 <span>Results</span>
               </h4>
-              <Results :proposal="proposal" width="full" />
+              <Results :proposal="proposal" with-details />
             </template>
             <div class="grid grid-cols-3 gap-2">
               <UiButton


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/473
Closes: https://github.com/snapshot-labs/sx-ui/issues/487

Display Results centered when displaying just the bar.
Changes:
- fetch quorum in proposal summary (bar was not displaying on Overview page).
- add `withDetails` prop to make `width` prop simpler
- center bar if `!withDetails`.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/223212292-3d227694-1b53-46ff-a884-77a5d3a5646b.png" width="600" />
<img src="https://user-images.githubusercontent.com/1968722/223212310-8c1a034a-c2a3-4e3b-abc1-19bad7f15c86.png" width="600" />

## Test plan

- Go to overview/proposals page, results bar is centered vertically there.
- Go to proposal page, results bar displays as it used to.