### PR TITLE
fix: hide confirm button when picking contact in ModalTransaction

### DIFF
--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -252,7 +252,7 @@ watch(
         />
       </div>
     </div>
-    <template #footer>
+    <template v-if="!showPicker" #footer>
       <UiButton class="w-full" @click="handleSubmit">Confirm</UiButton>
     </template>
   </UiModal>


### PR DESCRIPTION
## Summary

Closes https://github.com/snapshot-labs/sx-ui/issues/451

## Test plan

- Go to create proposal page, click Contract call
- Click contact picker icon
- Confirm button is not displayed while contact picker is active.