### PR TITLE
feat: use real treasury

### DIFF
--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
 import { ref, computed, Ref } from 'vue';
 import draggable from 'vuedraggable';
-import spaceData from '@/helpers/space.json';
-import { Transaction as TransactionType } from '@/types';
+import { useTreasury } from '@/composables/useTreasury';
+import { Transaction as TransactionType, Space } from '@/types';
 
-const props = defineProps<{ modelValue: TransactionType[] }>();
+const props = defineProps<{
+  modelValue: TransactionType[];
+  space?: Space;
+}>();
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: TransactionType[]): void;
 }>();
+
+const { treasury } = useTreasury(props.space);
 
 const editedTx: Ref<number | null> = ref(null);
 const modalState: Ref<{
@@ -68,27 +73,18 @@ function editTx(index: number) {
       <div
         class="mb-3 flex flex-no-wrap overflow-x-scroll no-scrollbar scrolling-touch items-start space-x-3"
       >
-        <a
-          class="px-4 py-3 border-b border rounded-lg block min-w-[165px]"
-          @click="openModal('sendToken')"
-        >
+        <ExecutionButton :disabled="!treasury" @click="openModal('sendToken')">
           <IH-stop />
           Send token
-        </a>
-        <a
-          class="px-4 py-3 border-b border rounded-lg block min-w-[165px]"
-          @click="openModal('sendNft')"
-        >
+        </ExecutionButton>
+        <ExecutionButton :disabled="!treasury" @click="openModal('sendNft')">
           <IH-photograph />
           Send NFT
-        </a>
-        <a
-          class="px-4 py-3 border-b border rounded-lg block min-w-[165px]"
-          @click="openModal('contractCall')"
-        >
+        </ExecutionButton>
+        <ExecutionButton @click="openModal('contractCall')">
           <IH-chip />
           Contract call
-        </a>
+        </ExecutionButton>
       </div>
     </div>
     <div v-if="txs.length > 0" class="x-block !border-x rounded-lg">
@@ -119,16 +115,18 @@ function editTx(index: number) {
     </div>
     <teleport to="#modal">
       <ModalSendToken
+        v-if="treasury"
         :open="modalOpen.sendToken"
-        :address="spaceData.wallet"
-        :network="spaceData.network"
+        :address="treasury.wallet"
+        :network="treasury.network"
         :initial-state="modalState.sendToken"
         @close="modalOpen.sendToken = false"
         @add="addTx"
       />
       <ModalSendNft
+        v-if="treasury"
         :open="modalOpen.sendNft"
-        :address="spaceData.wallet"
+        :address="treasury.wallet"
         :initial-state="modalState.sendNft"
         @close="modalOpen.sendNft = false"
         @add="addTx"

--- a/src/components/Block/TokenPicker.vue
+++ b/src/components/Block/TokenPicker.vue
@@ -6,7 +6,6 @@ import snapshot from '@snapshot-labs/snapshot.js';
 import { abis } from '@/helpers/abis';
 import { ETH_CONTRACT } from '@/helpers/constants';
 import { _n, shorten } from '@/helpers/utils';
-import spaceData from '@/helpers/space.json';
 import type { Token } from '@/helpers/alchemy';
 
 const { Multicaller, getProvider } = snapshot.utils;
@@ -15,6 +14,8 @@ const props = defineProps<{
   searchValue: string;
   loading: boolean;
   assets: Token[];
+  address: string;
+  network: number;
 }>();
 
 const emit = defineEmits<{
@@ -59,7 +60,7 @@ async function fetchCustomToken(address) {
 
   customTokenLoading.value = true;
 
-  const network = spaceData.network;
+  const network = props.network;
   const provider = getProvider(network);
   const tokens = [address];
 
@@ -69,7 +70,7 @@ async function fetchCustomToken(address) {
       multi.call(`${token}.name`, token, 'name');
       multi.call(`${token}.symbol`, token, 'symbol');
       multi.call(`${token}.decimals`, token, 'decimals');
-      multi.call(`${token}.balance`, token, 'balanceOf', [spaceData.wallet]);
+      multi.call(`${token}.balance`, token, 'balanceOf', [props.address]);
     });
 
     const result = await multi.execute();

--- a/src/components/ExecutionButton.vue
+++ b/src/components/ExecutionButton.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    disabled?: boolean;
+  }>(),
+  {
+    disabled: false
+  }
+);
+
+const emit = defineEmits<{
+  disabled?: boolean;
+  (e: 'click');
+}>();
+</script>
+
+<template>
+  <button
+    :disabled="disabled"
+    class="button px-4 py-3 border-b border rounded-lg block min-w-[165px] text-start text-skin-link"
+    :class="{}"
+    @click="emit('click')"
+  >
+    <slot />
+  </button>
+</template>
+
+<style scoped lang="scss">
+.button {
+  &:disabled {
+    color: var(--border-color) !important;
+    cursor: not-allowed;
+  }
+}
+</style>

--- a/src/components/Modal/SendToken.vue
+++ b/src/components/Modal/SendToken.vue
@@ -174,6 +174,8 @@ watch(currentToken, token => {
       <BlockTokenPicker
         v-if="pickerType === 'token'"
         :assets="allAssets"
+        :address="address"
+        :network="network"
         :loading="loading"
         :search-value="searchValue"
         @pick="

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -2,6 +2,8 @@
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useUiStore } from '@/stores/ui';
+import { useSpacesStore } from '@/stores/spaces';
+import { useTreasury } from '@/composables/useTreasury';
 
 // TODO: need to import all icons https://github.com/antfu/unplugin-icons/issues/5
 // move to this when stable to avoid imports https://www.npmjs.com/package/@iconify/tailwind
@@ -13,8 +15,15 @@ import IHUsers from '~icons/heroicons-outline/users';
 
 const route = useRoute();
 const uiStore = useUiStore();
+const spacesStore = useSpacesStore();
 
-const NAVIGATION_CONFIG = {
+const currentRouteName = computed(() => String(route.matched[0]?.name));
+const space = computed(() =>
+  currentRouteName.value === 'space' ? spacesStore.spacesMap.get(route.params.id as string) : null
+);
+const { treasury } = useTreasury(space);
+
+const navigationConfig = computed(() => ({
   space: {
     overview: {
       name: 'Overview',
@@ -24,10 +33,14 @@ const NAVIGATION_CONFIG = {
       name: 'Proposals',
       icon: IHNewspaper
     },
-    treasury: {
-      name: 'Treasury',
-      icon: IHCash
-    },
+    ...(treasury.value
+      ? {
+          treasury: {
+            name: 'Treasury',
+            icon: IHCash
+          }
+        }
+      : undefined),
     settings: {
       name: 'Settings',
       icon: IHCog
@@ -39,9 +52,8 @@ const NAVIGATION_CONFIG = {
       icon: IHUsers
     }
   }
-};
-const currentRouteName = computed(() => String(route.matched[0]?.name));
-const navigationItems = computed(() => NAVIGATION_CONFIG[currentRouteName.value || '']);
+}));
+const navigationItems = computed(() => navigationConfig.value[currentRouteName.value || '']);
 </script>
 
 <template>
@@ -58,7 +70,7 @@ const navigationItems = computed(() => NAVIGATION_CONFIG[currentRouteName.value 
         v-for="(item, key) in navigationItems"
         :key="key"
         :to="{ name: `${currentRouteName}-${key}` }"
-        class="px-4 py-[7px] block space-x-2 text-skin-text flex items-center"
+        class="px-4 py-[7px] space-x-2 text-skin-text flex items-center"
         :class="route.name === `${currentRouteName}-${key}` && 'text-skin-link'"
       >
         <component :is="item.icon" class="inline-block"></component>

--- a/src/composables/useTreasury.ts
+++ b/src/composables/useTreasury.ts
@@ -1,0 +1,24 @@
+import { computed, Ref, ComputedRef } from 'vue';
+import { Space } from '@/types';
+
+type NullableSpace = Space | undefined | null;
+
+export function useTreasury(spaceRef?: Space | Ref<NullableSpace> | ComputedRef<NullableSpace>) {
+  const treasury = computed(() => {
+    if (!spaceRef) return;
+
+    const space = 'value' in spaceRef ? spaceRef.value : spaceRef;
+    if (!space || !space.wallet) return null;
+
+    const [networkId, wallet] = space.wallet.split(':');
+
+    if (networkId !== 'gor' || !wallet) return null;
+
+    return {
+      network: 5,
+      wallet
+    };
+  });
+
+  return { treasury };
+}

--- a/src/helpers/space.json
+++ b/src/helpers/space.json
@@ -1,4 +1,0 @@
-{
-  "network": 5,
-  "wallet": "0x11455A53117B5142A8Bf5E6DcaFcD504eb633Ae1"
-}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -181,6 +181,11 @@ export async function verifyNetwork(web3Provider: Web3Provider, chainId: number)
  * @returns ERC1155 metadata object
  */
 export function createErc1155Metadata(metadata: SpaceMetadata) {
+  const wallets: string[] = [];
+  if (metadata.walletNetwork && metadata.walletAddress) {
+    wallets.push(`${metadata.walletNetwork}:${metadata.walletAddress}`);
+  }
+
   return {
     name: metadata.name,
     description: metadata.description,
@@ -189,7 +194,7 @@ export function createErc1155Metadata(metadata: SpaceMetadata) {
       github: metadata.github,
       twitter: metadata.twitter,
       discord: metadata.discord,
-      wallets: [`${metadata.walletNetwork}:${metadata.walletAddress}`]
+      wallets
     }
   };
 }

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -140,7 +140,11 @@ async function handleProposeClick() {
         <Preview :url="proposals[proposalKey].discussion" />
       </div>
       <h4 class="eyebrow mb-3">Execution</h4>
-      <BlockExecutionEditable v-model="proposals[proposalKey].execution" class="mb-4" />
+      <BlockExecutionEditable
+        v-model="proposals[proposalKey].execution"
+        :space="space"
+        class="mb-4"
+      />
     </Container>
     <teleport to="#modal">
       <ModalDrafts

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -6,11 +6,12 @@ import { useClipboard } from '@vueuse/core';
 import { useBalances } from '@/composables/useBalances';
 import { useEditor } from '@/composables/useEditor';
 import { useNfts } from '@/composables/useNfts';
-import spaceData from '@/helpers/space.json';
-import { _n, shorten, explorerUrl } from '@/helpers/utils';
+import { useTreasury } from '@/composables/useTreasury';
+import { _n, shorten } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
 import { ETH_CONTRACT } from '@/helpers/constants';
 import type { Token } from '@/helpers/alchemy';
-import type { Space } from '@/types';
+import type { NetworkID, Space } from '@/types';
 import { Transaction as TransactionType } from '@/types';
 
 const props = defineProps<{ space: Space }>();
@@ -19,19 +20,30 @@ const router = useRouter();
 const { copy, copied } = useClipboard();
 const { loading, loaded, assets, loadBalances } = useBalances();
 const { loading: nftsLoading, loaded: nftsLoaded, nfts, loadNfts } = useNfts();
+const { treasury } = useTreasury(props.space);
 const { createDraft } = useEditor();
-
-const totalQuote = computed(() =>
-  assets.value.reduce((acc, asset) => {
-    return acc + asset.value;
-  }, 0)
-);
 
 const page: Ref<'tokens' | 'nfts'> = ref('tokens');
 const modalOpen = ref({
   tokens: false,
   nfts: false
 });
+
+const currentNetwork = computed(() => {
+  if (!props.space.wallet) return null;
+
+  try {
+    return getNetwork(props.space.wallet.split(':')[0] as NetworkID);
+  } catch (err) {
+    return null;
+  }
+});
+
+const totalQuote = computed(() =>
+  assets.value.reduce((acc, asset) => {
+    return acc + asset.value;
+  }, 0)
+);
 
 const sortedAssets = computed(() =>
   (assets || []).value.sort((a, b) => {
@@ -52,98 +64,108 @@ function addTx(tx: TransactionType) {
 }
 
 onMounted(() => {
-  loadBalances(spaceData.wallet, spaceData.network);
-  loadNfts(spaceData.wallet);
+  if (!treasury.value) return;
+
+  loadBalances(treasury.value.wallet, treasury.value.network);
+  loadNfts(treasury.value.wallet);
 });
 </script>
 
 <template>
-  <div class="p-4 space-x-2 flex">
-    <div class="flex-auto" />
-    <a>
-      <UiButton class="!px-0 w-[46px]" @click="copy(spaceData.wallet)">
-        <IH-duplicate v-if="!copied" class="inline-block" />
-        <IH-check v-else class="inline-block" />
-      </UiButton>
-    </a>
-    <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
-      <IH-arrow-sm-right class="inline-block -rotate-45" />
-    </UiButton>
-  </div>
-  <div class="space-y-3">
-    <div>
-      <Label label="Treasury" sticky />
-      <a
-        :href="explorerUrl('1', spaceData.wallet)"
-        target="_blank"
-        class="flex justify-between items-center mx-4 py-3 block border-b"
-      >
-        <Stamp :id="spaceData.wallet" type="avatar" :size="32" class="mr-3" />
-        <div class="flex-1 leading-[22px]">
-          <h4 class="text-skin-link" v-text="shorten(spaceData.wallet)" />
-          <div class="text-skin-text text-sm" v-text="shorten(spaceData.wallet)" />
-        </div>
-        <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
+  <div v-if="!treasury || !currentNetwork" class="p-4">No treasury configured</div>
+  <template v-else>
+    <div class="p-4 space-x-2 flex">
+      <div class="flex-auto" />
+      <a>
+        <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
+          <IH-duplicate v-if="!copied" class="inline-block" />
+          <IH-check v-else class="inline-block" />
+        </UiButton>
       </a>
+      <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
+        <IH-arrow-sm-right class="inline-block -rotate-45" />
+      </UiButton>
     </div>
-    <div>
-      <div class="flex pl-4 border-b">
-        <Link :is-active="page === 'tokens'" text="Tokens" class="pr-3" @click="page = 'tokens'" />
-        <Link :is-active="page === 'nfts'" text="NFTs" @click="page = 'nfts'" />
+    <div class="space-y-3">
+      <div>
+        <Label label="Treasury" sticky />
+        <a
+          :href="currentNetwork?.helpers.getExplorerUrl(treasury.wallet, 'address')"
+          target="_blank"
+          class="flex justify-between items-center mx-4 py-3 border-b"
+        >
+          <Stamp :id="treasury.wallet" type="avatar" :size="32" class="mr-3" />
+          <div class="flex-1 leading-[22px]">
+            <h4 class="text-skin-link" v-text="shorten(treasury.wallet)" />
+            <div class="text-skin-text text-sm" v-text="shorten(treasury.wallet)" />
+          </div>
+          <h3 v-text="`$${_n(totalQuote.toFixed())}`" />
+        </a>
       </div>
-      <div v-if="page === 'tokens'">
-        <UiLoading v-if="loading && !loaded" class="px-4 py-3 block" />
-        <div v-for="(asset, i) in sortedAssets" :key="i" class="mx-4 py-3 border-b flex">
-          <div class="flex-auto flex items-center min-w-0">
-            <Stamp :id="asset.contractAddress" type="token" :size="32" />
-            <div class="flex flex-col ml-3 leading-[22px] min-w-0 pr-2 md:pr-0">
-              <h4 class="text-skin-link" v-text="asset.symbol" />
-              <div class="text-sm truncate" v-text="asset.name" />
+      <div>
+        <div class="flex pl-4 border-b">
+          <Link
+            :is-active="page === 'tokens'"
+            text="Tokens"
+            class="pr-3"
+            @click="page = 'tokens'"
+          />
+          <Link :is-active="page === 'nfts'" text="NFTs" @click="page = 'nfts'" />
+        </div>
+        <div v-if="page === 'tokens'">
+          <UiLoading v-if="loading && !loaded" class="px-4 py-3 block" />
+          <div v-for="(asset, i) in sortedAssets" :key="i" class="mx-4 py-3 border-b flex">
+            <div class="flex-auto flex items-center min-w-0">
+              <Stamp :id="asset.contractAddress" type="token" :size="32" />
+              <div class="flex flex-col ml-3 leading-[22px] min-w-0 pr-2 md:pr-0">
+                <h4 class="text-skin-link" v-text="asset.symbol" />
+                <div class="text-sm truncate" v-text="asset.name" />
+              </div>
+            </div>
+            <div
+              v-if="asset.price"
+              class="flex-col items-end text-right leading-[22px] w-[180px] hidden md:block"
+            >
+              <h4 class="text-skin-link" v-text="`$${_n(asset.price)}`" />
+              <div v-if="asset.change" class="text-sm">
+                <div v-if="asset.change > 0" class="text-green" v-text="`+${_n(asset.change)}%`" />
+                <div v-if="asset.change < 0" class="text-red" v-text="`${_n(asset.change)}%`" />
+              </div>
+            </div>
+            <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px]">
+              <h4
+                class="text-skin-link"
+                v-text="_n(formatUnits(asset.tokenBalance || 0, asset.decimals || 0))"
+              />
+              <div v-if="asset.price" class="text-sm" v-text="`$${_n(asset.price)}`" />
             </div>
           </div>
-          <div
-            v-if="asset.price"
-            class="flex-col items-end text-right leading-[22px] w-[180px] hidden md:block"
-          >
-            <h4 class="text-skin-link" v-text="`$${_n(asset.price)}`" />
-            <div v-if="asset.change" class="text-sm">
-              <div v-if="asset.change > 0" class="text-green" v-text="`+${_n(asset.change)}%`" />
-              <div v-if="asset.change < 0" class="text-red" v-text="`${_n(asset.change)}%`" />
+        </div>
+        <div v-else-if="page === 'nfts'">
+          <UiLoading v-if="nftsLoading && !nftsLoaded" class="px-4 py-3 block" />
+          <div class="grid gap-2 grid-cols-3 md:grid-cols-4 lg:grid-cols-6 py-3 px-2">
+            <div v-for="(nft, i) in nfts" :key="i" class="block px-3 py-1 mb-3">
+              <NftPreview :item="nft" class="w-full" />
+              <div class="mt-2 text-sm truncate">{{ nft.displayTitle }}</div>
             </div>
-          </div>
-          <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px]">
-            <h4
-              class="text-skin-link"
-              v-text="_n(formatUnits(asset.tokenBalance || 0, asset.decimals || 0))"
-            />
-            <div v-if="asset.price" class="text-sm" v-text="`$${_n(asset.price)}`" />
           </div>
         </div>
       </div>
-      <div v-else-if="page === 'nfts'">
-        <UiLoading v-if="nftsLoading && !nftsLoaded" class="px-4 py-3 block" />
-        <div class="grid gap-2 grid-cols-3 md:grid-cols-4 lg:grid-cols-6 py-3 px-2">
-          <div v-for="(nft, i) in nfts" :key="i" class="block px-3 py-1 mb-3">
-            <NftPreview :item="nft" class="w-full" />
-            <div class="mt-2 text-sm truncate">{{ nft.displayTitle }}</div>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-  <teleport to="#modal">
-    <ModalSendToken
-      :open="modalOpen.tokens"
-      :address="spaceData.wallet"
-      :network="spaceData.network"
-      @close="modalOpen.tokens = false"
-      @add="addTx"
-    />
-    <ModalSendNft
-      :open="modalOpen.nfts"
-      :address="spaceData.wallet"
-      @close="modalOpen.nfts = false"
-      @add="addTx"
-    />
-  </teleport>
+    <teleport to="#modal">
+      <ModalSendToken
+        :open="modalOpen.tokens"
+        :address="treasury.wallet"
+        :network="treasury.network"
+        @close="modalOpen.tokens = false"
+        @add="addTx"
+      />
+      <ModalSendNft
+        :open="modalOpen.nfts"
+        :address="treasury.wallet"
+        @close="modalOpen.nfts = false"
+        @add="addTx"
+      />
+    </teleport>
+  </template>
 </template>


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/465

This PR makes use of real treasury address (from metadata) to be displayed on UI: on treasury page and proposal creator.

## Test plan

- Go to space without treasury: http://localhost:8080/#/gor:0x232214209dcbb0328d0ac28d9a85efe4be8dcd7f
- Treasury tab is missing, when creating proposal SendToken/NFT modals are disabled.
- Go to space without treasury: http://localhost:8080/#/gor:0xb3782e21cedaf9183da9c472f810cc2fd337c6a2
- Treasury tab is there, when creating proposal SendToken/NFT modals are enabled.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/223411334-69bbfedc-330c-4a98-ac2c-62f48a3f994c.png" width="400" />
<img src="https://user-images.githubusercontent.com/1968722/223411391-05905154-09d0-43ed-9853-cf62e20c6f4e.png" width="400" />