### PR TITLE
feat: format voting power based on decimals

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@snapshot-labs/pineapple": "^0.1.0-beta.1",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
     "@snapshot-labs/snapshot.js": "^0.4.11",
-    "@snapshot-labs/sx": "^0.1.0-beta.23",
+    "@snapshot-labs/sx": "^0.1.0-beta.25",
     "@vueuse/core": "^9.4.0",
     "@walletconnect/client": "^1.7.8",
     "ajv": "^8.11.0",

--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
+import { _n } from '@/helpers/utils';
 import { Proposal as ProposalType } from '@/types';
 
 const props = withDefaults(
   defineProps<{
     proposal: ProposalType;
+    decimals?: number;
     withDetails?: boolean;
     width?: number;
   }>(),
   {
+    decimals: 0,
     withDetails: false,
     width: 100
   }
@@ -64,7 +67,7 @@ const visibleResults = computed(() =>
           {{ result.progress.toFixed(0) }}%
         </span>
         <IH-lightning-bolt class="inline-block ml-1" />
-        {{ result.score }}
+        {{ _n(Number(result.score) / 10 ** decimals) }}
       </div>
     </div>
     <div

--- a/src/components/S/IObject.vue
+++ b/src/components/S/IObject.vue
@@ -60,6 +60,7 @@ const getComponent = (property: { type: string; format: string; enum?: string[] 
       if (property.enum) return ISelect;
       return IString;
     case 'number':
+    case 'integer':
       return INumber;
     case 'boolean':
       return IBoolean;

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -83,11 +83,8 @@ export function useActions() {
       maxVotingDuration: settings.maxVotingDuration,
       proposalThreshold: BigInt(settings.proposalThreshold),
       quorum: BigInt(settings.quorum),
-      authenticators: authenticators.map(config => config.address),
-      votingStrategies: votingStrategies.map(config => config.address),
-      votingStrategiesParams: votingStrategies.map(config =>
-        config.generateParams ? config.generateParams(config.params) : []
-      ),
+      authenticators,
+      votingStrategies,
       executionStrategies,
       metadataUri: `ipfs://${pinned.cid}`
     });

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -54,6 +54,7 @@ export const PROPOSALS_QUERY = gql`
         id
         quorum
         authenticators
+        strategies_metadata
         executors
         executors_types
       }
@@ -112,6 +113,7 @@ export const PROPOSALS_SUMMARY_QUERY = gql`
     space {
       id
       authenticators
+      strategies_metadata
       executors
     }
     author {
@@ -195,6 +197,7 @@ export const SPACE_QUERY = gql`
       proposal_threshold
       strategies
       strategies_params
+      strategies_metadata
       authenticators
       executors
       executors_types
@@ -223,6 +226,7 @@ export const SPACES_QUERY = gql`
       proposal_threshold
       strategies
       strategies_params
+      strategies_metadata
       authenticators
       executors
       executors_types

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -8,6 +8,7 @@ export const PROPOSAL_QUERY = gql`
       space {
         id
         authenticators
+        strategies_metadata
         executors
         executors_types
       }

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -90,9 +90,8 @@ export function createActions(provider: Provider, chainId: number): NetworkActio
         maxVotingDuration: number;
         proposalThreshold: bigint;
         quorum: bigint;
-        authenticators: string[];
-        votingStrategies: string[];
-        votingStrategiesParams: string[][];
+        authenticators: StrategyConfig[];
+        votingStrategies: StrategyConfig[];
         executionStrategies: StrategyConfig[];
         metadataUri: string;
       }
@@ -110,9 +109,10 @@ export function createActions(provider: Provider, chainId: number): NetworkActio
       const response = await client.deploySpace({
         signer: web3.getSigner(),
         ...params,
-        votingStrategies: params.votingStrategies.map((strategy, i) => ({
-          addy: strategy,
-          params: params.votingStrategiesParams[i][0] ?? '0x'
+        authenticators: params.authenticators.map(config => config.address),
+        votingStrategies: params.votingStrategies.map(config => ({
+          addy: config.address,
+          params: config.generateParams ? config.generateParams(config.params)[0] : '0x'
         })),
         executionStrategies: processedExecutionStrategies.map((strategy, i) => {
           const config = params.executionStrategies[i];

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -114,6 +114,9 @@ export function createActions(provider: Provider, chainId: number): NetworkActio
           addy: config.address,
           params: config.generateParams ? config.generateParams(config.params)[0] : '0x'
         })),
+        votingStrategiesMetadata: params.votingStrategies.map(config =>
+          config.generateMetadata ? config.generateMetadata(config.params) : '0x00'
+        ),
         executionStrategies: processedExecutionStrategies.map((strategy, i) => {
           const config = params.executionStrategies[i];
 

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -60,7 +60,8 @@ export const EDITOR_VOTING_STRATEGIES = [
   {
     address: '0x0bed117707f698fccb68223de297bf3e3df7082c',
     name: 'Delegated Comp Token',
-    generateSummary: (params: Record<string, any>) => `(${shorten(params.contractAddress)})`,
+    generateSummary: (params: Record<string, any>) =>
+      `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
     generateMetadata: (params: Record<string, any>) => `0x${params.decimals.toString(16)}`,
     paramsDefinition: {

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -62,17 +62,23 @@ export const EDITOR_VOTING_STRATEGIES = [
     name: 'Delegated Comp Token',
     generateSummary: (params: Record<string, any>) => `(${shorten(params.contractAddress)})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
+    generateMetadata: (params: Record<string, any>) => `0x${params.decimals.toString(16)}`,
     paramsDefinition: {
       type: 'object',
       title: 'Params',
       additionalProperties: false,
-      required: ['contractAddress'],
+      required: ['contractAddress', 'decimals'],
       properties: {
         contractAddress: {
           type: 'string',
           format: 'address',
-          title: 'Contract address',
+          title: 'Token address',
           examples: ['0x0000…']
+        },
+        decimals: {
+          type: 'integer',
+          title: 'Decimals',
+          examples: ['18']
         }
       }
     }

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -78,9 +78,8 @@ export function createActions(
         maxVotingDuration: number;
         proposalThreshold: bigint;
         quorum: bigint;
-        authenticators: string[];
-        votingStrategies: string[];
-        votingStrategiesParams: string[][];
+        authenticators: StrategyConfig[];
+        votingStrategies: StrategyConfig[];
         executionStrategies: StrategyConfig[];
         metadataUri: string;
       }
@@ -93,6 +92,11 @@ export function createActions(
 
       return spaceManager.deploySpace({
         ...params,
+        authenticators: params.authenticators.map(config => config.address),
+        votingStrategies: params.votingStrategies.map(strategy => strategy.address),
+        votingStrategiesParams: params.votingStrategies.map(strategy =>
+          strategy.generateParams ? strategy.generateParams(strategy.params) : []
+        ),
         executionStrategies: params.executionStrategies.map(strategy => strategy.address)
       });
     },

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -43,9 +43,8 @@ export type NetworkActions = {
       maxVotingDuration: number;
       proposalThreshold: bigint;
       quorum: bigint;
-      authenticators: string[];
-      votingStrategies: string[];
-      votingStrategiesParams: string[][];
+      authenticators: StrategyConfig[];
+      votingStrategies: StrategyConfig[];
       executionStrategies: StrategyConfig[];
       metadataUri: string;
     }

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -18,6 +18,7 @@ export type StrategyTemplate = {
   paramsDefinition: any;
   generateSummary?: (params: Record<string, any>) => string;
   generateParams?: (params: Record<string, any>) => any[];
+  generateMetadata?: (params: Record<string, any>) => string;
   deploy?: (
     client: any,
     signer: Signer,

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export type Space = {
   proposal_threshold: string;
   strategies: string[];
   strategies_params: any[];
+  strategies_metadata: string[];
   authenticators: string[];
   executors: string[];
   executors_types: string[];
@@ -56,6 +57,7 @@ export type Proposal = {
   space: {
     id: string;
     authenticators: string[];
+    strategies_metadata: string[];
     executors: string[];
     executors_types: string[];
   };

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -179,7 +179,7 @@ watch([() => web3.value.account, proposal], () => getVotingPower());
                 <IH-chart-bar class="inline-block mr-2" />
                 <span>Results</span>
               </h4>
-              <Results :proposal="proposal" with-details />
+              <Results :proposal="proposal" :decimals="votingPowerDecimals" with-details />
               <div class="mt-2">
                 <div v-if="userVote.choice === 1">
                   You already voted <strong>for</strong> this proposal
@@ -197,7 +197,7 @@ watch([() => web3.value.account, proposal], () => getVotingPower());
                 <IH-chart-bar class="inline-block mr-2" />
                 <span>Results</span>
               </h4>
-              <Results :proposal="proposal" with-details />
+              <Results :proposal="proposal" :decimals="votingPowerDecimals" with-details />
             </template>
             <div class="grid grid-cols-3 gap-2">
               <UiButton

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -26,6 +26,14 @@ const votingPower = ref(0n);
 const loadingVotingPower = ref(true);
 
 const proposal = computed(() => proposalsStore.getProposal(space, id, networkId as NetworkID));
+const votingPowerDecimals = computed(() => {
+  if (!proposal.value) return 0;
+
+  return Math.max(
+    ...proposal.value.space.strategies_metadata.map(metadata => parseInt(metadata, 16)),
+    0
+  );
+});
 
 const discussion = computed(() => {
   if (!proposal.value?.discussion) return null;
@@ -118,7 +126,7 @@ watch([() => web3.value.account, proposal], () => getVotingPower());
               class="mr-2"
             >
               <IH-lightning-bolt class="inline-block" />
-              <span class="ml-1">{{ _n(votingPower, 'compact') }}</span>
+              <span class="ml-1">{{ _n(Number(votingPower) / 10 ** votingPowerDecimals) }}</span>
             </UiButton>
             <a :href="sanitizeUrl(getUrl(proposal.metadata_uri))" target="_blank">
               <UiButton class="!w-[46px] !h-[46px] !px-[12px]">

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -19,6 +19,9 @@ const loadingVotingPower = ref(true);
 const proposalsRecord = computed(
   () => proposalsStore.proposals[`${props.space.network}:${props.space.id}`]
 );
+const votingPowerDecimals = computed(() => {
+  return Math.max(...props.space.strategies_metadata.map(metadata => parseInt(metadata, 16)), 0);
+});
 
 async function handleEndReached() {
   if (!proposalsRecord.value?.hasMoreProposals) return;
@@ -76,7 +79,7 @@ watch(
           }"
         >
           <IH-lightning-bolt class="inline-block" />
-          <span class="ml-1">{{ _n(votingPower, 'compact') }}</span>
+          <span class="ml-1">{{ _n(Number(votingPower) / 10 ** votingPowerDecimals) }}</span>
         </UiButton>
         <router-link :to="{ name: 'editor' }">
           <UiButton class="!px-0 w-[46px]">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
 
-"@snapshot-labs/sx@^0.1.0-beta.23":
-  version "0.1.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.23.tgz#8c1c9c2b917cf0b49aeffa9d7d185aa6a7373de0"
-  integrity sha512-ZEbAVBs3SUoqWCdsS5TGYbkT5xSc0x1mFtx5fft1sVBCv9I5pnWhg3qJVjOtv615fAKURtNjtdZL/PifkFqCSQ==
+"@snapshot-labs/sx@^0.1.0-beta.25":
+  version "0.1.0-beta.25"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.25.tgz#fdd7ddf89d15d05024cb0131570754e39f444ffb"
+  integrity sha512-dEwZ0+yd6lCdTZmEREdD/tmZQgF1AiBilkjpvpTb2v15/4fWhC9iqrixbWFjrRuBazZvf4kDj3gQshv5woYBcg==
   dependencies:
     "@ethereumjs/block" "^3.6.3"
     "@ethereumjs/common" "^2.6.5"


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/469

- pass StrategyConfig to network actions
- set decimals on deploy
- interpret voting strategy metadata as decimals

## Test plan

- Create space with voting strategy, editor asks you to provide decimals
- Go to space with decimals (http://localhost:8080/#/gor:0xb2df4a0562d757df00fbc2bb3701041d05b4d757/proposals)
- It formats VP correctly.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/224076945-5d0b5b6a-e3ab-43d8-864d-f1a42d0c8480.png" width="600" />
