### PR TITLE
feat: add generic UI errors for actions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,6 +68,7 @@ watch(route, () => {
         <router-view :key="route.path" class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
       </div>
     </div>
+    <Notifications />
     <div id="modal" />
   </div>
 </template>

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -1,0 +1,20 @@
+<script lang="ts" setup>
+import { useUiStore } from '@/stores/ui';
+
+const uiStore = useUiStore();
+</script>
+
+<template>
+  <div class="fixed bottom-4 left-4 right-4 md:left-1/2 md:right-0 md:-translate-x-1/2 z-50">
+    <UiAlert
+      v-for="notification in uiStore.notifications"
+      :key="notification.id"
+      dismissable
+      :type="notification.type"
+      class="mb-2 last:mb-0"
+      @close="uiStore.dismissNotification(notification.id)"
+    >
+      {{ notification.message }}
+    </UiAlert>
+  </div>
+</template>

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -5,13 +5,13 @@ const uiStore = useUiStore();
 </script>
 
 <template>
-  <div class="fixed bottom-4 left-4 right-4 md:left-1/2 md:right-0 md:-translate-x-1/2 z-50">
+  <div class="fixed bottom-4 left-0 right-0 z-50">
     <UiAlert
       v-for="notification in uiStore.notifications"
       :key="notification.id"
       dismissable
       :type="notification.type"
-      class="mb-2 last:mb-0"
+      class="w-fit max-w-[90%] mx-auto mb-2 last:mb-0"
       @close="uiStore.dismissNotification(notification.id)"
     >
       {{ notification.message }}

--- a/src/components/Ui/Alert.vue
+++ b/src/components/Ui/Alert.vue
@@ -1,17 +1,33 @@
 <script setup lang="ts">
+import { NotificationType } from '@/types';
+
 defineProps<{
-  type: 'error';
+  type: NotificationType;
+  dismissable?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close');
 }>();
 </script>
 
 <template>
   <div
-    class="w-full py-2 px-3 mb-4 rounded border text-sm"
+    class="flex gap-2 justify-between items-center w-full py-2 px-3 rounded border text-sm"
     :class="{
       'bg-rose-100 border-rose-300 text-rose-500 dark:bg-rose-700 dark:border-rose-700 dark:text-neutral-100':
-        type === 'error'
+        type === 'error',
+      'bg-yellow-100 border-yellow-300 text-yellow-600 dark:bg-amber-500 dark:border-amber-500 dark:text-neutral-100':
+        type === 'warning'
     }"
   >
     <slot />
+    <a
+      v-if="dismissable"
+      class="text-skin-link opacity-50 hover:opacity-100"
+      @click="emit('close')"
+    >
+      <IH-x />
+    </a>
   </div>
 </template>

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -26,7 +26,9 @@ export function useActions() {
       try {
         return await fn(...args);
       } catch (err) {
-        uiStore.addNotification('error', 'Something went wrong. Please try again later.');
+        if (err.code !== 'ACTION_REJECTED' && err.message !== 'User abort') {
+          uiStore.addNotification('error', 'Something went wrong. Please try again later.');
+        }
 
         throw err;
       }

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -21,6 +21,18 @@ export function useActions() {
   const { modalAccountOpen } = useModal();
   const auth = getInstance();
 
+  function wrapWithErrors(fn) {
+    return async (...args) => {
+      try {
+        return await fn(...args);
+      } catch (err) {
+        uiStore.addNotification('error', 'Something went wrong. Please try again later.');
+
+        throw err;
+      }
+    };
+  }
+
   async function wrapPromise(networkId: NetworkID, promise: Promise<any>) {
     const network = getNetwork(networkId);
 
@@ -191,7 +203,7 @@ export function useActions() {
     uiStore.addPendingTransaction(receipt.hash, 'gor');
   }
 
-  return {
+  const actions = {
     createSpace,
     updateMetadata,
     vote,
@@ -200,4 +212,8 @@ export function useActions() {
     receiveProposal,
     executeTransactions
   };
+
+  return Object.fromEntries(
+    Object.entries(actions).map(([key, value]) => [key, wrapWithErrors(value)])
+  );
 }

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,7 +1,13 @@
 import { defineStore } from 'pinia';
 import { getNetwork } from '@/networks';
 import { lsSet, lsGet } from '@/helpers/utils';
-import { NetworkID } from '@/types';
+import { NotificationType, NetworkID } from '@/types';
+
+type Notification = {
+  id: string;
+  type: NotificationType;
+  message: string;
+};
 
 type PendingTransaction = {
   networkId: NetworkID;
@@ -17,11 +23,26 @@ function updateStorage(pendingTransactions: PendingTransaction[]) {
 export const useUiStore = defineStore('ui', {
   state: () => ({
     sidebarOpen: false,
+    notifications: [] as Notification[],
     pendingTransactions: [] as PendingTransaction[]
   }),
   actions: {
     async toggleSidebar() {
       this.sidebarOpen = !this.sidebarOpen;
+    },
+    addNotification(type: NotificationType, message: string, timeout = 5000) {
+      const id = crypto.randomUUID();
+
+      this.notifications.push({
+        id,
+        type,
+        message
+      });
+
+      setTimeout(() => this.dismissNotification(id), 5000);
+    },
+    dismissNotification(id: string) {
+      this.notifications = this.notifications.filter(notification => notification.id !== id);
     },
     async addPendingTransaction(txId: string, networkId: NetworkID) {
       this.pendingTransactions.push({

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -39,7 +39,7 @@ export const useUiStore = defineStore('ui', {
         message
       });
 
-      setTimeout(() => this.dismissNotification(id), 5000);
+      setTimeout(() => this.dismissNotification(id), timeout);
     },
     dismissNotification(id: string) {
       this.notifications = this.notifications.filter(notification => notification.id !== id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+// UI
+export type NotificationType = 'error' | 'warning';
+
 export type NetworkID = 'gor' | 'sn-tn2';
 export type Choice = 1 | 2 | 3;
 

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -146,7 +146,7 @@ watch(proposalData, () => {
       </div>
     </nav>
     <Container v-if="proposals[proposalKey]" class="pt-5 s-box">
-      <UiAlert v-if="!fetchingVotingPower && !votingPowerValid" type="error">
+      <UiAlert v-if="!fetchingVotingPower && !votingPowerValid" type="error" class="mb-4">
         You do not have enough voting power to create proposal in this space.
       </UiAlert>
       <h4 class="eyebrow mb-3">Context</h4>


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/477

This PR adds generic UI errors to actions. They are the same for every action, but should be okay for now, at least you see when something failed.

## Test plan
- Add throw in some action in `useActions`.
- Try this action.
- Generic message appears.

## Screenshots
<img src="https://user-images.githubusercontent.com/1968722/224316551-6d1c431e-76bb-452b-86dd-7bebaf0d4c4a.png" width="600" />
