### PR TITLE
fix: mark withDetails as optional

### DIFF
--- a/src/components/Results.vue
+++ b/src/components/Results.vue
@@ -5,7 +5,7 @@ import { Proposal as ProposalType } from '@/types';
 const props = withDefaults(
   defineProps<{
     proposal: ProposalType;
-    withDetails: boolean;
+    withDetails?: boolean;
     width?: number;
   }>(),
   {


### PR DESCRIPTION
It's actually optional, but type was set as required, causing it to throw warnings.
