### PR TITLE
feat: prevent voting before voting delay ended

### DIFF
--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -58,6 +58,7 @@ async function handleVoteClick(choice: Choice) {
       <div class="hidden md:block">
         <Vote :proposal="proposal">
           <template #unsupported><div /></template>
+          <template #waiting><div /></template>
           <template #voted>
             <Results :proposal="proposal" />
           </template>

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -31,6 +31,10 @@ const isSupported = computed(() => {
     You have already voted for this proposal
   </slot>
 
+  <slot v-else-if="proposal.has_started" name="waiting">
+    Voting for this proposal hasn't started yet
+  </slot>
+
   <slot v-else-if="proposal.has_ended || proposal.executed" name="ended">
     Proposal voting window has ended
   </slot>

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useAccount } from '@/composables/useAccount';
+import { _t } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import type { Proposal as ProposalType } from '@/types';
 
@@ -32,7 +33,7 @@ const isSupported = computed(() => {
   </slot>
 
   <slot v-else-if="proposal.has_started" name="waiting">
-    Voting for this proposal hasn't started yet
+    Voting for this proposal hasn't started yet. Voting will start {{ _t(proposal.start) }}.
   </slot>
 
   <slot v-else-if="proposal.has_ended || proposal.executed" name="ended">

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -13,7 +13,9 @@ import type { PaginationOpts, NetworkApi } from '@/networks/types';
 import type { Space, Proposal, Vote, User, Transaction, NetworkID } from '@/types';
 
 type ApiSpace = Omit<Space, 'network'>;
-type ApiProposal = Omit<Proposal, 'has_ended' | 'execution' | 'network'> & { execution: string };
+type ApiProposal = Omit<Proposal, 'has_started' | 'has_ended' | 'execution' | 'network'> & {
+  execution: string;
+};
 
 function formatExecution(execution: string): Transaction[] {
   if (execution === '') return [];
@@ -43,6 +45,7 @@ function formatProposal(
   return {
     ...proposal,
     execution: formatExecution(proposal.execution),
+    has_started: proposal.start * 1000 >= now,
     has_ended: proposal.max_end * 1000 <= now,
     network: networkId
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export type Proposal = {
   created: number;
   tx: string;
   vote_count: number;
+  has_started: boolean;
   has_ended: boolean;
   executed: boolean;
 };


### PR DESCRIPTION
We should prevent voting during voting delay period.

Closes: https://github.com/snapshot-labs/sx-ui/issues/498

## Test plan

- Create proposal on http://localhost:8080/#/gor:0xff0a04a1e441903f3f5631cfaf6c024cd923a47f
- You can't vote on it right away.

