### PR TITLE
fix: keep balances/nfts state inside of composable

### DIFF
--- a/src/composables/useBalances.ts
+++ b/src/composables/useBalances.ts
@@ -2,11 +2,11 @@ import { ref, computed, Ref } from 'vue';
 import { formatUnits } from '@ethersproject/units';
 import { getBalances, GetBalancesResponse } from '@/helpers/alchemy';
 
-const assets: Ref<GetBalancesResponse> = ref([]);
-const loading = ref(true);
-const loaded = ref(false);
-
 export function useBalances() {
+  const assets: Ref<GetBalancesResponse> = ref([]);
+  const loading = ref(true);
+  const loaded = ref(false);
+
   async function loadBalances(address: string, networkId: number) {
     const data = await getBalances(address, networkId);
 

--- a/src/composables/useNfts.ts
+++ b/src/composables/useNfts.ts
@@ -3,11 +3,11 @@ import snapshot from '@snapshot-labs/snapshot.js';
 
 const SUPPORTED_ABIS = ['ERC721', 'ERC1155'];
 
-const nfts: Ref<any[]> = ref([]);
-const loading = ref(true);
-const loaded = ref(false);
-
 export function useNfts() {
+  const nfts: Ref<any[]> = ref([]);
+  const loading = ref(true);
+  const loaded = ref(false);
+
   async function loadNfts(address) {
     loading.value = true;
 


### PR DESCRIPTION
Currently NFTs and balances are global, meaning that switching from one space to another you will see old results.

## Test plan
- Go to one space (Decimals 16 + 18) -> Treasury -> NFTs.
- **Without refreshing**.
- Go to different space (Or-Land) -> Treasury -> NFTs.
- NFTs and balances were loading initially, you didn't see values from different space.