### PR TITLE
feat: add v0.4.0 contracts support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@snapshot-labs/pineapple": "^0.1.0-beta.1",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
     "@snapshot-labs/snapshot.js": "^0.4.11",
-    "@snapshot-labs/sx": "^0.1.0-beta.25",
+    "@snapshot-labs/sx": "^0.1.0-beta.26",
     "@vueuse/core": "^9.4.0",
     "@walletconnect/client": "^1.7.8",
     "ajv": "^8.11.0",

--- a/src/components/Block/SpaceFormStrategies.vue
+++ b/src/components/Block/SpaceFormStrategies.vue
@@ -2,12 +2,18 @@
 import { ref, computed, Ref } from 'vue';
 import type { StrategyConfig, StrategyTemplate } from '@/networks/types';
 
-const props = defineProps<{
-  modelValue: StrategyConfig[];
-  title: string;
-  description: string;
-  availableStrategies: StrategyTemplate[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    modelValue: StrategyConfig[];
+    limit?: number;
+    title: string;
+    description: string;
+    availableStrategies: StrategyTemplate[];
+  }>(),
+  {
+    limit: Infinity
+  }
+);
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: StrategyConfig[]);
@@ -21,7 +27,11 @@ const activeStrategies = computed({
 const editedStrategy: Ref<StrategyConfig | null> = ref(null);
 const editStrategyModalOpen = ref(false);
 
+const limitReached = computed(() => activeStrategies.value.length >= props.limit);
+
 function addStrategy(strategy: StrategyTemplate) {
+  if (limitReached.value) return;
+
   const strategyConfig = {
     id: crypto.randomUUID(),
     params: {},
@@ -101,7 +111,11 @@ function handleStrategySave(value: Record<string, any>) {
         <button
           v-for="strategy in availableStrategies"
           :key="strategy.address"
+          :disabled="limitReached"
           class="flex items-center rounded-lg border cursor-pointer px-3 py-2 text-skin-link"
+          :class="{
+            'opacity-50 cursor-not-allowed': limitReached
+          }"
           @click="addStrategy(strategy)"
         >
           <IH-plus-circle />

--- a/src/components/Block/SpaceFormVoting.vue
+++ b/src/components/Block/SpaceFormVoting.vue
@@ -40,13 +40,13 @@ const definition = {
       title: 'Max. voting duration',
       examples: ['86400']
     },
-    proposalThreshold: {
-      type: 'string',
-      format: 'uint256',
-      title: 'Proposal threshold',
-      examples: ['1']
-    },
     ...(!evmNetworks.includes(props.selectedNetworkId) && {
+      proposalThreshold: {
+        type: 'string',
+        format: 'uint256',
+        title: 'Proposal threshold',
+        examples: ['1']
+      },
       quorum: {
         type: 'string',
         format: 'uint256',

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -3,7 +3,6 @@ import { getNetwork, evmNetworks } from '@/networks';
 import { useUiStore } from '@/stores/ui';
 import { useWeb3 } from '@/composables/useWeb3';
 import { useModal } from '@/composables/useModal';
-import { createErc1155Metadata } from '@/helpers/utils';
 import type {
   Transaction,
   Proposal,

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -61,6 +61,7 @@ export function useActions() {
     metadata: SpaceMetadata,
     settings: SpaceSettings,
     authenticators: StrategyConfig[],
+    validationStrategy: StrategyConfig,
     votingStrategies: StrategyConfig[],
     executionStrategies: StrategyConfig[]
   ) {
@@ -74,8 +75,6 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const pinned = await network.helpers.pin(createErc1155Metadata(metadata));
-
     const receipt = await network.actions.createSpace(auth.web3, {
       controller: web3.value.account,
       votingDelay: settings.votingDelay,
@@ -86,9 +85,10 @@ export function useActions() {
         ? { quorum: BigInt(settings.quorum) }
         : {}),
       authenticators,
+      validationStrategy,
       votingStrategies,
       executionStrategies,
-      metadataUri: `ipfs://${pinned.cid}`
+      metadata
     });
 
     console.log('Receipt', receipt);
@@ -105,13 +105,7 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const pinned = await network.helpers.pin(createErc1155Metadata(metadata));
-
-    const receipt = await network.actions.setMetadataUri(
-      auth.web3,
-      space.id,
-      `ipfs://${pinned.cid}`
-    );
+    const receipt = await network.actions.setMetadata(auth.web3, space, metadata);
 
     console.log('Receipt', receipt);
     uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -180,7 +180,10 @@ export async function verifyNetwork(web3Provider: Web3Provider, chainId: number)
  * @param metadata space metadata
  * @returns ERC1155 metadata object
  */
-export function createErc1155Metadata(metadata: SpaceMetadata) {
+export function createErc1155Metadata(
+  metadata: SpaceMetadata,
+  extraProperties?: Record<string, any>
+) {
   const wallets: string[] = [];
   if (metadata.walletNetwork && metadata.walletAddress) {
     wallets.push(`${metadata.walletNetwork}:${metadata.walletAddress}`);
@@ -194,7 +197,8 @@ export function createErc1155Metadata(metadata: SpaceMetadata) {
       github: metadata.github,
       twitter: metadata.twitter,
       discord: metadata.discord,
-      wallets
+      wallets,
+      ...extraProperties
     }
   };
 }

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -1,78 +1,20 @@
 import { Provider } from '@ethersproject/providers';
-import { clients, getExecutionData, getEvmStrategy, evmGoerli } from '@snapshot-labs/sx';
-import {
-  RELAYER_AUTHENTICATORS,
-  SUPPORTED_AUTHENTICATORS,
-  SUPPORTED_STRATEGIES
-} from './constants';
-import { verifyNetwork } from '@/helpers/utils';
+import { clients, getEvmStrategy, evmGoerli } from '@snapshot-labs/sx';
+import { createErc1155Metadata, verifyNetwork } from '@/helpers/utils';
 import { convertToMetaTransactions } from '@/helpers/transactions';
+import { getSalt, getExecution, pickAuthenticatorAndStrategies } from './helpers';
 import type { Web3Provider } from '@ethersproject/providers';
-import type { NetworkActions, StrategyConfig, VotingPower } from '@/networks/types';
+import type { NetworkActions, NetworkHelpers, StrategyConfig, VotingPower } from '@/networks/types';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
-import type { Space, Proposal } from '@/types';
+import type { Space, Proposal, SpaceMetadata } from '@/types';
 
 type Choice = 0 | 1 | 2;
-type SpaceExecutionData = Pick<Space, 'executors' | 'executors_types'>;
 
-const VANILLA_EXECUTOR = '0x6241b5c89350bb3c465179706cf26050ea32444f';
-
-function buildExecution(space: SpaceExecutionData, transactions: MetaTransaction[]) {
-  const avatarIndex = space.executors_types.findIndex(
-    executorType => executorType === 'SimpleQuorumAvatar'
-  );
-
-  if (avatarIndex !== -1) {
-    const address = space.executors[avatarIndex];
-
-    const networkConfig = {
-      ...evmGoerli,
-      executors: {
-        ...evmGoerli.executors,
-        [address]: {
-          type: 'avatar' as const
-        }
-      }
-    };
-
-    return getExecutionData(space.executors[avatarIndex], networkConfig, { transactions });
-  }
-
-  if (space.executors.find(executor => executor === VANILLA_EXECUTOR)) {
-    if (transactions.length) {
-      console.warn('transactions will be ignored as vanilla executor is used');
-    }
-
-    return {
-      executor: VANILLA_EXECUTOR,
-      executionParams: ['0x00']
-    };
-  }
-
-  throw new Error('No supported executor configured for this space');
-}
-
-function pickAuthenticatorAndStrategies(authenticators: string[], strategies: string[]) {
-  const authenticator = authenticators.find(
-    authenticator => SUPPORTED_AUTHENTICATORS[authenticator]
-  );
-
-  const selectedStrategies = strategies
-    .map((strategy, index) => ({ address: strategy, index } as const))
-    .filter(({ address }) => SUPPORTED_STRATEGIES[address]);
-
-  if (!authenticator || selectedStrategies.length === 0) {
-    throw new Error('Unsupported space');
-  }
-
-  return {
-    useRelayer: !!RELAYER_AUTHENTICATORS[authenticator],
-    authenticator,
-    strategies: selectedStrategies
-  };
-}
-
-export function createActions(provider: Provider, chainId: number): NetworkActions {
+export function createActions(
+  provider: Provider,
+  helpers: NetworkHelpers,
+  chainId: number
+): NetworkActions {
   const manaUrl: string = import.meta.env.VITE_MANA_URL || 'http://localhost:3000';
 
   const client = new clients.EvmEthereumTx();
@@ -91,53 +33,77 @@ export function createActions(provider: Provider, chainId: number): NetworkActio
         proposalThreshold: bigint;
         quorum: bigint;
         authenticators: StrategyConfig[];
+        validationStrategy: StrategyConfig;
         votingStrategies: StrategyConfig[];
         executionStrategies: StrategyConfig[];
-        metadataUri: string;
+        metadata: SpaceMetadata;
       }
     ) {
       await verifyNetwork(web3, chainId);
 
-      const processedExecutionStrategies = await Promise.all(
-        params.executionStrategies.map(async config =>
-          config.deploy
-            ? await config.deploy(client, web3.getSigner(), params.controller, config.params)
-            : config.address
-        )
+      const salt = getSalt();
+      const spaceAddress = await client.predictSpaceAddress({ signer: web3.getSigner(), salt });
+
+      const executionStrategies = await Promise.all(
+        params.executionStrategies.map(async config => {
+          if (!config.deploy) return config.address;
+
+          const address = await config.deploy(
+            client,
+            web3.getSigner(),
+            params.controller,
+            spaceAddress,
+            config.params
+          );
+
+          return address;
+        })
+      );
+
+      const pinned = await helpers.pin(
+        createErc1155Metadata(params.metadata, {
+          executionStrategies
+        })
       );
 
       const response = await client.deploySpace({
         signer: web3.getSigner(),
-        ...params,
-        authenticators: params.authenticators.map(config => config.address),
-        votingStrategies: params.votingStrategies.map(config => ({
-          addy: config.address,
-          params: config.generateParams ? config.generateParams(config.params)[0] : '0x'
-        })),
-        votingStrategiesMetadata: params.votingStrategies.map(config =>
-          config.generateMetadata ? config.generateMetadata(config.params) : '0x00'
-        ),
-        executionStrategies: processedExecutionStrategies.map((strategy, i) => {
-          const config = params.executionStrategies[i];
-
-          return {
-            addy: strategy,
-            params: config.generateParams
-              ? config.generateParams(params.executionStrategies[i].params)[0]
-              : []
-          };
-        })
+        salt,
+        params: {
+          ...params,
+          authenticators: params.authenticators.map(config => config.address),
+          votingStrategies: params.votingStrategies.map(config => ({
+            addy: config.address,
+            params: config.generateParams ? config.generateParams(config.params)[0] : '0x'
+          })),
+          votingStrategiesMetadata: params.votingStrategies.map(config =>
+            config.generateMetadata ? config.generateMetadata(config.params) : '0x00'
+          ),
+          proposalValidationStrategy: {
+            addy: params.validationStrategy.address,
+            params: params.validationStrategy.generateParams
+              ? params.validationStrategy.generateParams(params.validationStrategy.params)[0]
+              : '0x'
+          },
+          metadataUri: `ipfs://${pinned.cid}`
+        }
       });
 
       return { hash: response.txId };
     },
-    setMetadataUri: async (web3: Web3Provider, spaceId: string, metadataUri: string) => {
+    setMetadata: async (web3: Web3Provider, space: Space, metadata: SpaceMetadata) => {
       await verifyNetwork(web3, chainId);
+
+      const pinned = await helpers.pin(
+        createErc1155Metadata(metadata, {
+          executionStrategies: space.executors
+        })
+      );
 
       return client.setMetadataUri({
         signer: web3.getSigner(),
-        space: spaceId,
-        metadataUri
+        space: space.id,
+        metadataUri: `ipfs://${pinned.cid}`
       });
     },
     propose: async (
@@ -154,18 +120,16 @@ export function createActions(provider: Provider, chainId: number): NetworkActio
         space.strategies
       );
 
-      const executionData = buildExecution(space, transactions);
-      const index = space.executors.findIndex(executor => executor === executionData.executor);
+      const { executor, executionData } = getExecution(space, transactions);
 
       const data = {
         space: space.id,
         authenticator,
         strategies,
-        executor: {
-          index,
-          address: executionData.executor
+        executionStrategy: {
+          addy: executor,
+          params: executionData.executionParams[0]
         },
-        executionParams: executionData.executionParams[0],
         metadataUri: `ipfs://${cid}`
       };
 
@@ -226,7 +190,7 @@ export function createActions(provider: Provider, chainId: number): NetworkActio
     executeTransactions: async (web3: Web3Provider, proposal: Proposal) => {
       await verifyNetwork(web3, chainId);
 
-      const executionData = buildExecution(
+      const { executionData } = getExecution(
         proposal.space,
         convertToMetaTransactions(proposal.execution)
       );

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -1,65 +1,101 @@
+import { clients } from '@snapshot-labs/sx';
 import { shorten } from '@/helpers/utils';
 import type { Signer } from '@ethersproject/abstract-signer';
 
 export const API_URL = 'https://api.thegraph.com/subgraphs/name/snapshot-labs/sx-goerli';
 
 export const SUPPORTED_AUTHENTICATORS = {
-  '0xcc3fb327de5428d182ba2e739aea5978c0e2ce35': true,
-  '0x277f388b77cd36fff1c0e976c49a7c54413a449a': true
+  '0xddb36b865a1021524b936fb29fcba5fac073db74': true,
+  '0xc537d997ddc783e071f82ccbfaa0d768d310001b': true
 };
 
 export const SUPPORTED_STRATEGIES = {
-  '0xf3e55d22845689be3e062975444d09799e522a6c': true,
-  '0x0bed117707f698fccb68223de297bf3e3df7082c': true,
-  '0x95287283ed7c583120b06ff48a655062976ac41c': true
+  '0xeba53160c146cbf77a150e9a218d4c2de5db6b51': true,
+  '0x343baf4b44f7f79b14301cfa8068e3f8be7470de': true,
+  '0x4aaa33b4367dc5657854bd40738201651ec0cc7b': true,
+  '0xf50bf15e9fe61e27625a4ecdfc23211297e8be85': true
 };
 
 export const SUPPORTED_EXECUTORS = {
-  '0x6241b5c89350bb3c465179706cf26050ea32444f': true
+  SimpleQuorumAvatar: true
 };
 
 export const RELAYER_AUTHENTICATORS = {
-  '0x277f388b77cd36fff1c0e976c49a7c54413a449a': true
+  '0xc537d997ddc783e071f82ccbfaa0d768d310001b': true
 };
 
 export const AUTHS = {
   '0xdd66652e93293c32aa3288509d9a46c785e3f786': 'Vanilla',
-  '0x277f388b77cd36fff1c0e976c49a7c54413a449a': 'Ethereum signature',
-  '0xcc3fb327de5428d182ba2e739aea5978c0e2ce35': 'Ethereum transaction'
+  '0xc537d997ddc783e071f82ccbfaa0d768d310001b': 'Ethereum signature',
+  '0xddb36b865a1021524b936fb29fcba5fac073db74': 'Ethereum transaction'
 };
 
 export const STRATEGIES = {
-  '0xf3e55d22845689be3e062975444d09799e522a6c': 'Vanilla',
-  '0x0bed117707f698fccb68223de297bf3e3df7082c': 'Delegated Comp Token',
-  '0x95287283ed7c583120b06ff48a655062976ac41c': 'Whitelist'
+  '0xeba53160c146cbf77a150e9a218d4c2de5db6b51': 'Vanilla',
+  '0x343baf4b44f7f79b14301cfa8068e3f8be7470de': 'Delegated Comp Token',
+  '0x4aaa33b4367dc5657854bd40738201651ec0cc7b': 'Oz Votes',
+  '0xf50bf15e9fe61e27625a4ecdfc23211297e8be85': 'Whitelist'
 };
 
-export const EXECUTORS = {
-  '0x6241b5c89350bb3c465179706cf26050ea32444f': 'Vanilla'
-};
+export const EXECUTORS = {};
 
 export const EDITOR_AUTHENTICATORS = [
   {
-    address: '0xcc3fb327de5428d182ba2e739aea5978c0e2ce35',
+    address: '0xddb36b865a1021524b936fb29fcba5fac073db74',
     name: 'Ethereum transaction',
     paramsDefinition: null
   },
   {
-    address: '0x277f388b77cd36fff1c0e976c49a7c54413a449a',
+    address: '0xc537d997ddc783e071f82ccbfaa0d768d310001b',
     name: 'Ethereum signature',
+    paramsDefinition: null
+  }
+];
+
+export const EDITOR_PROPOSAL_VALIDATIONS = [
+  {
+    address: '0x80d9665e5761a778a97283dec14581c4c0bf8d51',
+    name: 'Vanilla',
     paramsDefinition: null
   }
 ];
 
 export const EDITOR_VOTING_STRATEGIES = [
   {
-    address: '0xf3e55d22845689be3e062975444d09799e522a6c',
+    address: '0xeba53160c146cbf77a150e9a218d4c2de5db6b51',
     name: 'Vanilla',
     paramsDefinition: null
   },
   {
-    address: '0x0bed117707f698fccb68223de297bf3e3df7082c',
+    address: '0x343baf4b44f7f79b14301cfa8068e3f8be7470de',
     name: 'Delegated Comp Token',
+    generateSummary: (params: Record<string, any>) =>
+      `(${shorten(params.contractAddress)}, ${params.decimals})`,
+    generateParams: (params: Record<string, any>) => [params.contractAddress],
+    generateMetadata: (params: Record<string, any>) => `0x${params.decimals.toString(16)}`,
+    paramsDefinition: {
+      type: 'object',
+      title: 'Params',
+      additionalProperties: false,
+      required: ['contractAddress', 'decimals'],
+      properties: {
+        contractAddress: {
+          type: 'string',
+          format: 'address',
+          title: 'Token address',
+          examples: ['0x0000…']
+        },
+        decimals: {
+          type: 'integer',
+          title: 'Decimals',
+          examples: ['18']
+        }
+      }
+    }
+  },
+  {
+    address: '0x4aaa33b4367dc5657854bd40738201651ec0cc7b',
+    name: 'Oz Votes',
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
@@ -88,28 +124,7 @@ export const EDITOR_VOTING_STRATEGIES = [
 
 export const EDITOR_EXECUTION_STRATEGIES = [
   {
-    address: '0x6241b5c89350bb3c465179706cf26050ea32444f',
-    name: 'Vanilla',
-    generateSummary: (params: Record<string, any>) => `(${params.quorum})`,
-    generateParams: (params: Record<string, any>) => [
-      `0x${params.quorum.toString(16).padStart(64, '0')}`
-    ],
-    paramsDefinition: {
-      type: 'object',
-      title: 'Params',
-      additionalProperties: false,
-      required: ['quorum'],
-      properties: {
-        quorum: {
-          type: 'string',
-          title: 'Quorum',
-          examples: ['1']
-        }
-      }
-    }
-  },
-  {
-    address: '0x87f527c699ce6c7cb65718d5c7d468597d952cab',
+    address: '',
     type: 'SimpleQuorumAvatar',
     name: 'Avatar',
     generateSummary: (params: Record<string, any>) =>
@@ -117,13 +132,24 @@ export const EDITOR_EXECUTION_STRATEGIES = [
     generateParams: (params: Record<string, any>) => [
       `0x${params.quorum.toString(16).padStart(64, '0')}`
     ],
-    deploy: async (client: any, signer: Signer, controller, params: Record<string, any>) => {
-      return client.deployAvatarExecution({
+    deploy: async (
+      client: clients.EvmEthereumTx,
+      signer: Signer,
+      controller: string,
+      spaceAddress: string,
+      params: Record<string, any>
+    ): Promise<string> => {
+      const { address } = await client.deployAvatarExecution({
         signer,
-        controller,
-        target: params.contractAddress,
-        spaces: []
+        params: {
+          controller,
+          target: params.contractAddress,
+          spaces: [spaceAddress],
+          quorum: BigInt(params.quorum)
+        }
       });
+
+      return address;
     },
     paramsDefinition: {
       type: 'object',

--- a/src/networks/evm/helpers.ts
+++ b/src/networks/evm/helpers.ts
@@ -1,0 +1,60 @@
+type SpaceExecutionData = Pick<Space, 'executors' | 'executors_types'>;
+type ExecutorType = Parameters<typeof getEvmExecutionData>[0];
+
+import { getEvmExecutionData } from '@snapshot-labs/sx';
+import {
+  RELAYER_AUTHENTICATORS,
+  SUPPORTED_AUTHENTICATORS,
+  SUPPORTED_STRATEGIES,
+  SUPPORTED_EXECUTORS
+} from './constants';
+import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
+import type { Space } from '@/types';
+
+export function getSalt() {
+  const buffer = new Uint8Array(32);
+  crypto.getRandomValues(buffer);
+
+  return `0x${buffer.reduce((acc, val) => acc + val.toString(16).padStart(2, '0'), '')}`;
+}
+
+export function getExecution(space: SpaceExecutionData, transactions: MetaTransaction[]) {
+  const supportedExecutionIndex = space.executors_types.findIndex(
+    executorType => SUPPORTED_EXECUTORS[executorType]
+  );
+
+  if (supportedExecutionIndex === -1) {
+    throw new Error('No supported executor configured for this space');
+  }
+
+  const executor = space.executors[supportedExecutionIndex];
+  const executorType = space.executors_types[supportedExecutionIndex] as ExecutorType;
+  const executionData = getEvmExecutionData(executorType, executor, {
+    transactions
+  });
+
+  return {
+    executor,
+    executionData
+  };
+}
+
+export function pickAuthenticatorAndStrategies(authenticators: string[], strategies: string[]) {
+  const authenticator = authenticators.find(
+    authenticator => SUPPORTED_AUTHENTICATORS[authenticator]
+  );
+
+  const selectedStrategies = strategies
+    .map((strategy, index) => ({ address: strategy, index } as const))
+    .filter(({ address }) => SUPPORTED_STRATEGIES[address]);
+
+  if (!authenticator || selectedStrategies.length === 0) {
+    throw new Error('Unsupported space');
+  }
+
+  return {
+    useRelayer: !!RELAYER_AUTHENTICATORS[authenticator],
+    authenticator,
+    strategies: selectedStrategies
+  };
+}

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -11,23 +11,24 @@ export function createEvmNetwork(networkId: NetworkID): Network {
   const chainId = 5;
 
   const provider = createProvider(`https://rpc.brovider.xyz/${chainId}`);
+  const helpers = {
+    pin: pinGraph,
+    waitForTransaction: (txId: string) => provider.waitForTransaction(txId),
+    getExplorerUrl: (id, type) => {
+      let dataType: 'tx' | 'address' = 'tx';
+      if (['address', 'contract'].includes(type)) dataType = 'address';
+
+      return `${networks[chainId].explorer}/${dataType}/${id}`;
+    }
+  };
 
   return {
     name: 'Ethereum (goerli)',
     hasReceive: false,
     managerConnectors: ['injected', 'walletconnect', 'walletlink', 'portis', 'gnosis'],
-    actions: createActions(provider, chainId),
+    actions: createActions(provider, helpers, chainId),
     api: createApi(constants.API_URL, networkId),
     constants,
-    helpers: {
-      pin: pinGraph,
-      waitForTransaction: (txId: string) => provider.waitForTransaction(txId),
-      getExplorerUrl: (id, type) => {
-        let dataType: 'tx' | 'address' = 'tx';
-        if (['address', 'contract'].includes(type)) dataType = 'address';
-
-        return `${networks[chainId].explorer}/${dataType}/${id}`;
-      }
-    }
+    helpers
   };
 }

--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -49,6 +49,8 @@ export const EDITOR_AUTHENTICATORS = [
   }
 ];
 
+export const EDITOR_PROPOSAL_VALIDATIONS = [];
+
 export const EDITOR_VOTING_STRATEGIES = [
   {
     address: '0x58623786b93d9b6ed1f83cec5c6fa6bea5f399d2795ee56a6123bdd83f5aa48',

--- a/src/networks/starknet/index.ts
+++ b/src/networks/starknet/index.ts
@@ -11,35 +11,36 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
   const l1ChainId = 5;
 
   const provider = createProvider();
+  const helpers = {
+    pin: async (content: any) => {
+      const pinned = await pin(content);
+      if (!pinned) throw new Error('Failed to pin');
+
+      return {
+        provider: pinned.provider,
+        cid: pinned.cid
+      };
+    },
+    waitForTransaction: txId =>
+      provider.waitForTransaction(txId, {
+        successStates: [TransactionStatus.ACCEPTED_ON_L1, TransactionStatus.ACCEPTED_ON_L2]
+      }),
+    getExplorerUrl: (id, type) => {
+      let dataType: 'tx' | 'contract' = 'tx';
+      if (['address', 'contract'].includes(type)) dataType = 'contract';
+
+      return `https://testnet-2.starkscan.co/${dataType}/${id}`;
+    }
+  };
 
   return {
     name: 'Starknet (testnet2)',
     baseNetworkId: 'gor',
     hasReceive: true,
     managerConnectors: ['argentx'],
-    actions: createActions(provider, { l1ChainId }),
+    actions: createActions(provider, helpers, { l1ChainId }),
     api: createApi(constants.API_URL, networkId),
     constants,
-    helpers: {
-      pin: async (content: any) => {
-        const pinned = await pin(content);
-        if (!pinned) throw new Error('Failed to pin');
-
-        return {
-          provider: pinned.provider,
-          cid: pinned.cid
-        };
-      },
-      waitForTransaction: txId =>
-        provider.waitForTransaction(txId, {
-          successStates: [TransactionStatus.ACCEPTED_ON_L1, TransactionStatus.ACCEPTED_ON_L2]
-        }),
-      getExplorerUrl: (id, type) => {
-        let dataType: 'tx' | 'contract' = 'tx';
-        if (['address', 'contract'].includes(type)) dataType = 'contract';
-
-        return `https://testnet-2.starkscan.co/${dataType}/${id}`;
-      }
-    }
+    helpers
   };
 }

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -1,7 +1,7 @@
 import type { Web3Provider } from '@ethersproject/providers';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding';
-import type { Space, Proposal, Vote, User, Choice, NetworkID } from '@/types';
+import type { Space, SpaceMetadata, Proposal, Vote, User, Choice, NetworkID } from '@/types';
 
 export type PaginationOpts = { limit: number; skip?: number };
 export type Connector =
@@ -15,6 +15,7 @@ export type Connector =
 export type StrategyTemplate = {
   address: string;
   name: string;
+  type?: string;
   paramsDefinition: any;
   generateSummary?: (params: Record<string, any>) => string;
   generateParams?: (params: Record<string, any>) => any[];
@@ -23,6 +24,7 @@ export type StrategyTemplate = {
     client: any,
     signer: Signer,
     controller: string,
+    spaceAddress: string,
     params: Record<string, any>
   ) => Promise<string>;
 };
@@ -52,12 +54,13 @@ export type NetworkActions = {
       proposalThreshold: bigint;
       quorum?: bigint;
       authenticators: StrategyConfig[];
+      validationStrategy: StrategyConfig;
       votingStrategies: StrategyConfig[];
       executionStrategies: StrategyConfig[];
-      metadataUri: string;
+      metadata: SpaceMetadata;
     }
   );
-  setMetadataUri(web3: Web3Provider, spaceId: string, metadataUri: string);
+  setMetadata(web3: Web3Provider, space: Space, metadata: SpaceMetadata);
   propose(
     web3: Web3Provider,
     account: string,
@@ -90,6 +93,12 @@ export type NetworkApi = {
   loadUser(userId: string): Promise<User>;
 };
 
+export type NetworkHelpers = {
+  pin: (content: any) => Promise<{ cid: string; provider: string }>;
+  waitForTransaction(txId: string): Promise<any>;
+  getExplorerUrl(id: string, type: 'transaction' | 'address' | 'contract'): string;
+};
+
 export type Network = {
   name: string;
   baseNetworkId?: NetworkID;
@@ -106,12 +115,9 @@ export type Network = {
     STRATEGIES: { [key: string]: string };
     EXECUTORS: { [key: string]: string };
     EDITOR_AUTHENTICATORS: StrategyTemplate[];
+    EDITOR_PROPOSAL_VALIDATIONS: StrategyTemplate[];
     EDITOR_VOTING_STRATEGIES: StrategyTemplate[];
     EDITOR_EXECUTION_STRATEGIES: StrategyTemplate[];
   };
-  helpers: {
-    pin: (content: any) => Promise<{ cid: string; provider: string }>;
-    waitForTransaction(txId: string): Promise<any>;
-    getExplorerUrl(id: string, type: 'transaction' | 'address' | 'contract'): string;
-  };
+  helpers: NetworkHelpers;
 };

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -155,7 +155,7 @@ watch([() => web3.value.account, proposal], () => getVotingPower());
           v-if="
             proposal.execution &&
             proposal.execution.length > 0 &&
-            proposal.scores_total >= proposal.quorum
+            BigInt(proposal.scores_total) >= BigInt(proposal.quorum)
           "
         >
           <h4 class="mb-3 eyebrow flex items-center">

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { shorten, _d } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
+import { getNetwork, evmNetworks } from '@/networks';
 import { Space } from '@/types';
 
 const props = defineProps<{ space: Space }>();
@@ -26,7 +26,7 @@ const network = computed(() => getNetwork(props.space.network));
           <div class="s-label !mb-0">Max. voting period</div>
           <h4 class="text-skin-link text-md" v-text="_d(space.max_voting_period)" />
         </div>
-        <div class="mb-3">
+        <div v-if="!evmNetworks.includes(space.network)" class="mb-3">
           <div class="s-label !mb-0" v-text="'Proposal threshold'" />
           <h4 class="text-skin-link text-md" v-text="space.proposal_threshold" />
         </div>

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { shorten, _d } from '@/helpers/utils';
-import { getNetwork, evmNetworks } from '@/networks';
+import { getNetwork } from '@/networks';
 import { Space } from '@/types';
 
 const props = defineProps<{ space: Space }>();
@@ -26,7 +26,7 @@ const network = computed(() => getNetwork(props.space.network));
           <div class="s-label !mb-0">Max. voting period</div>
           <h4 class="text-skin-link text-md" v-text="_d(space.max_voting_period)" />
         </div>
-        <div v-if="!evmNetworks.includes(space.network)" class="mb-3">
+        <div class="mb-3">
           <div class="s-label !mb-0" v-text="'Proposal threshold'" />
           <h4 class="text-skin-link text-md" v-text="space.proposal_threshold" />
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,10 +1163,10 @@
     json-to-graphql-query "^2.2.4"
     lodash.set "^4.3.2"
 
-"@snapshot-labs/sx@^0.1.0-beta.25":
-  version "0.1.0-beta.25"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.25.tgz#fdd7ddf89d15d05024cb0131570754e39f444ffb"
-  integrity sha512-dEwZ0+yd6lCdTZmEREdD/tmZQgF1AiBilkjpvpTb2v15/4fWhC9iqrixbWFjrRuBazZvf4kDj3gQshv5woYBcg==
+"@snapshot-labs/sx@^0.1.0-beta.26":
+  version "0.1.0-beta.26"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.26.tgz#ac755a7228dd676b46eeaa15ac41ff3968e7802e"
+  integrity sha512-V3IGK5L0RZElqgalrEiNcSsswnokoEpoNTM47dCml5ZOfGFCyLqcwbU7GasDc2ZphzGNLSnsSa234FQW8wEYAA==
   dependencies:
     "@ethereumjs/block" "^3.6.3"
     "@ethereumjs/common" "^2.6.5"


### PR DESCRIPTION
## Summary

This PR updates code to work with latest contracts.

Missing functionality (will be added in next PRs, too many changes in this one already):
- No proper proposal validation support (you can only create spaces with vanilla validation, editor checks against proposal threshold that is hardcoded to 0 at API).
- Users can't pick execution strategy if there are multiple
- ~There is no vanilla execution strategy right now (needs to be deployed and some changes are needed on sx-subgraph).~ won't be used

## Test plan

I tested EthSig, Vanilla voting, CompVoting, AvatarExecution.

- Create your own space (you need to use avatar execution, you will only need to enableModule through Gnosis to enable your execution strategy, no other configuration needed).
- Propose
- Vote
- Execute