### PR TITLE
chore: use StaticJsonRpcProvider

### DIFF
--- a/src/networks/evm/provider.ts
+++ b/src/networks/evm/provider.ts
@@ -1,5 +1,5 @@
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
 export function createProvider(RPC_URL: string) {
-  return new JsonRpcProvider(RPC_URL);
+  return new StaticJsonRpcProvider(RPC_URL);
 }


### PR DESCRIPTION
Using StaticJsonRpcProvider avoid querying `eth_chainId` before each `eth_call`

Here is an example on proposals page:

Before:
<img width="751" alt="image" src="https://user-images.githubusercontent.com/16245250/227339338-43e235e1-7a99-45f3-937f-e68afaaa8af9.png">

After:
<img width="749" alt="image" src="https://user-images.githubusercontent.com/16245250/227339168-ac4c64d1-efd1-4386-ba66-c1e1d829ea83.png">
