### PR TITLE
feat: add Proposal validation to create space form

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@braintree/sanitize-url": "^6.0.0",
     "@ensdomains/eth-ens-namehash": "^2.0.15",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
+    "@ethersproject/abi": "^5.7.0",
     "@ethersproject/address": "^5.6.1",
     "@ethersproject/bignumber": "^5.6.2",
     "@ethersproject/constants": "^5.6.1",

--- a/src/components/Block/SpaceFormStrategies.vue
+++ b/src/components/Block/SpaceFormStrategies.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { ref, computed, Ref } from 'vue';
 import type { StrategyConfig, StrategyTemplate } from '@/networks/types';
 
-const props = withDefaults(
+withDefaults(
   defineProps<{
     modelValue: StrategyConfig[];
     limit?: number;
@@ -18,119 +17,18 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: 'update:modelValue', value: StrategyConfig[]);
 }>();
-
-const activeStrategies = computed({
-  get: () => props.modelValue,
-  set: newValue => emit('update:modelValue', newValue)
-});
-
-const editedStrategy: Ref<StrategyConfig | null> = ref(null);
-const editStrategyModalOpen = ref(false);
-
-const limitReached = computed(() => activeStrategies.value.length >= props.limit);
-
-function addStrategy(strategy: StrategyTemplate) {
-  if (limitReached.value) return;
-
-  const strategyConfig = {
-    id: crypto.randomUUID(),
-    params: {},
-    ...strategy
-  };
-
-  if (strategy.paramsDefinition) {
-    editStrategy(strategyConfig);
-  } else {
-    activeStrategies.value = [...activeStrategies.value, strategyConfig];
-  }
-}
-
-function editStrategy(strategy: StrategyConfig) {
-  editedStrategy.value = strategy;
-  editStrategyModalOpen.value = true;
-}
-
-function removeStrategy(strategy: StrategyConfig) {
-  activeStrategies.value = activeStrategies.value.filter(s => s.id !== strategy.id);
-}
-
-function handleStrategySave(value: Record<string, any>) {
-  editStrategyModalOpen.value = false;
-
-  let allStrategies = [...activeStrategies.value];
-  if (editedStrategy.value && !allStrategies.find(s => s.id === editedStrategy.value?.id)) {
-    allStrategies.push(editedStrategy.value);
-  }
-
-  activeStrategies.value = allStrategies.map(strategy => {
-    if (strategy.id !== editedStrategy.value?.id) return strategy;
-
-    return {
-      ...strategy,
-      params: value
-    };
-  });
-}
 </script>
 
 <template>
-  <div>
-    <div class="mb-4">
-      <h3 class="mb-2">{{ title }}</h3>
-      <span class="mb-3 inline-block">
-        {{ description }}
-      </span>
-      <h4 class="eyebrow mb-2">Active</h4>
-      <div class="mb-3">
-        <div v-if="activeStrategies.length === 0">No strategies selected</div>
-        <div
-          v-for="strategy in activeStrategies"
-          v-else
-          :key="strategy.id"
-          class="flex justify-between items-center rounded-lg border px-4 py-3 mb-3 text-skin-link"
-        >
-          <div class="flex min-w-0">
-            <div class="whitespace-nowrap">{{ strategy.name }}</div>
-            <div v-if="strategy.generateSummary" class="ml-2 pr-2 text-skin-text truncate">
-              {{ strategy.generateSummary(strategy.params) }}
-            </div>
-          </div>
-          <div class="flex gap-3">
-            <a v-if="strategy.paramsDefinition" @click="editStrategy(strategy)">
-              <IH-pencil />
-            </a>
-            <a @click="removeStrategy(strategy)">
-              <IH-trash />
-            </a>
-          </div>
-        </div>
-      </div>
-      <h4 class="eyebrow mb-2">Available</h4>
-      <div v-if="availableStrategies.length === 0">No strategies available</div>
-      <div v-else class="flex flex-wrap gap-2">
-        <button
-          v-for="strategy in availableStrategies"
-          :key="strategy.address"
-          :disabled="limitReached"
-          class="flex items-center rounded-lg border cursor-pointer px-3 py-2 text-skin-link"
-          :class="{
-            'opacity-50 cursor-not-allowed': limitReached
-          }"
-          @click="addStrategy(strategy)"
-        >
-          <IH-plus-circle />
-          <div class="ml-2">{{ strategy.name }}</div>
-        </button>
-      </div>
-    </div>
-    <teleport to="#modal">
-      <ModalEditStrategy
-        :open="editStrategyModalOpen"
-        :definition="editedStrategy?.paramsDefinition"
-        :initial-state="editedStrategy?.params"
-        @close="editStrategyModalOpen = false"
-        @save="handleStrategySave"
-      />
-    </teleport>
+  <div class="mb-4">
+    <h3 class="mb-2">{{ title }}</h3>
+    <span class="mb-3 inline-block">
+      {{ description }}
+    </span>
+    <BlockStrategiesConfigurator
+      :model-value="modelValue"
+      :available-strategies="availableStrategies"
+      @update:model-value="value => emit('update:modelValue', value)"
+    />
   </div>
 </template>

--- a/src/components/Block/SpaceFormValidation.vue
+++ b/src/components/Block/SpaceFormValidation.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, Ref } from 'vue';
+import type { StrategyConfig, StrategyTemplate } from '@/networks/types';
+
+const props = defineProps<{
+  modelValue: StrategyConfig | null;
+  title: string;
+  description: string;
+  availableStrategies: StrategyTemplate[];
+  availableVotingStrategies: StrategyTemplate[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: StrategyConfig | null);
+}>();
+
+const editedStrategy: Ref<StrategyConfig | null> = ref(null);
+const editStrategyModalOpen = ref(false);
+const votingStrategies = ref([] as StrategyConfig[]);
+
+const activeStrategy = computed({
+  get: () => props.modelValue,
+  set: newValue => emit('update:modelValue', newValue)
+});
+
+function addStrategy(strategy: StrategyTemplate) {
+  const strategyConfig = {
+    id: crypto.randomUUID(),
+    params: {},
+    ...strategy
+  };
+
+  if (strategy.paramsDefinition) {
+    editStrategy(strategyConfig);
+  } else {
+    activeStrategy.value = strategyConfig;
+  }
+}
+
+function editStrategy(strategy: StrategyConfig) {
+  editedStrategy.value = strategy;
+  editStrategyModalOpen.value = true;
+}
+
+function removeStrategy() {
+  activeStrategy.value = null;
+}
+
+function handleStrategySave(value: Record<string, any>) {
+  editStrategyModalOpen.value = false;
+
+  if (!editedStrategy.value) return;
+
+  activeStrategy.value = {
+    ...editedStrategy.value,
+    params: value
+  };
+}
+
+onMounted(() => {
+  votingStrategies.value = activeStrategy.value?.params?.strategies || [];
+});
+
+watch(
+  () => votingStrategies.value,
+  to => {
+    if (!activeStrategy.value) return;
+
+    activeStrategy.value = {
+      ...activeStrategy.value,
+      params: {
+        ...activeStrategy.value?.params,
+        strategies: to
+      }
+    };
+  }
+);
+</script>
+
+<template>
+  <div>
+    <div class="mb-4">
+      <h3 class="mb-2">{{ title }}</h3>
+      <span class="mb-3 inline-block">
+        {{ description }}
+      </span>
+      <div class="mb-3">
+        <div v-if="!activeStrategy">No strategies selected</div>
+        <div
+          v-else
+          class="flex justify-between items-center rounded-lg border px-4 py-3 mb-3 text-skin-link"
+        >
+          <div class="flex min-w-0">
+            <div class="whitespace-nowrap">{{ activeStrategy.name }}</div>
+            <div v-if="activeStrategy.generateSummary" class="ml-2 pr-2 text-skin-text truncate">
+              {{ activeStrategy.generateSummary(activeStrategy.params) }}
+            </div>
+          </div>
+          <div class="flex gap-3">
+            <a v-if="activeStrategy.paramsDefinition" @click="editStrategy(activeStrategy)">
+              <IH-pencil />
+            </a>
+            <a @click="removeStrategy()">
+              <IH-trash />
+            </a>
+          </div>
+        </div>
+      </div>
+      <div v-if="!activeStrategy" class="flex flex-wrap gap-2">
+        <button
+          v-for="strategy in availableStrategies"
+          :key="strategy.address"
+          class="flex items-center rounded-lg border cursor-pointer px-3 py-2 text-skin-link"
+          @click="addStrategy(strategy)"
+        >
+          <IH-plus-circle />
+          <div class="ml-2">{{ strategy.name }}</div>
+        </button>
+      </div>
+      <div v-if="activeStrategy?.type === 'VotingPower'">
+        <h3 class="eyebrow mb-2">Included strategies</h3>
+        <span class="mb-3 inline-block">
+          Select strategies that will be used to compute proposal
+        </span>
+        <BlockStrategiesConfigurator
+          v-model="votingStrategies"
+          :available-strategies="availableVotingStrategies"
+        />
+      </div>
+    </div>
+    <teleport to="#modal">
+      <ModalEditStrategy
+        :open="editStrategyModalOpen"
+        :definition="editedStrategy?.paramsDefinition"
+        :initial-state="editedStrategy?.params"
+        @close="editStrategyModalOpen = false"
+        @save="handleStrategySave"
+      />
+    </teleport>
+  </div>
+</template>

--- a/src/components/Block/StrategiesConfigurator.vue
+++ b/src/components/Block/StrategiesConfigurator.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { ref, computed, Ref } from 'vue';
+import type { StrategyConfig, StrategyTemplate } from '@/networks/types';
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: StrategyConfig[];
+    limit?: number;
+    availableStrategies: StrategyTemplate[];
+  }>(),
+  {
+    limit: Infinity
+  }
+);
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: StrategyConfig[]);
+}>();
+
+const activeStrategies = computed({
+  get: () => props.modelValue,
+  set: newValue => emit('update:modelValue', newValue)
+});
+
+const editedStrategy: Ref<StrategyConfig | null> = ref(null);
+const editStrategyModalOpen = ref(false);
+
+const limitReached = computed(() => activeStrategies.value.length >= props.limit);
+
+function addStrategy(strategy: StrategyTemplate) {
+  if (limitReached.value) return;
+
+  const strategyConfig = {
+    id: crypto.randomUUID(),
+    params: {},
+    ...strategy
+  };
+
+  if (strategy.paramsDefinition) {
+    editStrategy(strategyConfig);
+  } else {
+    activeStrategies.value = [...activeStrategies.value, strategyConfig];
+  }
+}
+
+function editStrategy(strategy: StrategyConfig) {
+  editedStrategy.value = strategy;
+  editStrategyModalOpen.value = true;
+}
+
+function removeStrategy(strategy: StrategyConfig) {
+  activeStrategies.value = activeStrategies.value.filter(s => s.id !== strategy.id);
+}
+
+function handleStrategySave(value: Record<string, any>) {
+  editStrategyModalOpen.value = false;
+
+  let allStrategies = [...activeStrategies.value];
+  if (editedStrategy.value && !allStrategies.find(s => s.id === editedStrategy.value?.id)) {
+    allStrategies.push(editedStrategy.value);
+  }
+
+  activeStrategies.value = allStrategies.map(strategy => {
+    if (strategy.id !== editedStrategy.value?.id) return strategy;
+
+    return {
+      ...strategy,
+      params: value
+    };
+  });
+}
+</script>
+
+<template>
+  <div>
+    <h4 class="eyebrow mb-2">Active</h4>
+    <div class="mb-3">
+      <div v-if="activeStrategies.length === 0">No strategies selected</div>
+      <div
+        v-for="strategy in activeStrategies"
+        v-else
+        :key="strategy.id"
+        class="flex justify-between items-center rounded-lg border px-4 py-3 mb-3 text-skin-link"
+      >
+        <div class="flex min-w-0">
+          <div class="whitespace-nowrap">{{ strategy.name }}</div>
+          <div v-if="strategy.generateSummary" class="ml-2 pr-2 text-skin-text truncate">
+            {{ strategy.generateSummary(strategy.params) }}
+          </div>
+        </div>
+        <div class="flex gap-3">
+          <a v-if="strategy.paramsDefinition" @click="editStrategy(strategy)">
+            <IH-pencil />
+          </a>
+          <a @click="removeStrategy(strategy)">
+            <IH-trash />
+          </a>
+        </div>
+      </div>
+    </div>
+    <h4 class="eyebrow mb-2">Available</h4>
+    <div v-if="availableStrategies.length === 0">No strategies available</div>
+    <div v-else class="flex flex-wrap gap-2">
+      <button
+        v-for="strategy in availableStrategies"
+        :key="strategy.address"
+        :disabled="limitReached"
+        class="flex items-center rounded-lg border cursor-pointer px-3 py-2 text-skin-link"
+        :class="{
+          'opacity-50 cursor-not-allowed': limitReached
+        }"
+        @click="addStrategy(strategy)"
+      >
+        <IH-plus-circle />
+        <div class="ml-2">{{ strategy.name }}</div>
+      </button>
+    </div>
+    <teleport to="#modal">
+      <ModalEditStrategy
+        :open="editStrategyModalOpen"
+        :definition="editedStrategy?.paramsDefinition"
+        :initial-state="editedStrategy?.params"
+        @close="editStrategyModalOpen = false"
+        @save="handleStrategySave"
+      />
+    </teleport>
+  </div>
+</template>

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -17,6 +17,7 @@ export type StrategyTemplate = {
   name: string;
   type?: string;
   paramsDefinition: any;
+  validate?: (params: Record<string, any>) => boolean;
   generateSummary?: (params: Record<string, any>) => string;
   generateParams?: (params: Record<string, any>) => any[];
   generateMetadata?: (params: Record<string, any>) => string;


### PR DESCRIPTION
## Summary

This PR adds simple UI for configuring Proposal validation for space.

After picking proposal validation you will need to configure it (in case of Voting Power Proposal Validation), by configuring voting power strategies that will be used for it.

**This PR doesn't validate proposal threshold correctly on editor page yet, will be added once sx-subgraph indexes those.**

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/227386498-4f6488d2-4b06-46da-ad32-f0343465b0e8.png" width="800" />


## Test plan

- Create space with proposal validation
- Propose **This will only work if your voting strategies for voting are the same for proposal validation, if not check below how to hard code it.**

Override strategies here to match your (indexes has to be correct, same as when deployed):
https://github.com/snapshot-labs/sx-ui/blob/752d0027739e2c64d81c2c5dd2d79162aba6818a/src/networks/evm/actions.ts#L128
```js
strategies: [
  {
    index: 0,
    address: '0xeba53160c146cbf77a150e9a218d4c2de5db6b51'
  },
  {
    index: 1,
    address: '0x343baf4b44f7f79b14301cfa8068e3f8be7470de'
  }
],
 ```