### PR TITLE
fix: limit proposal link width

### DIFF
--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -33,7 +33,7 @@ async function handleVoteClick(choice: Choice) {
               id: `${proposal.network}:${proposal.space.id}`
             }
           }"
-          class="block"
+          class="block max-w-fit"
         >
           <h3 v-text="proposal.title || `Proposal #${proposal.proposal_id}`" />
         </router-link>


### PR DESCRIPTION
## Summary

Previously it was possible to click on Proposal's component background to be navigated to proposal (only top half worked), and it was super confusing.

This PR limits clickable area to only proposal title.