### PR TITLE
fix: shift sticky to avoid gap

### DIFF
--- a/src/components/Label.vue
+++ b/src/components/Label.vue
@@ -9,7 +9,7 @@ defineProps({
   <h4
     class="eyebrow border-b py-2 px-4 text-skin-text"
     :class="{
-      'sticky top-[72px] bg-skin-bg': sticky
+      'sticky top-[71.5px] bg-skin-bg': sticky
     }"
     v-text="label"
   />

--- a/src/components/Label.vue
+++ b/src/components/Label.vue
@@ -9,7 +9,7 @@ defineProps({
   <h4
     class="eyebrow border-b py-2 px-4 text-skin-text"
     :class="{
-      'sticky top-[71.5px] bg-skin-bg': sticky
+      'sticky top-[71px] lg:top-[72px] bg-skin-bg': sticky
     }"
     v-text="label"
   />


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/506

Sticky is [bugy](https://twitter.com/youyuxi/status/1436026679059787781?lang=en) and not following screen exactly, which can cause some gaps.

Using workaround to shift it further up to avoid it.