### PR TITLE
chore: change sx-api URL

### DIFF
--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -1,6 +1,6 @@
 import { shorten } from '@/helpers/utils';
 
-export const API_URL = 'https://testnet-api-1.snapshotx.xyz';
+export const API_URL = 'https://api-1.snapshotx.xyz';
 
 export const SUPPORTED_AUTHENTICATORS = {
   '0x64cce9272197eba6353f5bbf060e097e516b411e66e83a9cf5910a08697df14': true


### PR DESCRIPTION
Change SX-API URL from https://testnet-api-1.snapshotx.xyz to https://api-1.snapshotx.xyz to match with UI.