### PR TITLE
fix: default to null for wallet in edit space modal

### DIFF
--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -11,8 +11,8 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   twitter: '',
   github: '',
   discord: '',
-  walletNetwork: 'gor',
-  walletAddress: ''
+  walletNetwork: null,
+  walletAddress: null
 };
 
 const props = defineProps<{
@@ -59,8 +59,13 @@ watch(
     form.twitter = props.space.twitter;
 
     const [walletNetwork, walletAddress] = props.space.wallet.split(':');
-    form.walletNetwork = walletNetwork as NetworkID;
-    form.walletAddress = walletAddress;
+    if (walletNetwork && walletAddress) {
+      form.walletNetwork = walletNetwork as NetworkID;
+      form.walletAddress = walletAddress;
+    } else {
+      form.walletNetwork = null;
+      form.walletAddress = null;
+    }
   }
 );
 </script>


### PR DESCRIPTION
## Summary

Currently when opening edit space modal for space without treasury configured it will show wallet address field, even though it shouldn't do that.

That's because we are defaulting to '' and when decoding we might put undefined values into them as well.

This PR changes those fields to default to null.

## Test plan

- Go to space you control without treasury (create one or edit existing one if you don't have one).
- Click on edit space button.
- Treasury address field is invisible when No treasury is selected.