### PR TITLE
feat: link to execution transaction on Proposal page

### DIFF
--- a/src/components/Block/Actions.vue
+++ b/src/components/Block/Actions.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useActions } from '@/composables/useActions';
 import { getNetwork } from '@/networks';
+import { shorten } from '@/helpers/utils';
 import type { Proposal as ProposalType } from '@/types';
 
 const props = defineProps<{ proposal: ProposalType }>();
@@ -13,6 +14,11 @@ const finalizeProposalSending = ref(false);
 const receiveProposalSending = ref(false);
 const executeTransactionsSending = ref(false);
 const executeQueuedProposalSending = ref(false);
+
+const network = computed(() => getNetwork(props.proposal.network));
+const baseNetwork = computed(() =>
+  network.value.baseNetworkId ? getNetwork(network.value.baseNetworkId) : network.value
+);
 
 async function handleFinalizeProposalClick() {
   finalizeProposalSending.value = true;
@@ -57,10 +63,17 @@ async function handleExecuteQueuedProposalClick() {
 
 <template>
   <div class="x-block !border-x rounded-lg p-3">
-    <div v-if="proposal.completed">Proposal has been already executed</div>
+    <div v-if="proposal.execution_tx">
+      Proposal has been already executed at
+      <a
+        target="_blank"
+        :href="baseNetwork.helpers.getExplorerUrl(proposal.execution_tx, 'transaction')"
+        v-text="shorten(proposal.execution_tx)"
+      />
+    </div>
     <template v-else>
       <UiButton
-        v-if="getNetwork(proposal.network).hasReceive"
+        v-if="network.hasReceive"
         class="block mb-2 w-full flex justify-center items-center"
         :loading="finalizeProposalSending"
         @click="handleFinalizeProposalClick"
@@ -69,7 +82,7 @@ async function handleExecuteQueuedProposalClick() {
         Finalize proposal
       </UiButton>
       <UiButton
-        v-if="getNetwork(proposal.network).hasReceive"
+        v-if="network.hasReceive"
         class="block mb-2 w-full flex justify-center items-center"
         :loading="receiveProposalSending"
         @click="handleReceiveProposalClick"

--- a/src/components/Block/Actions.vue
+++ b/src/components/Block/Actions.vue
@@ -66,10 +66,13 @@ async function handleExecuteQueuedProposalClick() {
     <div v-if="proposal.execution_tx">
       Proposal has been already executed at
       <a
+        class="inline-flex items-center"
         target="_blank"
         :href="baseNetwork.helpers.getExplorerUrl(proposal.execution_tx, 'transaction')"
-        v-text="shorten(proposal.execution_tx)"
-      />
+      >
+        {{ shorten(proposal.execution_tx) }}
+        <IH-external-link class="inline-block ml-1"
+      /></a>
     </div>
     <template v-else>
       <UiButton

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -36,6 +36,7 @@ export const PROPOSAL_QUERY = gql`
       strategies_params
       created
       tx
+      execution_tx
       vote_count
       executed
       completed
@@ -86,6 +87,7 @@ export const PROPOSALS_QUERY = gql`
       strategies_params
       created
       tx
+      execution_tx
       vote_count
       executed
       completed
@@ -147,6 +149,7 @@ export const PROPOSALS_SUMMARY_QUERY = gql`
     strategies_params
     created
     tx
+    execution_tx
     vote_count
     executed
     completed

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export type Proposal = {
   strategies_params: any[];
   created: number;
   tx: string;
+  execution_tx: string | null;
   vote_count: number;
   has_started: boolean;
   has_execution_window_opened: boolean;


### PR DESCRIPTION
## Summary

Depends on https://github.com/snapshot-labs/sx-ui/pull/524

Closes: https://github.com/snapshot-labs/sx-ui/issues/529

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/228265773-bbfdbf23-dc74-4b28-aa34-c2e5a1a00f64.png" width="600" />


## Test plan

- Create and execute proposal (for timelock you will need to wait for "Execute queued proposal" button).
- Or check existing: http://localhost:8080/#/gor:0x818287662201bea70095bccc397b4ed69c142349/proposal/3
- Refresh page, it links to execution tx (the one that moved funds).