### PR TITLE
feat: add _c helper for formatting currencies

### DIFF
--- a/src/components/VotingPowerIndicator.vue
+++ b/src/components/VotingPowerIndicator.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { useWeb3 } from '@/composables/useWeb3';
-import { _n } from '@/helpers/utils';
+import { _c } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 import { VotingPower } from '@/networks/types';
 
@@ -34,7 +34,7 @@ const decimals = computed(() =>
       @click="modalOpen = true"
     >
       <IH-lightning-bolt class="inline-block" />
-      <span class="ml-1">{{ _n(Number(votingPower) / 10 ** decimals) }}</span>
+      <span class="ml-1">{{ _c(votingPower, decimals) }}</span>
     </UiButton>
     <teleport to="#modal">
       <ModalVotingPower

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -68,8 +68,9 @@ export function _n(value: any, notation: 'standard' | 'compact' = 'standard') {
 }
 
 export function _c(value: string | bigint, decimals = 18) {
-  const parsed = Number(value) / 10 ** decimals;
-  if (parsed < 0.000001) return `~0`;
+  const raw = BigInt(value);
+  const parsed = Number(raw) / 10 ** decimals;
+  if (raw !== 0n && parsed < 0.000001) return `~0`;
 
   const formatter = new Intl.NumberFormat('en', { maximumFractionDigits: 6 });
   return formatter.format(parsed);

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -67,6 +67,14 @@ export function _n(value: any, notation: 'standard' | 'compact' = 'standard') {
   return formatter.format(value);
 }
 
+export function _c(value: string | bigint, decimals = 18) {
+  const parsed = Number(value) / 10 ** decimals;
+  if (parsed < 0.000001) return `~0`;
+
+  const formatter = new Intl.NumberFormat('en', { maximumFractionDigits: 6 });
+  return formatter.format(parsed);
+}
+
 export function jsonParse(input, fallback?) {
   if (typeof input !== 'string') {
     return fallback || {};

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -70,9 +70,9 @@ export function _n(value: any, notation: 'standard' | 'compact' = 'standard') {
 export function _c(value: string | bigint, decimals = 18) {
   const raw = BigInt(value);
   const parsed = Number(raw) / 10 ** decimals;
-  if (raw !== 0n && parsed < 0.000001) return `~0`;
+  if (raw !== 0n && parsed < 0.001) return `~0`;
 
-  const formatter = new Intl.NumberFormat('en', { maximumFractionDigits: 6 });
+  const formatter = new Intl.NumberFormat('en', { maximumFractionDigits: 3 });
   return formatter.format(parsed);
 }
 

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { onMounted, computed, ref, Ref } from 'vue';
 import { useRouter } from 'vue-router';
-import { formatUnits } from '@ethersproject/units';
 import { useClipboard } from '@vueuse/core';
 import { useBalances } from '@/composables/useBalances';
 import { useEditor } from '@/composables/useEditor';
 import { useNfts } from '@/composables/useNfts';
 import { useTreasury } from '@/composables/useTreasury';
-import { _n, shorten } from '@/helpers/utils';
+import { _n, _c, shorten } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
 import { ETH_CONTRACT } from '@/helpers/constants';
 import type { Token } from '@/helpers/alchemy';
@@ -145,7 +144,7 @@ onMounted(() => {
             <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px]">
               <h4
                 class="text-skin-link"
-                v-text="_n(formatUnits(asset.tokenBalance || 0, asset.decimals || 0))"
+                v-text="_c(asset.tokenBalance || 0n, asset.decimals || 0)"
               />
               <div v-if="asset.price" class="text-sm" v-text="`$${_n(asset.price)}`" />
             </div>


### PR DESCRIPTION
This PR adds `_c` helper for currency formatting, that specifies maximum number of decimal digits and displays `~0` in case number would is too small.

Closes: https://github.com/snapshot-labs/sx-ui/issues/528

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/228673501-cdc4c739-ed4c-4137-b660-686989a27c8a.png" width="400" />

## Test plan

- Set your VP to small amount (`1n`) here: https://github.com/snapshot-labs/sx-ui/blob/2753c894aa2065e50f9430833f0ac3a743d065b9/src/components/VotingPowerIndicator.vue#L37
- It displays as ~0.