### PR TITLE
feat: add voting power symbols

### DIFF
--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -66,8 +66,8 @@ const definition = computed(() => {
       votingPowerSymbol: {
         type: 'string',
         maxLength: 6,
-        title: 'Voting Power symbol',
-        examples: ['VP']
+        title: 'Voting power symbol',
+        examples: ['e.g. VP']
       },
       walletNetwork: {
         type: ['string', 'null'],

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -63,6 +63,12 @@ const definition = computed(() => {
         title: 'Discord',
         examples: ['Discord handle']
       },
+      votingPowerSymbol: {
+        type: 'string',
+        maxLength: 6,
+        title: 'Voting Power symbol',
+        examples: ['VP']
+      },
       walletNetwork: {
         type: ['string', 'null'],
         enum: [null, ...enabledNetworks],

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -11,6 +11,7 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   twitter: '',
   github: '',
   discord: '',
+  votingPowerSymbol: '',
   walletNetwork: null,
   walletAddress: null
 };
@@ -57,6 +58,7 @@ watch(
     form.github = props.space.github;
     form.discord = props.space.discord;
     form.twitter = props.space.twitter;
+    form.votingPowerSymbol = props.space.voting_power_symbol;
 
     const [walletNetwork, walletAddress] = props.space.wallet.split(':');
     if (walletNetwork && walletAddress) {

--- a/src/components/Modal/VotingPower.vue
+++ b/src/components/Modal/VotingPower.vue
@@ -4,7 +4,6 @@ import { getNetwork } from '@/networks';
 import { _n, shorten } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 import { VotingPower } from '@/networks/types';
-import voting from '@snapshot-labs/snapshot.js/src/voting';
 
 const props = defineProps<{
   open: boolean;

--- a/src/components/Modal/VotingPower.vue
+++ b/src/components/Modal/VotingPower.vue
@@ -47,8 +47,9 @@ const baseNetwork = computed(() =>
             {{ _n(Number(strategy.value) / 10 ** finalDecimals) }} {{ votingPowerSymbol }}
           </div>
         </div>
-        <div v-if="strategy.token" class="flex justify-between">
+        <div class="flex justify-between">
           <a
+            v-if="strategy.token"
             :href="baseNetwork.helpers.getExplorerUrl(strategy.token, 'contract')"
             target="_blank"
             class="flex items-center text-skin-text"
@@ -57,6 +58,7 @@ const baseNetwork = computed(() =>
             {{ shorten(strategy.token) }}
             <IH-external-link class="ml-1" />
           </a>
+          <div v-else />
           <div>
             {{ _n(Number(strategy.value) / 10 ** strategy.decimals) }}
             {{ strategy.symbol || 'units' }}

--- a/src/components/Modal/VotingPower.vue
+++ b/src/components/Modal/VotingPower.vue
@@ -56,7 +56,10 @@ const baseNetwork = computed(() =>
             {{ shorten(strategy.token) }}
             <IH-external-link class="ml-1" />
           </a>
-          <div>{{ _n(Number(strategy.value) / 10 ** strategy.decimals) }} units</div>
+          <div>
+            {{ _n(Number(strategy.value) / 10 ** strategy.decimals) }}
+            {{ strategy.symbol || 'units' }}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Modal/VotingPower.vue
+++ b/src/components/Modal/VotingPower.vue
@@ -4,10 +4,12 @@ import { getNetwork } from '@/networks';
 import { _n, shorten } from '@/helpers/utils';
 import { NetworkID } from '@/types';
 import { VotingPower } from '@/networks/types';
+import voting from '@snapshot-labs/snapshot.js/src/voting';
 
 const props = defineProps<{
   open: boolean;
   networkId: NetworkID;
+  votingPowerSymbol: string;
   votingPowers: VotingPower[];
   finalDecimals: number;
 }>();
@@ -43,7 +45,7 @@ const baseNetwork = computed(() =>
             v-text="network.constants.STRATEGIES[strategy.address]"
           />
           <div class="text-skin-link">
-            {{ _n(Number(strategy.value) / 10 ** finalDecimals) }} VP
+            {{ _n(Number(strategy.value) / 10 ** finalDecimals) }} {{ votingPowerSymbol }}
           </div>
         </div>
         <div v-if="strategy.token" class="flex justify-between">

--- a/src/components/VotingPowerIndicator.vue
+++ b/src/components/VotingPowerIndicator.vue
@@ -20,6 +20,15 @@ const votingPower = computed(() => props.votingPowers.reduce((acc, b) => acc + b
 const decimals = computed(() =>
   Math.max(...props.votingPowers.map(votingPower => votingPower.decimals), 0)
 );
+const formattedVotingPower = computed(() => {
+  const value = _c(votingPower.value, decimals.value);
+
+  if (props.votingPowerSymbol) {
+    return `${value} ${props.votingPowerSymbol}`;
+  }
+
+  return value;
+});
 </script>
 
 <template>
@@ -35,7 +44,7 @@ const decimals = computed(() =>
       @click="modalOpen = true"
     >
       <IH-lightning-bolt class="inline-block" />
-      <span class="ml-1">{{ _c(votingPower, decimals) }} {{ votingPowerSymbol }}</span>
+      <span class="ml-1">{{ formattedVotingPower }}</span>
     </UiButton>
     <teleport to="#modal">
       <ModalVotingPower

--- a/src/components/VotingPowerIndicator.vue
+++ b/src/components/VotingPowerIndicator.vue
@@ -8,6 +8,7 @@ import { VotingPower } from '@/networks/types';
 const props = defineProps<{
   networkId: NetworkID;
   loading: boolean;
+  votingPowerSymbol: string;
   votingPowers: VotingPower[];
 }>();
 
@@ -34,12 +35,13 @@ const decimals = computed(() =>
       @click="modalOpen = true"
     >
       <IH-lightning-bolt class="inline-block" />
-      <span class="ml-1">{{ _c(votingPower, decimals) }}</span>
+      <span class="ml-1">{{ _c(votingPower, decimals) }} {{ votingPowerSymbol }}</span>
     </UiButton>
     <teleport to="#modal">
       <ModalVotingPower
         :open="modalOpen"
         :network-id="networkId"
+        :voting-power-symbol="votingPowerSymbol"
         :voting-powers="props.votingPowers"
         :final-decimals="decimals"
         @close="modalOpen = false"

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -12,6 +12,7 @@ describe('utils', () => {
         github: 'snapshot-labs',
         twitter: 'SnapshotLabs',
         discord: 'snapshot',
+        votingPowerSymbol: 'VOTE',
         walletNetwork: 'gor',
         walletAddress: '0x000000000000000000000000000000000000dead'
       });
@@ -21,6 +22,7 @@ describe('utils', () => {
         description: 'Test description',
         external_url: 'https://test.com',
         properties: {
+          voting_power_symbol: 'VOTE',
           github: 'snapshot-labs',
           twitter: 'SnapshotLabs',
           discord: 'snapshot',

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -203,6 +203,7 @@ export function createErc1155Metadata(
     description: metadata.description,
     external_url: metadata.externalUrl,
     properties: {
+      voting_power_symbol: metadata.votingPowerSymbol,
       github: metadata.github,
       twitter: metadata.twitter,
       discord: metadata.discord,

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -9,6 +9,11 @@ export const PROPOSAL_QUERY = gql`
         id
         authenticators
         strategies_metadata
+        strategies_parsed_metadata {
+          decimals
+          symbol
+          token
+        }
         executors
         executors_types
       }
@@ -60,6 +65,11 @@ export const PROPOSALS_QUERY = gql`
         quorum
         authenticators
         strategies_metadata
+        strategies_parsed_metadata {
+          decimals
+          symbol
+          token
+        }
         executors
         executors_types
       }
@@ -214,6 +224,11 @@ export const SPACE_QUERY = gql`
       strategies
       strategies_params
       strategies_metadata
+      strategies_parsed_metadata {
+        decimals
+        symbol
+        token
+      }
       authenticators
       executors
       executors_types
@@ -246,6 +261,11 @@ export const SPACES_QUERY = gql`
       strategies
       strategies_params
       strategies_metadata
+      strategies_parsed_metadata {
+        decimals
+        symbol
+        token
+      }
       authenticators
       executors
       executors_types

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -7,6 +7,7 @@ export const PROPOSAL_QUERY = gql`
       proposal_id
       space {
         id
+        voting_power_symbol
         authenticators
         strategies_metadata
         strategies_parsed_metadata {
@@ -62,6 +63,7 @@ export const PROPOSALS_QUERY = gql`
       proposal_id
       space {
         id
+        voting_power_symbol
         quorum
         authenticators
         strategies_metadata
@@ -212,6 +214,7 @@ export const SPACE_QUERY = gql`
       github
       twitter
       discord
+      voting_power_symbol
       wallet
       controller
       voting_delay
@@ -249,6 +252,7 @@ export const SPACES_QUERY = gql`
       github
       twitter
       discord
+      voting_power_symbol
       wallet
       controller
       voting_delay

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -69,7 +69,7 @@ export const EDITOR_PROPOSAL_VALIDATIONS = [
   {
     address: '0x03d512E0165d6B53ED2753Df2f3184fBd2b52E48',
     type: 'VotingPower',
-    name: 'Voting Power',
+    name: 'Voting power',
     validate: (params: Record<string, any>) => {
       return params?.strategies?.length > 0;
     },
@@ -148,7 +148,7 @@ export const EDITOR_VOTING_STRATEGIES = [
           type: 'string',
           maxLength: 6,
           title: 'Symbol',
-          examples: ['COMP']
+          examples: ['e.g. COMP']
         }
       }
     }
@@ -188,7 +188,7 @@ export const EDITOR_VOTING_STRATEGIES = [
           type: 'string',
           maxLength: 6,
           title: 'Symbol',
-          examples: ['COMP']
+          examples: ['e.g. COMP']
         }
       }
     }

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -119,7 +119,14 @@ export const EDITOR_VOTING_STRATEGIES = [
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
-    generateMetadata: (params: Record<string, any>) => `0x${params.decimals.toString(16)}`,
+    generateMetadata: (params: Record<string, any>) => ({
+      name: 'Delegated Comp Token',
+      properties: {
+        symbol: params.symbol,
+        decimals: parseInt(params.decimals),
+        token: params.contractAddress
+      }
+    }),
     paramsDefinition: {
       type: 'object',
       title: 'Params',
@@ -136,6 +143,12 @@ export const EDITOR_VOTING_STRATEGIES = [
           type: 'integer',
           title: 'Decimals',
           examples: ['18']
+        },
+        symbol: {
+          type: 'string',
+          maxLength: 6,
+          title: 'Symbol',
+          examples: ['COMP']
         }
       }
     }
@@ -146,7 +159,14 @@ export const EDITOR_VOTING_STRATEGIES = [
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
-    generateMetadata: (params: Record<string, any>) => `0x${params.decimals.toString(16)}`,
+    generateMetadata: (params: Record<string, any>) => ({
+      name: 'Delegated Comp Token',
+      properties: {
+        symbol: params.symbol,
+        decimals: parseInt(params.decimals),
+        token: params.contractAddress
+      }
+    }),
     paramsDefinition: {
       type: 'object',
       title: 'Params',
@@ -163,6 +183,12 @@ export const EDITOR_VOTING_STRATEGIES = [
           type: 'integer',
           title: 'Decimals',
           examples: ['18']
+        },
+        symbol: {
+          type: 'string',
+          maxLength: 6,
+          title: 'Symbol',
+          examples: ['COMP']
         }
       }
     }

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -111,7 +111,27 @@ export const EDITOR_VOTING_STRATEGIES = [
   {
     address: '0xeba53160c146cbf77a150e9a218d4c2de5db6b51',
     name: 'Vanilla',
-    paramsDefinition: null
+    generateMetadata: (params: Record<string, any>) => ({
+      name: 'Vanilla',
+      properties: {
+        symbol: params.symbol,
+        decimals: 1
+      }
+    }),
+    paramsDefinition: {
+      type: 'object',
+      title: 'Params',
+      additionalProperties: false,
+      required: [],
+      properties: {
+        symbol: {
+          type: 'string',
+          maxLength: 6,
+          title: 'Symbol',
+          examples: ['e.g. VP']
+        }
+      }
+    }
   },
   {
     address: '0x343baf4b44f7f79b14301cfa8068e3f8be7470de',

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -12,7 +12,7 @@ import type { Provider } from 'starknet';
 import type { Web3Provider } from '@ethersproject/providers';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
 import type { NetworkActions, NetworkHelpers, StrategyConfig, VotingPower } from '@/networks/types';
-import type { Space, SpaceMetadata, Proposal } from '@/types';
+import type { Space, SpaceMetadata, StrategyParsedMetadata, Proposal } from '@/types';
 
 const VANILLA_EXECUTOR = '0x4ecc83848a519cc22b0d0ffb70e65ec8dde85d3d13439eff7145d4063cf6b4d';
 const ZODIAC_EXECUTOR = '0x21dda40770f4317582251cffd5a0202d6b223dc167e5c8db25dc887d11eba81';
@@ -209,7 +209,7 @@ export function createActions(
     getVotingPower: async (
       strategiesAddresses: string[],
       strategiesParams: any[],
-      strategiesMetadata: string[],
+      strategiesMetadata: StrategyParsedMetadata[],
       voterAddress: string,
       timestamp: number
     ): Promise<VotingPower[]> => {
@@ -227,7 +227,7 @@ export function createActions(
       return Promise.all(
         strategiesAddresses.map(async (address, i) => {
           const strategy = getStarknetStrategy(address, defaultNetwork);
-          if (!strategy) return { address, value: 0n, decimals: 0 };
+          if (!strategy) return { address, value: 0n, decimals: 0, token: null, symbol: 'VP' };
 
           const value = await strategy.getVotingPower(
             address,
@@ -240,8 +240,8 @@ export function createActions(
             }
           );
 
-          const token = strategy.type === 'singleSlotProof' ? params2D[i][0] : undefined;
-          return { address, value, decimals: 0, token };
+          const token = strategy.type === 'singleSlotProof' ? params2D[i][0] : null;
+          return { address, value, decimals: 0, token, symbol: 'VP' };
         })
       );
     },

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -227,7 +227,7 @@ export function createActions(
       return Promise.all(
         strategiesAddresses.map(async (address, i) => {
           const strategy = getStarknetStrategy(address, defaultNetwork);
-          if (!strategy) return { address, value: 0n, decimals: 0, token: null, symbol: 'VP' };
+          if (!strategy) return { address, value: 0n, decimals: 0, token: null, symbol: '' };
 
           const value = await strategy.getVotingPower(
             address,
@@ -241,7 +241,7 @@ export function createActions(
           );
 
           const token = strategy.type === 'singleSlotProof' ? params2D[i][0] : null;
-          return { address, value, decimals: 0, token, symbol: 'VP' };
+          return { address, value, decimals: 0, token, symbol: '' };
         })
       );
     },

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -1,7 +1,16 @@
 import type { Web3Provider } from '@ethersproject/providers';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding';
-import type { Space, SpaceMetadata, Proposal, Vote, User, Choice, NetworkID } from '@/types';
+import type {
+  Space,
+  SpaceMetadata,
+  Proposal,
+  Vote,
+  User,
+  Choice,
+  NetworkID,
+  StrategyParsedMetadata
+} from '@/types';
 
 export type PaginationOpts = { limit: number; skip?: number };
 export type Connector =
@@ -20,7 +29,7 @@ export type StrategyTemplate = {
   validate?: (params: Record<string, any>) => boolean;
   generateSummary?: (params: Record<string, any>) => string;
   generateParams?: (params: Record<string, any>) => any[];
-  generateMetadata?: (params: Record<string, any>) => string;
+  generateMetadata?: (params: Record<string, any>) => any;
   deploy?: (
     client: any,
     signer: Signer,
@@ -39,7 +48,8 @@ export type VotingPower = {
   address: string;
   value: bigint;
   decimals: number;
-  token?: string;
+  token: string | null;
+  symbol: string;
 };
 
 // TODO: make sx.js accept Signer instead of Web3Provider | Wallet
@@ -77,7 +87,7 @@ export type NetworkActions = {
   getVotingPower(
     strategiesAddresses: string[],
     strategiesParams: any[],
-    strategiesMetadata: string[],
+    strategiesMetadata: StrategyParsedMetadata[],
     voterAddress: string,
     timestamp: number
   ): Promise<VotingPower[]>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,12 @@ export type SpaceSettings = {
   quorum?: string;
 };
 
+export type StrategyParsedMetadata = {
+  decimals: number;
+  symbol: string;
+  token: string | null;
+};
+
 export type Space = {
   id: string;
   network: NetworkID;
@@ -44,6 +50,7 @@ export type Space = {
   strategies: string[];
   strategies_params: any[];
   strategies_metadata: string[];
+  strategies_parsed_metadata: StrategyParsedMetadata[];
   authenticators: string[];
   executors: string[];
   executors_types: string[];
@@ -63,6 +70,7 @@ export type Proposal = {
     strategies_metadata: string[];
     executors: string[];
     executors_types: string[];
+    strategies_parsed_metadata: StrategyParsedMetadata[];
   };
   author: {
     id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type SpaceMetadata = {
   twitter: string;
   github: string;
   discord: string;
+  votingPowerSymbol: string;
   walletNetwork: NetworkID | null;
   walletAddress: string | null;
 };
@@ -38,6 +39,7 @@ export type Space = {
   twitter: string;
   github: string;
   discord: string;
+  voting_power_symbol: string;
   wallet: string;
   controller: string;
   voting_delay: number;
@@ -66,6 +68,7 @@ export type Proposal = {
   quorum: number;
   space: {
     id: string;
+    voting_power_symbol: string;
     authenticators: string[];
     strategies_metadata: string[];
     executors: string[];

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -72,7 +72,7 @@ const metadataForm: SpaceMetadata = reactive(
     twitter: '',
     github: '',
     discord: '',
-    votingPowerSymbol: 'VP',
+    votingPowerSymbol: '',
     walletNetwork: null,
     walletAddress: null
   })

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -72,6 +72,7 @@ const metadataForm: SpaceMetadata = reactive(
     twitter: '',
     github: '',
     discord: '',
+    votingPowerSymbol: 'VP',
     walletNetwork: null,
     walletAddress: null
   })

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -56,7 +56,7 @@ async function getVotingPower() {
     votingPowers.value = await network.actions.getVotingPower(
       proposal.value.strategies,
       proposal.value.strategies_params,
-      proposal.value.space.strategies_metadata,
+      proposal.value.space.strategies_parsed_metadata,
       web3.value.account,
       proposal.value.snapshot
     );

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -119,6 +119,7 @@ watch([() => web3.value.account, proposal], () => getVotingPower());
             <VotingPowerIndicator
               :network-id="networkId as NetworkID"
               :loading="loadingVotingPower"
+              :voting-power-symbol="proposal.space.voting_power_symbol"
               :voting-powers="votingPowers"
               class="mr-2"
             />

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -70,6 +70,7 @@ watch(
         <VotingPowerIndicator
           :network-id="space.network"
           :loading="loadingVotingPower"
+          :voting-power-symbol="space.voting_power_symbol"
           :voting-powers="votingPowers"
         />
         <router-link :to="{ name: 'editor' }">

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -38,7 +38,7 @@ async function getVotingPower() {
     votingPowers.value = await network.actions.getVotingPower(
       props.space.strategies,
       props.space.strategies_params,
-      props.space.strategies_metadata,
+      props.space.strategies_parsed_metadata,
       web3.value.account,
       Math.floor(Date.now() / 1000)
     );


### PR DESCRIPTION
This PR adds symbols for voting power strategies and global voting power symbol (for space).

Closes: https://github.com/snapshot-labs/sx-ui/issues/501

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/229635106-0f01f2ae-bf4f-4c7d-b112-910d378bcacb.png" width="300" />
<img src="https://user-images.githubusercontent.com/1968722/229635150-a7508e16-e46d-451c-92de-b07f9f377cba.png" width="600" />


## Test plan

- Create space with custom symbol and with voting strategies that have their own symbol too.
- Go to Proposals page, you can see proper units used.
