### PR TITLE
feat: add confirmation screen when deploying space

### DIFF
--- a/src/components/Block/CreationConfirmation.vue
+++ b/src/components/Block/CreationConfirmation.vue
@@ -29,10 +29,16 @@ const steps = computed(() => {
   const dependenciesSteps = props.executionStrategies.filter(strategy => strategy.deploy);
 
   return [
-    ...dependenciesSteps.map((_, i) => ({
-      id: `DEPLOYING_DEPS_${i}`,
-      title: 'Deploying dependency'
-    })),
+    ...dependenciesSteps.map((config, i) => {
+      const title = config.type
+        ? `Deploying ${network.value.constants.EXECUTORS[config.type]} execution strategy`
+        : 'Deploying dependency';
+
+      return {
+        id: `DEPLOYING_DEPS_${i}`,
+        title
+      };
+    }),
     {
       id: 'DEPLOYING_SPACE',
       title: 'Deploying space'

--- a/src/components/Block/CreationConfirmation.vue
+++ b/src/components/Block/CreationConfirmation.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { shorten } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
+import { StrategyConfig } from '@/networks/types';
+import { NetworkID, SpaceMetadata, SpaceSettings } from '@/types';
+
+const props = defineProps<{
+  networkId: NetworkID;
+  salt: string;
+  predictedSpaceAddress: string | null;
+  metadata: SpaceMetadata;
+  settings: SpaceSettings;
+  authenticators: StrategyConfig[];
+  validationStrategy: StrategyConfig;
+  votingStrategies: StrategyConfig[];
+  executionStrategies: StrategyConfig[];
+  controller: string;
+}>();
+
+const { deployDependency, createSpace } = useActions();
+
+const currentStep = ref(0);
+const completed = ref(false);
+const failed = ref(false);
+const txIds = ref({});
+
+const network = computed(() => getNetwork(props.networkId));
+const steps = computed(() => {
+  const dependenciesSteps = props.executionStrategies.filter(strategy => strategy.deploy);
+
+  return [
+    ...dependenciesSteps.map((_, i) => ({
+      id: `DEPLOYING_DEPS_${i}`,
+      title: 'Deploying dependency'
+    })),
+    {
+      id: 'DEPLOYING_SPACE',
+      title: 'Deploying space'
+    }
+  ];
+});
+
+async function deploy() {
+  const dependenciesSteps = props.executionStrategies.filter(strategy => strategy.deploy);
+  const executionStrategies = [] as StrategyConfig[];
+
+  for (let i = 0; i < dependenciesSteps.length; i++) {
+    const strategy = dependenciesSteps[i];
+
+    try {
+      const result = await deployDependency(
+        props.networkId,
+        props.controller,
+        props.predictedSpaceAddress,
+        strategy
+      );
+
+      if (!result) {
+        failed.value = true;
+        return;
+      }
+
+      const { address, txId } = result;
+
+      txIds.value[`DEPLOYING_DEPS_${i}`] = txId;
+      const confirmedReceipt = await network.value.helpers.waitForTransaction(txId);
+      if (confirmedReceipt.status === 0) throw new Error('Transaction failed');
+
+      executionStrategies.push({
+        ...strategy,
+        deploy: undefined,
+        address
+      });
+      currentStep.value = currentStep.value + 1;
+    } catch {
+      failed.value = true;
+      return;
+    }
+  }
+
+  try {
+    const result = await createSpace(
+      props.networkId,
+      props.salt,
+      props.metadata,
+      props.settings,
+      props.authenticators,
+      props.validationStrategy,
+      props.votingStrategies,
+      executionStrategies,
+      props.controller
+    );
+
+    if (!result) {
+      failed.value = true;
+      return;
+    }
+
+    txIds.value['DEPLOYING_SPACE'] = result;
+
+    const confirmedReceipt = await network.value.helpers.waitForTransaction(result);
+    if (confirmedReceipt.status === 0) throw new Error('Transaction failed');
+
+    completed.value = true;
+    currentStep.value = steps.value.length;
+  } catch {
+    failed.value = true;
+  }
+}
+
+onMounted(() => deploy());
+</script>
+
+<template>
+  <div class="pt-5 max-w-[50rem] mx-auto px-4">
+    <template v-if="completed">
+      <h1>Space deployed</h1>
+      <div>
+        Soon it will be available
+        <router-link
+          :to="{
+            name: 'space-overview',
+            params: { id: `${networkId}:${predictedSpaceAddress?.toLowerCase()}` }
+          }"
+          text="here"
+        />.
+      </div>
+    </template>
+    <template v-else-if="failed">
+      <h1>Space deployment failed</h1>
+      <div>Please try again later.</div>
+    </template>
+    <template v-else>
+      <h1>Space is currently being deployed</h1>
+      <div>Do not refresh this page until process is complete.</div>
+    </template>
+
+    <div class="flex flex-col mt-4">
+      <div v-for="(step, i) in steps" :key="step.id" class="flex items-center gap-4 mb-3 last:mb-0">
+        <div>
+          <IH-check v-if="i < currentStep" class="text-green" />
+          <IH-clock v-else-if="i > currentStep" />
+          <template v-else>
+            <UiLoading v-if="!failed" />
+            <IH-exclamation-circle v-else class="text-red" />
+          </template>
+        </div>
+        <div>
+          <h4 v-text="step.title" />
+          <a
+            v-if="txIds[step.id]"
+            class="inline-flex items-center"
+            target="_blank"
+            :href="network.helpers.getExplorerUrl(txIds[step.id], 'transaction')"
+          >
+            {{ shorten(txIds[step.id]) }}
+            <IH-external-link class="inline-block ml-1" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -24,9 +24,11 @@ export function createActions(
 
   return {
     async predictSpaceAddress(web3: Web3Provider, { salt }) {
+      await verifyNetwork(web3, chainId);
+
       return client.predictSpaceAddress({ signer: web3.getSigner(), salt });
     },
-    deployDependency(
+    async deployDependency(
       web3: Web3Provider,
       params: {
         controller: string;
@@ -34,6 +36,8 @@ export function createActions(
         strategy: StrategyConfig;
       }
     ) {
+      await verifyNetwork(web3, chainId);
+
       if (!params.strategy.deploy) {
         throw new Error('This strategy is not deployable');
       }

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -45,7 +45,10 @@ export const STRATEGIES = {
   '0xf50bf15e9fe61e27625a4ecdfc23211297e8be85': 'Whitelist'
 };
 
-export const EXECUTORS = {};
+export const EXECUTORS = {
+  SimpleQuorumAvatar: 'Avatar',
+  SimpleQuorumTimelock: 'Timelock'
+};
 
 export const EDITOR_AUTHENTICATORS = [
   {

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -182,8 +182,8 @@ export const EDITOR_EXECUTION_STRATEGIES = [
       controller: string,
       spaceAddress: string,
       params: Record<string, any>
-    ): Promise<string> => {
-      const { address } = await client.deployAvatarExecution({
+    ): Promise<{ address: string; txId: string }> => {
+      return client.deployAvatarExecution({
         signer,
         params: {
           controller,
@@ -192,8 +192,6 @@ export const EDITOR_EXECUTION_STRATEGIES = [
           quorum: BigInt(params.quorum)
         }
       });
-
-      return address;
     },
     paramsDefinition: {
       type: 'object',
@@ -226,8 +224,8 @@ export const EDITOR_EXECUTION_STRATEGIES = [
       controller: string,
       spaceAddress: string,
       params: Record<string, any>
-    ): Promise<string> => {
-      const { address } = await client.deployTimelockExecution({
+    ): Promise<{ address: string; txId: string }> => {
+      return client.deployTimelockExecution({
         signer,
         params: {
           controller,
@@ -236,8 +234,6 @@ export const EDITOR_EXECUTION_STRATEGIES = [
           quorum: BigInt(params.quorum)
         }
       });
-
-      return address;
     },
     paramsDefinition: {
       type: 'object',

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -70,8 +70,15 @@ export function createActions(
   const client = new Clients.EthereumSig(clientConfig);
 
   return {
+    async predictSpaceAddress() {
+      return null;
+    },
+    async deployDependency() {
+      throw new Error('Not implemented');
+    },
     async createSpace(
       web3: any,
+      salt: string,
       params: {
         controller: string;
         votingDelay: number;

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -27,7 +27,7 @@ export type StrategyTemplate = {
     controller: string,
     spaceAddress: string,
     params: Record<string, any>
-  ) => Promise<string>;
+  ) => Promise<{ address: string; txId: string }>;
 };
 
 export type StrategyConfig = StrategyTemplate & {
@@ -45,8 +45,18 @@ export type VotingPower = {
 // TODO: make sx.js accept Signer instead of Web3Provider | Wallet
 
 export type NetworkActions = {
+  predictSpaceAddress(web3: Web3Provider, params: { salt: string }): Promise<string | null>;
+  deployDependency(
+    web3: Web3Provider,
+    params: {
+      controller: string;
+      spaceAddress: string;
+      strategy: StrategyConfig;
+    }
+  ): Promise<{ address: string; txId: string }>;
   createSpace(
     web3: Web3Provider,
+    salt: string,
     params: {
       controller: string;
       votingDelay: number;

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -108,7 +108,11 @@ const network = computed(() => getNetwork(props.space.network));
         >
           <h4
             class="inline-block mr-3 flex-auto"
-            v-text="network.constants.EXECUTORS[executor] || space.executors_types[i]"
+            v-text="
+              network.constants.EXECUTORS[executor] ||
+              network.constants.EXECUTORS[space.executors_types[i]] ||
+              space.executors_types[i]
+            "
           />
           <div>
             <Stamp :id="executor" type="avatar" :size="18" class="mr-2 rounded-sm" />


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/452

This PR adds extra screen in editor that shows progress of deployment of the space.

Changes:
- Now deploying dependencies (currently execution strategies) has visual feedback.
- UI waits for previous transaction to confirm, in case they fail.
- You can access transaction link for each step.
- Actual controller from form is used for new space, currently it was hardcoded to person singing the transaction.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/230416771-4f435d8f-3e9e-4c07-8951-38b175130584.png" width="700" />
