### PR TITLE
feat: add avatar upload for space edit

### DIFF
--- a/src/components/S/IUploadImage.vue
+++ b/src/components/S/IUploadImage.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+const emit = defineEmits(['image-uploaded', 'image-remove']);
+
+const { upload, isUploadingImage } = useImageUpload();
+
+const fileInput = ref<HTMLInputElement | null>(null);
+function openFilePicker() {
+  fileInput.value?.click();
+}
+
+const uploadSuccess = ref(false);
+const previewFile = ref<File | undefined>(undefined);
+const previewUrl = ref<string | undefined>(undefined);
+
+function handleFileChange(e: Event) {
+  uploadSuccess.value = false;
+  if ((e.target as HTMLInputElement).files?.[0]) {
+    previewFile.value = (e.target as HTMLInputElement).files?.[0];
+    previewUrl.value = URL.createObjectURL(previewFile.value as File);
+  }
+}
+
+function uploadFile() {
+  return new Promise<void>(resolve => {
+    upload(previewFile.value, image => {
+      uploadSuccess.value = true;
+      console.log('image.url', image.url);
+      emit('image-uploaded', image.url);
+      resolve();
+    });
+  });
+}
+
+defineExpose({
+  previewFile,
+  previewUrl,
+  uploadFile
+});
+
+onBeforeUnmount(() => {
+  if (previewUrl.value) {
+    URL.revokeObjectURL(previewUrl.value);
+  }
+});
+</script>
+
+<template>
+  <div v-bind="$attrs" @click="openFilePicker()">
+    <slot
+      name="avatar"
+      :uploading="isUploadingImage"
+      :preview-file="previewFile"
+      :preview-url="previewUrl"
+    />
+  </div>
+  <input
+    ref="fileInput"
+    type="file"
+    accept="image/jpg, image/jpeg, image/png"
+    style="display: none"
+    @change="handleFileChange"
+  />
+</template>

--- a/src/composables/useImageUpload.ts
+++ b/src/composables/useImageUpload.ts
@@ -1,0 +1,58 @@
+import { ref } from 'vue';
+import { upload as pin } from '@snapshot-labs/pineapple';
+
+const isUploadingImage = ref(false);
+
+export function useImageUpload() {
+  const imageUploadError = ref('');
+  const imageUrl = ref('');
+  const imageName = ref('');
+
+  const reset = () => {
+    isUploadingImage.value = false;
+    imageUploadError.value = '';
+    imageUrl.value = '';
+    imageName.value = '';
+  };
+
+  const upload = async (
+    file: File | undefined,
+    onSuccess: (image: { name: string; url: string }) => void
+  ) => {
+    reset();
+    if (!file) return;
+    isUploadingImage.value = true;
+    const formData = new FormData();
+
+    // TODO: Additional Validations - File Size, File Type, Empty File, Hidden File
+
+    if (!['image/jpeg', 'image/jpg', 'image/png'].includes(file.type)) {
+      // TODO: add i18n for errors
+      imageUploadError.value = 'Unsupported file type';
+      isUploadingImage.value = false;
+      return;
+    }
+    formData.append('file', file);
+    try {
+      const receipt = await pin(formData);
+      imageUrl.value = `ipfs://${receipt.cid}`;
+      imageName.value = file.name;
+      onSuccess({ name: file.name, url: imageUrl.value });
+    } catch (err) {
+      // TODO: add notify
+      imageUploadError.value = (err as Error).message;
+    } finally {
+      isUploadingImage.value = false;
+    }
+  };
+
+  return {
+    isUploadingImage,
+    imageUploadError,
+    image: {
+      url: imageUrl,
+      name: imageName
+    },
+    upload
+  };
+}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -208,6 +208,7 @@ export function createErc1155Metadata(
 
   return {
     name: metadata.name,
+    avatar: metadata.avatar,
     description: metadata.description,
     external_url: metadata.externalUrl,
     properties: {

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -209,6 +209,7 @@ export const SPACE_QUERY = gql`
     space(id: $id) {
       id
       name
+      # avatar
       about
       external_url
       github

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type Choice = 1 | 2 | 3;
 
 export type SpaceMetadata = {
   name: string;
+  avatar: string;
   description: string;
   externalUrl: string;
   twitter: string;
@@ -34,6 +35,7 @@ export type Space = {
   id: string;
   network: NetworkID;
   name: string;
+  avatar: string;
   about?: string;
   external_url: string;
   twitter: string;


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/419
Moved from fork PR: https://github.com/snapshot-labs/sx-ui/pull/429

- [x] uploads avatar to ipfs with pineapple
- [x] save avatar url to space.avatar, need to be an owner of the space => need to create my space
- [x] add sx resolver to stamp.fyi service to serve sx space avatars
       like a space resolver [here](https://github.com/snapshot-labs/stamp/blob/master/src/resolvers/space.ts)
- [ ] upload avatar on space creation