### PR TITLE
feat: add selection of execution strategy at proposal creation time

### DIFF
--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import draggable from 'vuedraggable';
-import { Transaction as TransactionType, Space, SelectedStrategy } from '@/types';
 import { getNetwork } from '@/networks';
+import { Transaction as TransactionType, Space, SelectedStrategy } from '@/types';
 
 const props = defineProps<{
   modelValue: TransactionType[];

--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import draggable from 'vuedraggable';
-import { Transaction as TransactionType, Space } from '@/types';
+import { Transaction as TransactionType, Space, SelectedStrategy } from '@/types';
+import { getNetwork } from '@/networks';
 
 const props = defineProps<{
   modelValue: TransactionType[];
   space?: Space;
+  selectedExecutionStrategy: SelectedStrategy;
 }>();
 
 const emit = defineEmits<{
@@ -25,6 +27,12 @@ const modalOpen = ref({
   contractCall: false
 });
 
+const network = computed(() => (props.space ? getNetwork(props.space.network) : null));
+const currentTreasury = computed(() =>
+  props.selectedExecutionStrategy.type === 'SimpleQuorumTimelock' && network.value
+    ? { wallet: props.selectedExecutionStrategy.address, network: network.value?.baseChainId }
+    : treasury.value
+);
 const txs = computed({
   get: () => props.modelValue,
   set: newValue => {
@@ -71,11 +79,11 @@ function editTx(index: number) {
       <div
         class="mb-3 flex flex-no-wrap overflow-x-scroll no-scrollbar scrolling-touch items-start space-x-3"
       >
-        <ExecutionButton :disabled="!treasury" @click="openModal('sendToken')">
+        <ExecutionButton :disabled="!currentTreasury" @click="openModal('sendToken')">
           <IH-stop />
           Send token
         </ExecutionButton>
-        <ExecutionButton :disabled="!treasury" @click="openModal('sendNft')">
+        <ExecutionButton :disabled="!currentTreasury" @click="openModal('sendNft')">
           <IH-photograph />
           Send NFT
         </ExecutionButton>
@@ -113,18 +121,18 @@ function editTx(index: number) {
     </div>
     <teleport to="#modal">
       <ModalSendToken
-        v-if="treasury"
+        v-if="currentTreasury"
         :open="modalOpen.sendToken"
-        :address="treasury.wallet"
-        :network="treasury.network"
+        :address="currentTreasury.wallet"
+        :network="currentTreasury.network"
         :initial-state="modalState.sendToken"
         @close="modalOpen.sendToken = false"
         @add="addTx"
       />
       <ModalSendNft
-        v-if="treasury"
+        v-if="currentTreasury"
         :open="modalOpen.sendNft"
-        :address="treasury.wallet"
+        :address="currentTreasury.wallet"
         :initial-state="modalState.sendNft"
         @close="modalOpen.sendNft = false"
         @add="addTx"

--- a/src/components/Modal/SendToken.vue
+++ b/src/components/Modal/SendToken.vue
@@ -63,10 +63,6 @@ const currentToken = computed(() => {
 });
 const formValid = computed(() => currentToken.value && form.to && form.amount !== '');
 
-onMounted(() => {
-  loadBalances(props.address, props.network);
-});
-
 function handleAddCustomToken(token: Token) {
   if (customTokens.value.find(existing => existing.contractAddress === token.contractAddress)) {
     return;
@@ -124,6 +120,10 @@ function handleSubmit() {
   emit('close');
 }
 
+onMounted(() => {
+  loadBalances(props.address, props.network);
+});
+
 watch(
   () => props.open,
   () => {
@@ -140,6 +140,10 @@ watch(
     }
   }
 );
+
+watch([() => props.address, () => props.network], ([address, network]) => {
+  loadBalances(address, network);
+});
 
 watch(currentToken, token => {
   if (!token || typeof form.amount === 'string') return;

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -157,6 +157,7 @@ export function useActions() {
     title: string,
     body: string,
     discussion: string,
+    executionStrategy: string,
     execution: Transaction[]
   ) {
     if (!web3.value.account) {
@@ -188,6 +189,7 @@ export function useActions() {
         web3.value.account,
         space,
         pinned.cid,
+        executionStrategy,
         convertToMetaTransactions(transactions)
       )
     );

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -1,6 +1,5 @@
 import { lsGet, lsSet, omit } from '@/helpers/utils';
-import type { Drafts } from '@/types';
-import type { Proposal as ProposalType } from '@/types';
+import { Draft, Drafts } from '@/types';
 
 const proposals = reactive<Drafts>(lsGet('proposals', {}));
 
@@ -24,7 +23,7 @@ function generateId() {
   return (Math.random() + 1).toString(36).substring(7);
 }
 
-function createDraft(spaceId: string, payload?: Partial<ProposalType>) {
+function createDraft(spaceId: string, payload?: Partial<Draft> & { id?: string }) {
   const id = payload?.id || generateId();
   const key = `${spaceId}:${id}`;
 

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -32,6 +32,7 @@ function createDraft(spaceId: string, payload?: Partial<ProposalType>) {
     title: '',
     body: '',
     discussion: '',
+    executionStrategy: null,
     execution: [],
     updatedAt: Date.now(),
     ...payload

--- a/src/networks/evm/helpers.ts
+++ b/src/networks/evm/helpers.ts
@@ -5,31 +5,28 @@ import { getEvmExecutionData } from '@snapshot-labs/sx';
 import {
   RELAYER_AUTHENTICATORS,
   SUPPORTED_AUTHENTICATORS,
-  SUPPORTED_STRATEGIES,
-  SUPPORTED_EXECUTORS
+  SUPPORTED_STRATEGIES
 } from './constants';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
 import type { Space } from '@/types';
 
-export function getExecution(space: SpaceExecutionData, transactions: MetaTransaction[]) {
-  const supportedExecutionIndex = space.executors_types.findIndex(
-    executorType => SUPPORTED_EXECUTORS[executorType]
+export function getExecutionData(
+  space: SpaceExecutionData,
+  executionStrategy: string,
+  transactions: MetaTransaction[]
+) {
+  const supportedExecutionIndex = space.executors.findIndex(
+    executor => executor === executionStrategy
   );
 
   if (supportedExecutionIndex === -1) {
     throw new Error('No supported executor configured for this space');
   }
 
-  const executor = space.executors[supportedExecutionIndex];
   const executorType = space.executors_types[supportedExecutionIndex] as ExecutorType;
-  const executionData = getEvmExecutionData(executorType, executor, {
+  return getEvmExecutionData(executorType, executionStrategy, {
     transactions
   });
-
-  return {
-    executor,
-    executionData
-  };
 }
 
 export function pickAuthenticatorAndStrategies(authenticators: string[], strategies: string[]) {

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -24,6 +24,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
 
   return {
     name: 'Ethereum (goerli)',
+    baseChainId: chainId,
     hasReceive: false,
     managerConnectors: ['injected', 'walletconnect', 'walletlink', 'portis', 'gnosis'],
     actions: createActions(provider, helpers, chainId),

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -128,6 +128,7 @@ export function createActions(
       account: string,
       space: Space,
       cid: string,
+      executionStrategy: string,
       transactions: MetaTransaction[]
     ) => {
       await verifyNetwork(web3, l1ChainId);

--- a/src/networks/starknet/index.ts
+++ b/src/networks/starknet/index.ts
@@ -35,6 +35,7 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
 
   return {
     name: 'Starknet (testnet2)',
+    baseChainId: l1ChainId,
     baseNetworkId: 'gor',
     hasReceive: true,
     managerConnectors: ['argentx'],

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -90,6 +90,7 @@ export type NetworkActions = {
     account: string,
     space: Space,
     cid: string,
+    executionStrategy: string,
     transactions: MetaTransaction[]
   );
   vote(web3: Web3Provider, account: string, proposal: Proposal, choice: Choice);
@@ -130,6 +131,7 @@ export type NetworkHelpers = {
 
 export type Network = {
   name: string;
+  baseChainId: number;
   baseNetworkId?: NetworkID;
   hasReceive: boolean;
   managerConnectors: Connector[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,11 @@ export type NotificationType = 'error' | 'warning';
 export type NetworkID = 'gor' | 'sn-tn2';
 export type Choice = 1 | 2 | 3;
 
+export type SelectedStrategy = {
+  address: string;
+  type: string;
+};
+
 export type SpaceMetadata = {
   name: string;
   avatar: string;
@@ -138,6 +143,7 @@ export type Draft = {
   title: string;
   body: string;
   discussion: string;
+  executionStrategy: SelectedStrategy | null;
   execution: Transaction[];
   updatedAt: number;
 };

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -228,7 +228,9 @@ watch(proposalData, () => {
             "
           >
             <IH-cog />
-            {{ space.executors_types[i] }} ({{ shortenAddress(executor) }})
+            {{ network.constants.EXECUTORS[space.executors_types[i]] }} execution strategy ({{
+              shortenAddress(executor)
+            }})
           </ExecutionButton>
         </div>
         <BlockExecutionEditable

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -189,7 +189,7 @@ watch(proposalData, () => {
         :body="proposals[proposalKey].body"
       />
 
-      <div v-else class="s-base mb-5">
+      <div v-else class="s-base mb-3">
         <div class="s-label" v-text="'Description'" />
         <textarea
           v-model="proposals[proposalKey].body"
@@ -217,7 +217,7 @@ watch(proposalData, () => {
             :key="executor"
             class="flex-auto flex items-center gap-2"
             :class="{
-              'border-green': executionStrategy?.address === executor,
+              'border-skin-link': executionStrategy?.address === executor,
               'text-skin-border': executionStrategy?.address !== executor
             }"
             @click="

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -208,7 +208,7 @@ watch(proposalData, () => {
       </div>
       <div v-if="space">
         <h4 class="eyebrow mb-3">Execution</h4>
-        <div class="flex flex-col gap-2 mb-2">
+        <div class="flex flex-col gap-2 mb-3">
           <div v-if="supportedExecutionStrategies && !supportedExecutionStrategies.length">
             No supported execution strategies available.
           </div>

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -152,7 +152,7 @@ watch(proposalData, () => {
             :loading="sending || (web3.account !== '' && fetchingVotingPower)"
             :disabled="
               (!fetchingVotingPower && !votingPowerValid) ||
-              !proposals[proposalKey].executionStrategy
+              !proposals[proposalKey]?.executionStrategy
             "
             @click="handleProposeClick"
           >


### PR DESCRIPTION
## Summary

Depends on https://github.com/snapshot-labs/sx-ui/pull/552

Added field to make it possible to pick from different voting strategies that are configured for a space.

## Test plan
- Create space with multiple execution strategies, or use this one.
- You can select execution strategy when creating a proposal.

## Screenshots

![image](https://user-images.githubusercontent.com/1968722/231348227-95cff3ef-3c0e-409e-b59e-63d027305482.png)

