### PR TITLE
fix: use parsed decimals on Proposal page

### DIFF
--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -9,7 +9,6 @@ export const PROPOSAL_QUERY = gql`
         id
         voting_power_symbol
         authenticators
-        strategies_metadata
         strategies_parsed_metadata {
           decimals
           symbol
@@ -66,7 +65,6 @@ export const PROPOSALS_QUERY = gql`
         voting_power_symbol
         quorum
         authenticators
-        strategies_metadata
         strategies_parsed_metadata {
           decimals
           symbol
@@ -134,7 +132,6 @@ export const PROPOSALS_SUMMARY_QUERY = gql`
     space {
       id
       authenticators
-      strategies_metadata
       executors
     }
     author {
@@ -226,7 +223,6 @@ export const SPACE_QUERY = gql`
       voting_power_validation_strategy_strategies_params
       strategies
       strategies_params
-      strategies_metadata
       strategies_parsed_metadata {
         decimals
         symbol
@@ -264,7 +260,6 @@ export const SPACES_QUERY = gql`
       voting_power_validation_strategy_strategies_params
       strategies
       strategies_params
-      strategies_metadata
       strategies_parsed_metadata {
         decimals
         symbol

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,6 @@ export type Space = {
   voting_power_validation_strategy_strategies_params: string[];
   strategies: string[];
   strategies_params: any[];
-  strategies_metadata: string[];
   strategies_parsed_metadata: StrategyParsedMetadata[];
   authenticators: string[];
   executors: string[];
@@ -70,7 +69,6 @@ export type Proposal = {
     id: string;
     voting_power_symbol: string;
     authenticators: string[];
-    strategies_metadata: string[];
     executors: string[];
     executors_types: string[];
     strategies_parsed_metadata: StrategyParsedMetadata[];

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -23,7 +23,7 @@ const proposal = computed(() => proposalsStore.getProposal(space, id, networkId 
 const votingPowerDecimals = computed(() => {
   if (!proposal.value) return 0;
   return Math.max(
-    ...proposal.value.space.strategies_metadata.map(metadata => parseInt(metadata, 16)),
+    ...proposal.value.space.strategies_parsed_metadata.map(metadata => metadata.decimals),
     0
   );
 });


### PR DESCRIPTION
We were expecting old format for decimals on Proposal page.

## Test plan

- Go to http://localhost:8080/#/gor:0x65e4329e8c0fba31883b98e2cf3e81d3cdcac780/proposal/6
- Results have correct values of VP.