### PR TITLE
fix: display stamp preview as square

### DIFF
--- a/src/components/S/IStamp.vue
+++ b/src/components/S/IStamp.vue
@@ -52,7 +52,7 @@ async function handleFileChange(e: Event) {
     <img
       v-if="imgUrl"
       :src="imgUrl"
-      class="w-full min-w-[80px] h-full !rounded-lg group-hover:opacity-80"
+      class="w-[80px] h-[80px] object-cover !rounded-lg group-hover:opacity-80"
       :class="{
         'opacity-80': isUploadingImage
       }"


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/574

## Test plan

- Upload rectangle image.
- Preview is squared with cover fit (same as Stamp).