### PR TITLE
feat: add header buttons tooltips

### DIFF
--- a/src/components/Ui/Tooltip.vue
+++ b/src/components/Ui/Tooltip.vue
@@ -43,7 +43,7 @@ const arrowStyle = computed(() => {
 </script>
 
 <template>
-  <div class="relative">
+  <div class="relative inline-block">
     <div
       ref="referenceRef"
       class="h-full"

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -65,12 +65,8 @@ const grouped = computed(() => {
             </UiButton>
           </UiTooltip>
         </router-link>
-        <UiTooltip title="Edit space">
-          <UiButton
-            v-if="spaceIsEditable"
-            class="!px-0 w-[46px]"
-            @click="editSpaceModalOpen = true"
-          >
+        <UiTooltip v-if="spaceIsEditable" title="Edit space">
+          <UiButton class="!px-0 w-[46px]" @click="editSpaceModalOpen = true">
             <IH-cog class="inline-block" />
           </UiButton>
         </UiTooltip>

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -59,17 +59,27 @@ const grouped = computed(() => {
     <div class="relative bg-skin-border h-[140px] -mb-[70px]">
       <div class="absolute right-4 top-4 space-x-2">
         <router-link :to="{ name: 'editor' }">
-          <UiButton class="!px-0 w-[46px]">
-            <IH-pencil-alt class="inline-block" />
-          </UiButton>
+          <UiTooltip title="New proposal">
+            <UiButton class="!px-0 w-[46px]">
+              <IH-pencil-alt class="inline-block" />
+            </UiButton>
+          </UiTooltip>
         </router-link>
-        <UiButton v-if="spaceIsEditable" class="!px-0 w-[46px]" @click="editSpaceModalOpen = true">
-          <IH-cog class="inline-block" />
-        </UiButton>
-        <UiButton class="w-[46px] !px-0" @click="spacesStore.toggleSpaceStar(spaceIdComposite)">
-          <IS-star v-if="spaceStarred" class="inline-block" />
-          <IH-star v-else class="inline-block" />
-        </UiButton>
+        <UiTooltip title="Edit space">
+          <UiButton
+            v-if="spaceIsEditable"
+            class="!px-0 w-[46px]"
+            @click="editSpaceModalOpen = true"
+          >
+            <IH-cog class="inline-block" />
+          </UiButton>
+        </UiTooltip>
+        <UiTooltip :title="spaceStarred ? 'Remove from favorites' : 'Add to favorites'">
+          <UiButton class="w-[46px] !px-0" @click="spacesStore.toggleSpaceStar(spaceIdComposite)">
+            <IS-star v-if="spaceStarred" class="inline-block" />
+            <IH-star v-else class="inline-block" />
+          </UiButton>
+        </UiTooltip>
       </div>
     </div>
     <div class="px-4">

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -72,9 +72,11 @@ watch(
           :voting-powers="votingPowers"
         />
         <router-link :to="{ name: 'editor' }">
-          <UiButton class="!px-0 w-[46px]">
-            <IH-pencil-alt class="inline-block" />
-          </UiButton>
+          <UiTooltip title="New proposal">
+            <UiButton class="!px-0 w-[46px]">
+              <IH-pencil-alt class="inline-block" />
+            </UiButton>
+          </UiTooltip>
         </router-link>
       </div>
     </div>

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -79,15 +79,17 @@ onMounted(() => {
   <template v-else>
     <div class="p-4 space-x-2 flex">
       <div class="flex-auto" />
-      <a>
+      <UiTooltip title="Copy address">
         <UiButton class="!px-0 w-[46px]" @click="copy(treasury.wallet)">
           <IH-duplicate v-if="!copied" class="inline-block" />
           <IH-check v-else class="inline-block" />
         </UiButton>
-      </a>
-      <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
-        <IH-arrow-sm-right class="inline-block -rotate-45" />
-      </UiButton>
+      </UiTooltip>
+      <UiTooltip :title="page === 'tokens' ? 'Send token' : 'Send NFT'">
+        <UiButton class="!px-0 w-[46px]" @click="openModal(page)">
+          <IH-arrow-sm-right class="inline-block -rotate-45" />
+        </UiButton>
+      </UiTooltip>
     </div>
     <div class="space-y-3">
       <div>


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/575

@bonustrack currently tooltips blend into Space background because they use the same color. Do you want to use some border on tooltips to prevent it?
![image](https://user-images.githubusercontent.com/1968722/234051869-f3d2c7cc-5a43-4949-a706-993effae7456.png)


## Test plan
- Check space header buttons, all should have tooltips.