### PR TITLE
fix: keep reactivity for space in useTreasury

### DIFF
--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -11,7 +11,7 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: TransactionType[]): void;
 }>();
 
-const { treasury } = useTreasury(props.space);
+const { treasury } = useTreasury(toRef(props, 'space'));
 
 const editedTx: Ref<number | null> = ref(null);
 const modalState: Ref<{

--- a/src/composables/useTreasury.ts
+++ b/src/composables/useTreasury.ts
@@ -2,15 +2,11 @@ import { Space } from '@/types';
 
 type NullableSpace = Space | undefined | null;
 
-export function useTreasury(spaceRef?: Space | Ref<NullableSpace> | ComputedRef<NullableSpace>) {
+export function useTreasury(spaceRef: Ref<NullableSpace>) {
   const treasury = computed(() => {
-    if (!spaceRef) return;
+    if (!spaceRef.value || !spaceRef.value.wallet) return null;
 
-    const space = 'value' in spaceRef ? spaceRef.value : spaceRef;
-    if (!space || !space.wallet) return null;
-
-    const [networkId, wallet] = space.wallet.split(':');
-
+    const [networkId, wallet] = spaceRef.value.wallet.split(':');
     if (networkId !== 'gor' || !wallet) return null;
 
     return {

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -13,7 +13,7 @@ const router = useRouter();
 const { copy, copied } = useClipboard();
 const { loading, loaded, assets, loadBalances } = useBalances();
 const { loading: nftsLoading, loaded: nftsLoaded, nfts, loadNfts } = useNfts();
-const { treasury } = useTreasury(props.space);
+const { treasury } = useTreasury(toRef(props, 'space'));
 const { createDraft } = useEditor();
 
 const page: Ref<'tokens' | 'nfts'> = ref('tokens');


### PR DESCRIPTION
Current hook usage can lose reactivity, for example refreshing editor page will result in treasury not being found (buttons will be disabled) because space prop is loaded later.
This PR fixes it by making sure we are passing reactive value.

## Test plan
- Go to http://localhost:8080/#/gor:0x65e4329e8c0fba31883b98e2cf3e81d3cdcac780/create
- Refresh page
- Execution buttons are all enabled