### PR TITLE
fix: prevent elements overlapping

### DIFF
--- a/src/components/Topnav.vue
+++ b/src/components/Topnav.vue
@@ -49,7 +49,7 @@ watch(route, to => {
 
 <template>
   <nav
-    class="border-b fixed top-0 right-0 z-10 left-0 lg:left-[72px]"
+    class="border-b fixed top-0 right-0 z-50 left-0 lg:left-[72px]"
     :class="{
       'translate-x-[72px] lg:translate-x-0': uiStore.sidebarOpen
     }"

--- a/src/components/Ui/Tooltip.vue
+++ b/src/components/Ui/Tooltip.vue
@@ -43,7 +43,7 @@ const arrowStyle = computed(() => {
 </script>
 
 <template>
-  <div class="relative inline-block">
+  <div class="inline-block">
     <div
       ref="referenceRef"
       class="h-full"


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/579

## Test plan
- In create space form Topnav should always be on top
- In proposals list buttons shouldn't cover sticky titles.
- Tooltip should be in front of Topnav (@bonustrack is this what we want? this was previous behaviour)

## Screenshots
![image](https://user-images.githubusercontent.com/1968722/234341093-379a8326-24d6-4498-9e31-d54c8e2505a4.png)


![image](https://user-images.githubusercontent.com/1968722/234341033-ce8b0ed9-01b9-40dc-87cf-605c8fb4d0bb.png)

![image](https://user-images.githubusercontent.com/1968722/234340957-440faca0-a2cc-4f3a-aa36-2d4a1a788236.png)
