### PR TITLE
feat: display ozVotes token in modal

### DIFF
--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -292,7 +292,9 @@ export function createActions(
             provider
           );
 
-          const token = strategy.type === 'comp' ? strategiesParams[i] : undefined;
+          const token = ['comp', 'ozVotes'].includes(strategy.type)
+            ? strategiesParams[i]
+            : undefined;
           return {
             address,
             value,

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -48,7 +48,7 @@ export const PROPOSAL_VALIDATIONS = {
 export const STRATEGIES = {
   '0xeba53160c146cbf77a150e9a218d4c2de5db6b51': 'Vanilla',
   '0x343baf4b44f7f79b14301cfa8068e3f8be7470de': 'Delegated Comp Token',
-  '0x4aaa33b4367dc5657854bd40738201651ec0cc7b': 'Oz Votes',
+  '0x4aaa33b4367dc5657854bd40738201651ec0cc7b': 'OpenZeppelin Votes',
   '0xf50bf15e9fe61e27625a4ecdfc23211297e8be85': 'Whitelist'
 };
 


### PR DESCRIPTION
Currently ozVotes strategies do not show connected in VP modal, this can be added with simple fix.

## Test plan
- Go to http://localhost:8080/#/gor:0x90ccccd7667a8f67404c2f6fe3124ced1bb91237/proposals
- Click VP.
- Token address is shown in OZ votes voting strategy.

## Screenshots

<img src="https://user-images.githubusercontent.com/1968722/234649230-f60b5ad6-3369-4bfa-94c7-d390303698a0.png" width="400" />
