### PR TITLE
fix: set Vanilla decimals to 0 in metadata

### DIFF
--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -134,7 +134,7 @@ export const EDITOR_VOTING_STRATEGIES = [
       name: 'Vanilla',
       properties: {
         symbol: params.symbol,
-        decimals: 1
+        decimals: 0
       }
     }),
     paramsDefinition: {


### PR DESCRIPTION
When creating metadata for new vanilla strategies we should set decimals to 0.

Closes: https://github.com/snapshot-labs/sx-ui/issues/603