### PR TITLE
fix: use relative to set position of Tooltip

### DIFF
--- a/src/components/Label.vue
+++ b/src/components/Label.vue
@@ -1,15 +1,15 @@
-<script setup>
-defineProps({
-  label: String,
-  sticky: Boolean
-});
+<script setup lang="ts">
+defineProps<{
+  label: string;
+  sticky?: boolean;
+}>();
 </script>
 
 <template>
   <h4
     class="eyebrow border-b py-2 px-4 text-skin-text"
     :class="{
-      'sticky top-[71px] lg:top-[72px] bg-skin-bg': sticky
+      'sticky z-10 top-[71px] lg:top-[72px] bg-skin-bg': sticky
     }"
     v-text="label"
   />

--- a/src/components/Ui/Tooltip.vue
+++ b/src/components/Ui/Tooltip.vue
@@ -43,7 +43,7 @@ const arrowStyle = computed(() => {
 </script>
 
 <template>
-  <div class="inline-block">
+  <div class="inline-block relative">
     <div
       ref="referenceRef"
       class="h-full"


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/610

## Test plan
- Tooltips for vote buttons appear at correct position.
- Nothing breaks.