### PR TITLE
fix: move attrs and condition to Tooltip for indicator button

### DIFF
--- a/src/components/PendingTransactionsIndicator.vue
+++ b/src/components/PendingTransactionsIndicator.vue
@@ -12,10 +12,12 @@ const pendingTransactionsModalOpen = ref(false);
 </script>
 
 <template>
-  <UiTooltip title="Pending transactions">
+  <UiTooltip
+    v-if="uiStore.pendingTransactions.length > 0"
+    v-bind="$attrs"
+    title="Pending transactions"
+  >
     <UiButton
-      v-if="uiStore.pendingTransactions.length > 0"
-      v-bind="$attrs"
       class="!px-0 w-[46px] text-white bg-blue border-blue focus-within:border-blue focus:border-blue"
       @click="pendingTransactionsModalOpen = true"
     >


### PR DESCRIPTION
## Test plan

- Do some action (vote/create proposal).
- Hover over pending indicator (and keep it until indicator disappears).
- Tooltip's arrow is pointing to the center of the button.
- Once indicator disappears tooltip does too.

## Screenshot
<img src="https://user-images.githubusercontent.com/1968722/235129705-e94842ce-ff86-421e-965d-b9c20c527637.png" width="350" />