### PR TITLE
refactor: preserve types in useActions

### DIFF
--- a/src/components/Block/CreationConfirmation.vue
+++ b/src/components/Block/CreationConfirmation.vue
@@ -7,7 +7,7 @@ import { NetworkID, SpaceMetadata, SpaceSettings } from '@/types';
 const props = defineProps<{
   networkId: NetworkID;
   salt: string;
-  predictedSpaceAddress: string | null;
+  predictedSpaceAddress: string;
   metadata: SpaceMetadata;
   settings: SpaceSettings;
   authenticators: StrategyConfig[];

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -20,8 +20,8 @@ export function useActions() {
   const { modalAccountOpen } = useModal();
   const auth = getInstance();
 
-  function wrapWithErrors(fn) {
-    return async (...args) => {
+  function wrapWithErrors<T extends any[], U>(fn: (...args: T) => U) {
+    return async (...args: T): Promise<U> => {
       try {
         return await fn(...args);
       } catch (err) {
@@ -333,25 +333,21 @@ export function useActions() {
     uiStore.addPendingTransaction(receipt.hash, 'gor');
   }
 
-  const actions = {
-    predictSpaceAddress,
-    deployDependency,
-    createSpace,
-    updateMetadata,
-    vote,
-    propose,
-    updateProposal,
-    finalizeProposal,
-    receiveProposal,
-    executeTransactions,
-    executeQueuedProposal,
-    setVotingDelay,
-    setMinVotingDuration,
-    setMaxVotingDuration,
-    transferOwnership
+  return {
+    predictSpaceAddress: wrapWithErrors(predictSpaceAddress),
+    deployDependency: wrapWithErrors(deployDependency),
+    createSpace: wrapWithErrors(createSpace),
+    updateMetadata: wrapWithErrors(updateMetadata),
+    vote: wrapWithErrors(vote),
+    propose: wrapWithErrors(propose),
+    updateProposal: wrapWithErrors(updateProposal),
+    finalizeProposal: wrapWithErrors(finalizeProposal),
+    receiveProposal: wrapWithErrors(receiveProposal),
+    executeTransactions: wrapWithErrors(executeTransactions),
+    executeQueuedProposal: wrapWithErrors(executeQueuedProposal),
+    setVotingDelay: wrapWithErrors(setVotingDelay),
+    setMinVotingDuration: wrapWithErrors(setMinVotingDuration),
+    setMaxVotingDuration: wrapWithErrors(setMaxVotingDuration),
+    transferOwnership: wrapWithErrors(transferOwnership)
   };
-
-  return Object.fromEntries(
-    Object.entries(actions).map(([key, value]) => [key, wrapWithErrors(value)])
-  );
 }

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -180,7 +180,7 @@ watch(selectedNetworkId, () => {
 <template>
   <div>
     <BlockCreationConfirmation
-      v-if="confirming && salt && validationStrategy"
+      v-if="confirming && salt && predictedSpaceAddress && validationStrategy"
       :network-id="selectedNetworkId"
       :salt="salt"
       :predicted-space-address="predictedSpaceAddress"

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -32,13 +32,16 @@ async function handleSave(
     controller: transferOwnership
   };
 
-  const action = fieldActions[field];
-  if (!action) return;
+  if (!fieldActions[field]) return;
 
   settingsLoading.value[field] = true;
 
   try {
-    await action(props.space, field === 'controller' ? value : parseInt(value));
+    if (field === 'controller') {
+      await fieldActions[field](props.space, value);
+    } else {
+      await fieldActions[field](props.space, parseInt(value));
+    }
   } finally {
     settingsLoading.value[field] = false;
   }


### PR DESCRIPTION
It's annoying to deal with useActions right now because we lose types, this recovers proper types.