### PR TITLE
feat: add user friendly form errors

### DIFF
--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -13,10 +13,11 @@ function getErrorMessage(errorObject: ErrorObject): string {
       case 'address':
         return 'Must be a valid address.';
       case 'uint256':
+        return 'Must be a positive integer.';
       case 'int256':
-        return `Must be a valid ${errorObject.params.format} value.`;
+        return 'Must be an integer.';
       case 'ethValue':
-        return 'Must be a valid Ethereum value.';
+        return 'Must be a number.';
       default:
         return 'Invalid format.';
     }


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/534

This PR adds user friendly form messages.

1. Tries to use default message if it's not format error message.
2. If it's format error message use custom messages per type.
3. If it's format error message we don't have custom message for we show generic `Invalid format.` message as otherwise format isn't great (`must have format "ethValue"`).

## Test plan

Check some forms trying to break them that you know have validation working.

## Screenshots

![image](https://user-images.githubusercontent.com/1968722/236210469-995f3300-c611-4300-84be-09534155deec.png)
 