### PR TITLE
fix: parse fetched ABI

### DIFF
--- a/src/helpers/etherscan.ts
+++ b/src/helpers/etherscan.ts
@@ -9,5 +9,5 @@ export async function getABI(address: string) {
   const res = await fetch(`${uri}?${params}`);
   const { result } = await res.json();
 
-  return result;
+  return JSON.parse(result);
 }


### PR DESCRIPTION
## Summary

Regression from: https://github.com/snapshot-labs/sx-ui/pull/563

## Test plan

- Go to create proposal page.
- Create contract call execution with contract address of `0x3587b2F7E0E2D6166d6C14230e7Fe160252B0ba4`.
- It fetched ABI properly.