### PR TITLE
feat: add missing form validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@vueuse/core": "^9.4.0",
     "@walletconnect/client": "^1.7.8",
     "ajv": "^8.11.0",
+    "ajv-formats": "^2.1.1",
     "buffer": "^6.0.3",
     "dayjs": "^1.11.2",
     "electron": "^21.2.2",

--- a/src/components/Block/SpaceFormController.vue
+++ b/src/components/Block/SpaceFormController.vue
@@ -12,8 +12,8 @@ const emit = defineEmits<{
 
 const definition = {
   type: 'string',
+  format: 'address',
   title: 'Space controller',
-  minLength: 1,
   examples: ['0x0000…']
 };
 

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -51,6 +51,7 @@ const definition = computed(() => {
       },
       externalUrl: {
         type: 'string',
+        format: 'uri',
         title: 'Website',
         examples: ['Website URL']
       },
@@ -104,7 +105,9 @@ watch(
   }
 );
 
-const formErrors = computed(() => validateForm(definition.value, props.form));
+const formErrors = computed(() =>
+  validateForm(definition.value, props.form, { skipEmptyOptionalFields: true })
+);
 
 watch(formErrors, value => emit('errors', value));
 

--- a/src/components/S/INumber.vue
+++ b/src/components/S/INumber.vue
@@ -33,6 +33,7 @@ const inputValue = computed({
       v-model="inputValue"
       type="number"
       class="s-input"
+      v-bind="$attrs"
       :placeholder="definition.examples && definition.examples[0]"
     />
   </SBase>

--- a/src/components/Ui/Editable.vue
+++ b/src/components/Ui/Editable.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
+import SINumber from '@/components/S/INumber.vue';
+import SIString from '@/components/S/IString.vue';
+import { validateForm } from '@/helpers/validation';
+
 type Definition = {
-  format: string;
+  type: 'string' | 'integer';
+  format?: string;
   examples: string[];
 };
 
 const props = withDefaults(
   defineProps<{
-    initialValue: string;
+    initialValue: string | number;
     editable: boolean;
     loading?: boolean;
     definition: Definition;
@@ -15,12 +20,32 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (e: 'save', value: string);
+  (e: 'save', value: string | number);
 }>();
 
 const editing = ref(false);
 const inputValue = ref(props.initialValue);
 
+const Component = computed(() => {
+  if (props.definition.type === 'integer') return SINumber;
+  return SIString;
+});
+const formErrors = computed(() =>
+  validateForm(
+    {
+      type: 'object',
+      title: 'Editable',
+      additionalProperties: false,
+      required: ['value'],
+      properties: {
+        value: props.definition
+      }
+    },
+    {
+      value: inputValue.value
+    }
+  )
+);
 function handleSave() {
   emit('save', inputValue.value);
   editing.value = false;
@@ -31,15 +56,29 @@ function handleSave() {
   <div class="flex items-center gap-2 group w-fit" :class="{ 'mt-2': editing }">
     <UiLoading v-if="loading" />
     <template v-else>
-      <SIString v-if="editing" v-model="inputValue" class="!mb-0" :definition="definition" />
+      <component
+        :is="Component"
+        v-if="editing"
+        v-model="inputValue"
+        class="!mb-0"
+        :definition="definition"
+        :error="formErrors.value"
+      />
       <slot v-else />
       <template v-if="editing">
-        <button class="hover:opacity-80" @click="handleSave">
-          <IH-check />
-        </button>
-        <button class="hover:opacity-80" @click="editing = !editing">
-          <IH-x />
-        </button>
+        <div
+          class="flex gap-2 relative"
+          :class="{
+            'top-[-15px]': !!formErrors.value
+          }"
+        >
+          <button :disabled="!!formErrors.value" class="hover:opacity-80" @click="handleSave">
+            <IH-check />
+          </button>
+          <button class="hover:opacity-80" @click="editing = !editing">
+            <IH-x />
+          </button>
+        </div>
       </template>
       <template v-else>
         <button

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -33,6 +33,8 @@ export function validateForm(schema, form): Record<string, string> {
 
   ajv.addFormat('address', {
     validate: (value: string) => {
+      if (!value) return false;
+
       try {
         return !!validateAndParseAddress(value);
       } catch (err) {

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -1,4 +1,5 @@
 import Ajv, { ErrorObject } from 'ajv';
+import addFormats from 'ajv-formats';
 import { validateAndParseAddress } from 'starknet';
 import { isAddress } from '@ethersproject/address';
 import { parseUnits } from '@ethersproject/units';
@@ -10,6 +11,8 @@ function getErrorMessage(errorObject: ErrorObject): string {
 
   if (errorObject.keyword === 'format') {
     switch (errorObject.params.format) {
+      case 'uri':
+        return 'Must be a valid URL.';
       case 'address':
         return 'Must be a valid address.';
       case 'uint256':
@@ -28,8 +31,13 @@ function getErrorMessage(errorObject: ErrorObject): string {
     .toLocaleLowerCase()}.`;
 }
 
-export function validateForm(schema, form): Record<string, string> {
+export function validateForm(
+  schema,
+  form,
+  opts: { skipEmptyOptionalFields: boolean } = { skipEmptyOptionalFields: false }
+): Record<string, string> {
   const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
 
   ajv.addFormat('address', {
     validate: (value: string) => {
@@ -92,7 +100,18 @@ export function validateForm(schema, form): Record<string, string> {
 
   ajv.addKeyword('options');
 
-  ajv.validate(schema, form);
+  const requiredKeys = schema.required || [];
+  const processedForm = !opts.skipEmptyOptionalFields
+    ? form
+    : Object.fromEntries(
+        Object.entries(form).filter(([key, value]) => {
+          if (requiredKeys.includes(key)) return true;
+
+          return value !== '';
+        })
+      );
+
+  ajv.validate(schema, processedForm);
 
   const output = {};
   if (!ajv.errors) {

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -277,7 +277,7 @@ export const EDITOR_EXECUTION_STRATEGIES = [
       required: ['quorum', 'contractAddress'],
       properties: {
         quorum: {
-          type: 'string',
+          type: 'integer',
           title: 'Quorum',
           examples: ['1']
         },
@@ -322,12 +322,12 @@ export const EDITOR_EXECUTION_STRATEGIES = [
       required: ['quorum', 'timelockDelay'],
       properties: {
         quorum: {
-          type: 'string',
+          type: 'integer',
           title: 'Quorum',
           examples: ['1']
         },
         timelockDelay: {
-          type: 'string',
+          type: 'integer',
           title: 'Timelock delay',
           examples: ['1']
         }

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -57,13 +57,13 @@ async function handleSave(
           <div class="s-label !mb-0">Voting delay</div>
           <UiEditable
             :editable="spaceIsEditable"
-            :initial-value="space.voting_delay.toString()"
+            :initial-value="space.voting_delay"
             :loading="settingsLoading.votingDelay"
             :definition="{
-              format: 'number',
+              type: 'integer',
               examples: ['0']
             }"
-            @save="value => handleSave('votingDelay', value)"
+            @save="value => handleSave('votingDelay', value.toString())"
           >
             <h4 class="text-skin-link text-md" v-text="_d(space.voting_delay) || 'No delay'" />
           </UiEditable>
@@ -72,13 +72,13 @@ async function handleSave(
           <div class="s-label !mb-0">Min. voting period</div>
           <UiEditable
             :editable="spaceIsEditable"
-            :initial-value="space.min_voting_period.toString()"
+            :initial-value="space.min_voting_period"
             :loading="settingsLoading.minVotingPeriod"
             :definition="{
-              format: 'number',
+              type: 'integer',
               examples: ['0']
             }"
-            @save="value => handleSave('minVotingPeriod', value)"
+            @save="value => handleSave('minVotingPeriod', value.toString())"
           >
             <h4 class="text-skin-link text-md" v-text="_d(space.min_voting_period) || 'No min.'" />
           </UiEditable>
@@ -87,13 +87,13 @@ async function handleSave(
           <div class="s-label !mb-0">Max. voting period</div>
           <UiEditable
             :editable="spaceIsEditable"
-            :initial-value="space.max_voting_period.toString()"
+            :initial-value="space.max_voting_period"
             :loading="settingsLoading.maxVotingPeriod"
             :definition="{
-              format: 'number',
+              type: 'integer',
               examples: ['0']
             }"
-            @save="value => handleSave('maxVotingPeriod', value)"
+            @save="value => handleSave('maxVotingPeriod', value.toString())"
           >
             <h4 class="text-skin-link text-md" v-text="_d(space.max_voting_period)" />
           </UiEditable>
@@ -113,10 +113,11 @@ async function handleSave(
           :initial-value="space.controller"
           :loading="settingsLoading.controller"
           :definition="{
+            type: 'string',
             format: 'address',
             examples: ['0x0000…']
           }"
-          @save="value => handleSave('controller', value)"
+          @save="value => handleSave('controller', value.toString())"
         >
           <a :href="network.helpers.getExplorerUrl(space.controller, 'contract')" target="_blank">
             <Stamp :id="space.controller" type="avatar" :size="18" class="mr-2 rounded-sm" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,6 +2102,13 @@ agentkeepalive@^4.2.1:
     depd "^1.1.2"
     humanize-ms "^1.2.1"
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -2112,7 +2119,8 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.11.0:
+
+ajv@^8.0.0, ajv@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/606

This PR adds missing form validation:
- URL validation for discussion and website URL
- address validation for send token/NFT recipient and controller
- integer validation for quorum/timelock delay

It also required adding extra `skipEmptyOptionalFields` option to `validateForm` so we can decide what happens if we pass empty value for optional field, in most cases it might make sense to make it valid, which can be achieved with this option.

## Test plan

- Play with website URL, executions arguments and controller in create space form.
- Play with recipients in proposal execution modals and discussion URL.