### PR TITLE
feat: allow proposals without execution

### DIFF
--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -157,7 +157,7 @@ export function useActions() {
     title: string,
     body: string,
     discussion: string,
-    executionStrategy: string,
+    executionStrategy: string | null,
     execution: Transaction[]
   ) {
     if (!web3.value.account) {
@@ -203,7 +203,7 @@ export function useActions() {
     title: string,
     body: string,
     discussion: string,
-    executionStrategy: string,
+    executionStrategy: string | null,
     execution: Transaction[]
   ) {
     if (!web3.value.account) {

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -129,7 +129,7 @@ export function createActions(
       account: string,
       space: Space,
       cid: string,
-      executionStrategy: string,
+      executionStrategy: string | null,
       transactions: MetaTransaction[]
     ) => {
       await verifyNetwork(web3, chainId);
@@ -139,16 +139,24 @@ export function createActions(
         space.voting_power_validation_strategy_strategies
       );
 
-      const executionData = getExecutionData(space, executionStrategy, transactions);
+      let selectedExecutionStrategy;
+      if (executionStrategy) {
+        selectedExecutionStrategy = {
+          addy: executionStrategy,
+          params: getExecutionData(space, executionStrategy, transactions).executionParams[0]
+        };
+      } else {
+        selectedExecutionStrategy = {
+          addy: '0x0000000000000000000000000000000000000000',
+          params: '0x'
+        };
+      }
 
       const data = {
         space: space.id,
         authenticator,
         strategies,
-        executionStrategy: {
-          addy: executionStrategy,
-          params: executionData.executionParams[0]
-        },
+        executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${cid}`
       };
 
@@ -172,7 +180,7 @@ export function createActions(
       space: Space,
       proposalId: number,
       cid: string,
-      executionStrategy: string,
+      executionStrategy: string | null,
       transactions: MetaTransaction[]
     ) {
       await verifyNetwork(web3, chainId);
@@ -182,16 +190,24 @@ export function createActions(
         space.voting_power_validation_strategy_strategies
       );
 
-      const executionData = getExecutionData(space, executionStrategy, transactions);
+      let selectedExecutionStrategy;
+      if (executionStrategy) {
+        selectedExecutionStrategy = {
+          addy: executionStrategy,
+          params: getExecutionData(space, executionStrategy, transactions).executionParams[0]
+        };
+      } else {
+        selectedExecutionStrategy = {
+          addy: '0x0000000000000000000000000000000000000000',
+          params: '0x'
+        };
+      }
 
       const data = {
         space: space.id,
         proposal: proposalId,
         authenticator,
-        executionStrategy: {
-          addy: executionStrategy,
-          params: executionData.executionParams[0]
-        },
+        executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${cid}`
       };
 

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -128,7 +128,7 @@ export function createActions(
       account: string,
       space: Space,
       cid: string,
-      executionStrategy: string,
+      executionStrategy: string | null,
       transactions: MetaTransaction[]
     ) => {
       await verifyNetwork(web3, l1ChainId);

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -93,7 +93,7 @@ export type NetworkActions = {
     account: string,
     space: Space,
     cid: string,
-    executionStrategy: string,
+    executionStrategy: string | null,
     transactions: MetaTransaction[]
   );
   updateProposal(
@@ -102,7 +102,7 @@ export type NetworkActions = {
     space: Space,
     proposalId: number,
     cid: string,
-    executionStrategy: string,
+    executionStrategy: string | null,
     transactions: MetaTransaction[]
   );
   vote(web3: Web3Provider, account: string, proposal: Proposal, choice: Choice);

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -132,7 +132,6 @@ function validatePage(page: PageID) {
       ? validationStrategy.value.validate(validationStrategy.value.params)
       : true;
   }
-  if (page === 'executions') return executionStrategies.value.length > 0;
 
   return Object.values(pagesErrors.value[page]).length === 0;
 }

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -85,7 +85,6 @@ const canSubmit = computed(() => {
   return (
     !fetchingVotingPower.value &&
     votingPowerValid.value &&
-    proposals[proposalKey]?.executionStrategy &&
     Object.keys(formErrors.value).length === 0
   );
 });
@@ -96,7 +95,7 @@ if (!proposals[proposalKey]) {
 
 async function handleProposeClick() {
   const proposal = proposals[proposalKey];
-  if (!space.value || !proposal?.executionStrategy) return;
+  if (!space.value) return;
 
   sending.value = true;
 
@@ -109,8 +108,8 @@ async function handleProposeClick() {
         proposal.title,
         proposal.body,
         proposal.discussion,
-        proposal.executionStrategy.address,
-        proposal.execution
+        proposal.executionStrategy?.address ?? null,
+        proposal.executionStrategy?.address ? proposal.execution : []
       );
     } else {
       result = await propose(
@@ -118,8 +117,8 @@ async function handleProposeClick() {
         proposal.title,
         proposal.body,
         proposal.discussion,
-        proposal.executionStrategy.address,
-        proposal.execution
+        proposal.executionStrategy?.address ?? null,
+        proposal.executionStrategy?.address ? proposal.execution : []
       );
     }
     if (result) router.back();
@@ -259,9 +258,17 @@ watch(proposalData, () => {
       <div v-if="space">
         <h4 class="eyebrow mb-3">Execution</h4>
         <div class="flex flex-col gap-2 mb-3">
-          <div v-if="supportedExecutionStrategies && !supportedExecutionStrategies.length">
-            No supported execution strategies available.
-          </div>
+          <ExecutionButton
+            class="flex-auto flex items-center gap-2"
+            :class="{
+              'border-skin-link': executionStrategy === null,
+              'text-skin-border': executionStrategy !== null
+            }"
+            @click="executionStrategy = null"
+          >
+            <IH-cog />
+            No execution
+          </ExecutionButton>
           <ExecutionButton
             v-for="(executor, i) in supportedExecutionStrategies"
             :key="executor"

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -127,6 +127,14 @@ async function handleProposeClick() {
   }
 }
 
+async function handleExecutionStrategySelected(selectedExecutionStrategy: SelectedStrategy) {
+  if (executionStrategy.value?.address === selectedExecutionStrategy.address) {
+    executionStrategy.value = null;
+  } else {
+    executionStrategy.value = selectedExecutionStrategy;
+  }
+}
+
 async function getVotingPower() {
   if (!space.value || !web3.value.account) return;
 
@@ -259,17 +267,6 @@ watch(proposalData, () => {
         <h4 class="eyebrow mb-3">Execution</h4>
         <div class="flex flex-col gap-2 mb-3">
           <ExecutionButton
-            class="flex-auto flex items-center gap-2"
-            :class="{
-              'border-skin-link': executionStrategy === null,
-              'text-skin-border': executionStrategy !== null
-            }"
-            @click="executionStrategy = null"
-          >
-            <IH-cog />
-            No execution
-          </ExecutionButton>
-          <ExecutionButton
             v-for="(executor, i) in supportedExecutionStrategies"
             :key="executor"
             class="flex-auto flex items-center gap-2"
@@ -278,10 +275,10 @@ watch(proposalData, () => {
               'text-skin-border': executionStrategy?.address !== executor
             }"
             @click="
-              executionStrategy = {
+              handleExecutionStrategySelected({
                 address: executor,
                 type: space.executors_types[i]
-              }
+              })
             "
           >
             <IH-cog />

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -88,10 +88,13 @@ async function handleEditClick() {
     title: proposal.value.title,
     body: proposal.value.body,
     discussion: proposal.value.discussion,
-    executionStrategy: {
-      address: proposal.value.execution_strategy,
-      type: proposal.value.execution_strategy_type
-    },
+    executionStrategy:
+      proposal.value.execution_strategy_type === 'none'
+        ? null
+        : {
+            address: proposal.value.execution_strategy,
+            type: proposal.value.execution_strategy_type
+          },
     execution: proposal.value.execution
   });
 


### PR DESCRIPTION
## Summary

This PR enables option to create spaces with no execution strategies and proposals without execution.

Closes: https://github.com/snapshot-labs/sx-ui/issues/621

## Test plan

- Deploy space with no execution strategies.
- Create proposal with no execution (in space with no executions).
- Create proposal with no execution (in space with executions).
- Create proposal with execution (in space with executions).
- Edit proposal above to remove that execution (should disappear, quorum will remain as it needs sx-subgraph update).

## Screenshots

![image](https://user-images.githubusercontent.com/1968722/236270136-31833182-3cf0-49c2-b378-ef5f52621703.png)
