### PR TITLE
fix: offset cover photo 1px up to handle overscroll bug

### DIFF
--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -56,7 +56,7 @@ const grouped = computed(() => {
 
 <template>
   <div>
-    <div class="relative bg-skin-border h-[140px] -mb-[70px]">
+    <div class="relative bg-skin-border h-[140px] -mb-[70px] top-[-1px]">
       <div class="absolute right-4 top-4 space-x-2">
         <router-link :to="{ name: 'editor' }">
           <UiTooltip title="New proposal">

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -20,7 +20,7 @@ const user = computed(() => {
 <template>
   <UiLoading v-if="!usersStore.users[userId]?.loaded" class="block text-center p-4" />
   <div v-else-if="user">
-    <div class="relative bg-skin-border h-[140px] -mb-[70px]" />
+    <div class="relative bg-skin-border h-[140px] -mb-[70px] top-[-1px]" />
     <Container slim>
       <div class="text-center mb-4 relative">
         <Stamp :id="userId" :size="90" class="mb-2 border-[4px] border-skin-bg !bg-skin-border" />


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/609

On mobile scrolling with overscroll might result in inaccurate final position (it's overscrolled at rest by subpixel margin) causing background to be visible where it should be covered entirely by topnav.

This PR only affects Cover because it's the only thing that is currently impacted. If we find it happening in other places we could change app's margin from 72px to 71px to compensate.,