### PR TITLE
feat: add delegates page

### DIFF
--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -93,7 +93,13 @@ const definition = computed(() => {
               minLength: 1
             }
           }
-        : {})
+        : {}),
+      delegationApiUrl: {
+        type: 'string',
+        format: 'uri',
+        title: 'Delegation API URL',
+        examples: ['https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2']
+      }
     }
   };
 });

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -94,12 +94,26 @@ const definition = computed(() => {
             }
           }
         : {}),
-      delegationApiUrl: {
-        type: 'string',
-        format: 'uri',
-        title: 'Delegation API URL',
-        examples: ['https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2']
-      }
+      delegationApiType: {
+        type: ['string', 'null'],
+        enum: [null, 'governor-subgraph'],
+        options: [
+          { id: null, name: 'No delegation API' },
+          { id: 'governor-subgraph', name: 'Governor subgraph' }
+        ],
+        title: 'Delegation API type',
+        nullable: true
+      },
+      ...(props.form.delegationApiType !== null
+        ? {
+            delegationApiUrl: {
+              type: 'string',
+              format: 'uri',
+              title: 'Delegation API URL',
+              examples: ['https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2']
+            }
+          }
+        : {})
     }
   };
 });

--- a/src/components/Block/StrategiesConfigurator.vue
+++ b/src/components/Block/StrategiesConfigurator.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import IHCode from '~icons/heroicons-outline/code';
 import type { StrategyConfig, StrategyTemplate } from '@/networks/types';
 
 const props = withDefaults(

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -12,7 +12,8 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   discord: '',
   votingPowerSymbol: '',
   walletNetwork: null,
-  walletAddress: null
+  walletAddress: null,
+  delegationApiUrl: ''
 };
 
 const props = defineProps<{
@@ -59,6 +60,7 @@ watch(
     form.discord = props.space.discord;
     form.twitter = props.space.twitter;
     form.votingPowerSymbol = props.space.voting_power_symbol;
+    form.delegationApiUrl = props.space.delegation_api_url;
 
     const [walletNetwork, walletAddress] = props.space.wallet.split(':');
     if (walletNetwork && walletAddress) {

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -13,7 +13,8 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   votingPowerSymbol: '',
   walletNetwork: null,
   walletAddress: null,
-  delegationApiUrl: ''
+  delegationApiType: null,
+  delegationApiUrl: null
 };
 
 const props = defineProps<{
@@ -60,6 +61,7 @@ watch(
     form.discord = props.space.discord;
     form.twitter = props.space.twitter;
     form.votingPowerSymbol = props.space.voting_power_symbol;
+    form.delegationApiType = props.space.delegation_api_type;
     form.delegationApiUrl = props.space.delegation_api_url;
 
     const [walletNetwork, walletAddress] = props.space.wallet.split(':');

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -7,6 +7,7 @@ import { useSpacesStore } from '@/stores/spaces';
 import IHGlobeAlt from '~icons/heroicons-outline/globe-alt';
 import IHNewspaper from '~icons/heroicons-outline/newspaper';
 import IHCash from '~icons/heroicons-outline/cash';
+import IHLightningBolt from '~icons/heroicons-outline/lightning-bolt';
 import IHCog from '~icons/heroicons-outline/cog';
 import IHUsers from '~icons/heroicons-outline/users';
 import IHStop from '~icons/heroicons-outline/stop';
@@ -36,6 +37,14 @@ const navigationConfig = computed(() => ({
           treasury: {
             name: 'Treasury',
             icon: IHCash
+          }
+        }
+      : undefined),
+    ...(space.value?.delegation_api_url
+      ? {
+          delegates: {
+            name: 'Delegates',
+            icon: IHLightningBolt
           }
         }
       : undefined),

--- a/src/composables/useDelegates.ts
+++ b/src/composables/useDelegates.ts
@@ -1,0 +1,141 @@
+import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client/core';
+import gql from 'graphql-tag';
+
+type ApiDelegate = {
+  id: string;
+  delegatedVotes: string;
+  delegatedVotesRaw: string;
+  tokenHoldersRepresentedAmount: number;
+};
+
+type Delegate = ApiDelegate & {
+  delegatorsPercentage: number;
+  votesPercentage: number;
+};
+
+type Governance = {
+  delegatedVotes: string;
+  totalTokenHolders: string;
+  totalDelegates: string;
+};
+
+const DELEGATES_LIMIT = 50;
+
+const DELEGATES_QUERY = gql`
+  query ($first: Int!, $skip: Int!) {
+    delegates(first: $first, skip: $skip, orderBy: delegatedVotes, orderDirection: desc) {
+      id
+      delegatedVotes
+      delegatedVotesRaw
+      tokenHoldersRepresentedAmount
+    }
+    governance(id: "GOVERNANCE") {
+      delegatedVotes
+      totalTokenHolders
+      totalDelegates
+    }
+  }
+`;
+
+function convertUrl(apiUrl: string) {
+  const hostedPattern = /https:\/\/thegraph\.com\/hosted-service\/subgraph\/([\w-]+)\/([\w-]+)/;
+
+  const hostedMatch = apiUrl.match(hostedPattern);
+  if (hostedMatch) {
+    return `https://api.thegraph.com/subgraphs/name/${hostedMatch[1]}/${hostedMatch[2]}`;
+  }
+
+  return apiUrl;
+}
+
+export function useDelegates(delegationApiUrl: string) {
+  const delegates: Ref<Delegate[]> = ref([]);
+  const loading = ref(false);
+  const loadingMore = ref(false);
+  const loaded = ref(false);
+  const failed = ref(false);
+  const hasMore = ref(false);
+
+  const httpLink = createHttpLink({
+    uri: convertUrl(delegationApiUrl)
+  });
+
+  const apollo = new ApolloClient({
+    link: httpLink,
+    cache: new InMemoryCache({
+      addTypename: false
+    }),
+    defaultOptions: {
+      query: {
+        fetchPolicy: 'no-cache'
+      }
+    }
+  });
+
+  async function _fetch(overwrite: boolean) {
+    const { data } = await apollo.query({
+      query: DELEGATES_QUERY,
+      variables: {
+        first: DELEGATES_LIMIT,
+        skip: overwrite ? 0 : delegates.value.length
+      }
+    });
+
+    const governanceData = data.governance as Governance;
+    const delegatesData = data.delegates as ApiDelegate[];
+
+    const newDelegates = delegatesData.map((delegate: ApiDelegate) => {
+      const delegatorsPercentage =
+        (Number(delegate.tokenHoldersRepresentedAmount) /
+          Number(governanceData.totalTokenHolders)) *
+        100;
+      const votesPercentage =
+        (Number(delegate.delegatedVotes) / Number(governanceData.delegatedVotes)) * 100;
+
+      return {
+        ...delegate,
+        delegatorsPercentage,
+        votesPercentage
+      };
+    });
+
+    delegates.value = overwrite ? newDelegates : [...delegates.value, ...newDelegates];
+
+    hasMore.value = delegatesData.length === DELEGATES_LIMIT;
+  }
+
+  async function fetch() {
+    if (loading.value || loaded.value) return;
+    loading.value = true;
+
+    try {
+      await _fetch(true);
+
+      loaded.value = true;
+    } catch (err) {
+      failed.value = true;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function fetchMore() {
+    if (loading.value || !loaded.value) return;
+    loadingMore.value = true;
+
+    await _fetch(false);
+
+    loadingMore.value = false;
+  }
+
+  return {
+    loading,
+    loadingMore,
+    loaded,
+    failed,
+    hasMore,
+    delegates,
+    fetch,
+    fetchMore
+  };
+}

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -15,7 +15,8 @@ describe('utils', () => {
         discord: 'snapshot',
         votingPowerSymbol: 'VOTE',
         walletNetwork: 'gor',
-        walletAddress: '0x000000000000000000000000000000000000dead'
+        walletAddress: '0x000000000000000000000000000000000000dead',
+        delegationApiUrl: 'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2'
       });
 
       expect(metadata).toEqual({
@@ -28,7 +29,9 @@ describe('utils', () => {
           github: 'snapshot-labs',
           twitter: 'SnapshotLabs',
           discord: 'snapshot',
-          wallets: ['gor:0x000000000000000000000000000000000000dead']
+          wallets: ['gor:0x000000000000000000000000000000000000dead'],
+          delegation_api_url:
+            'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2'
         }
       });
     });

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -16,6 +16,7 @@ describe('utils', () => {
         votingPowerSymbol: 'VOTE',
         walletNetwork: 'gor',
         walletAddress: '0x000000000000000000000000000000000000dead',
+        delegationApiType: 'governor-subgraph',
         delegationApiUrl: 'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2'
       });
 
@@ -30,6 +31,7 @@ describe('utils', () => {
           twitter: 'SnapshotLabs',
           discord: 'snapshot',
           wallets: ['gor:0x000000000000000000000000000000000000dead'],
+          delegation_api_type: 'governor-subgraph',
           delegation_api_url:
             'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2'
         }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -226,6 +226,7 @@ export function createErc1155Metadata(
     description: metadata.description,
     external_url: metadata.externalUrl,
     properties: {
+      delegation_api_type: metadata.delegationApiType,
       delegation_api_url: metadata.delegationApiUrl,
       voting_power_symbol: metadata.votingPowerSymbol,
       github: metadata.github,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -226,6 +226,7 @@ export function createErc1155Metadata(
     description: metadata.description,
     external_url: metadata.externalUrl,
     properties: {
+      delegation_api_url: metadata.delegationApiUrl,
       voting_power_symbol: metadata.votingPowerSymbol,
       github: metadata.github,
       twitter: metadata.twitter,

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -217,6 +217,7 @@ export const SPACE_QUERY = gql`
       discord
       voting_power_symbol
       wallet
+      delegation_api_type
       delegation_api_url
       controller
       voting_delay

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -217,6 +217,7 @@ export const SPACE_QUERY = gql`
       discord
       voting_power_symbol
       wallet
+      delegation_api_url
       controller
       voting_delay
       min_voting_period
@@ -254,6 +255,7 @@ export const SPACES_QUERY = gql`
       discord
       voting_power_symbol
       wallet
+      delegation_api_url
       controller
       voting_delay
       min_voting_period

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@ import SpaceProposals from '@/views/Space/Proposals.vue';
 import SpaceSearchProposals from '@/views/Space/SearchProposals.vue';
 import SpaceSettings from '@/views/Space/Settings.vue';
 import SpaceTreasury from '@/views/Space/Treasury.vue';
+import SpaceDelegates from '@/views/Space/Delegates.vue';
 import Editor from '@/views/Editor.vue';
 import Proposal from '@/views/Proposal.vue';
 import User from '@/views/User.vue';
@@ -26,7 +27,8 @@ const routes: any[] = [
       { path: 'proposals', name: 'space-proposals', component: SpaceProposals },
       { path: 'search', name: 'space-search-proposals', component: SpaceSearchProposals },
       { path: 'settings', name: 'space-settings', component: SpaceSettings },
-      { path: 'treasury', name: 'space-treasury', component: SpaceTreasury }
+      { path: 'treasury', name: 'space-treasury', component: SpaceTreasury },
+      { path: 'delegates', name: 'space-delegates', component: SpaceDelegates }
     ]
   },
   {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type SpaceMetadata = {
   votingPowerSymbol: string;
   walletNetwork: NetworkID | null;
   walletAddress: string | null;
+  delegationApiUrl: string;
 };
 
 export type SpaceSettings = {
@@ -43,6 +44,7 @@ export type Space = {
   avatar: string;
   about?: string;
   external_url: string;
+  delegation_api_url: string;
   twitter: string;
   github: string;
   discord: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ export type SpaceMetadata = {
   votingPowerSymbol: string;
   walletNetwork: NetworkID | null;
   walletAddress: string | null;
-  delegationApiUrl: string;
+  delegationApiType: string | null;
+  delegationApiUrl: string | null;
 };
 
 export type SpaceSettings = {
@@ -44,7 +45,8 @@ export type Space = {
   avatar: string;
   about?: string;
   external_url: string;
-  delegation_api_url: string;
+  delegation_api_type: string | null;
+  delegation_api_url: string | null;
   twitter: string;
   github: string;
   discord: string;

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -71,7 +71,8 @@ const metadataForm: SpaceMetadata = reactive(
     votingPowerSymbol: '',
     walletNetwork: null,
     walletAddress: null,
-    delegationApiUrl: ''
+    delegationApiType: null,
+    delegationApiUrl: null
   })
 );
 const selectedNetworkId: Ref<NetworkID> = ref('gor');

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -70,7 +70,8 @@ const metadataForm: SpaceMetadata = reactive(
     discord: '',
     votingPowerSymbol: '',
     walletNetwork: null,
-    walletAddress: null
+    walletAddress: null,
+    delegationApiUrl: ''
   })
 );
 const selectedNetworkId: Ref<NetworkID> = ref('gor');

--- a/src/views/Space/Delegates.vue
+++ b/src/views/Space/Delegates.vue
@@ -6,7 +6,7 @@ import { Space } from '@/types';
 const props = defineProps<{ space: Space }>();
 
 const { loading, loadingMore, loaded, failed, hasMore, delegates, fetch, fetchMore } = useDelegates(
-  props.space.delegation_api_url
+  props.space.delegation_api_url as string
 );
 
 const currentNetwork = computed(() => {

--- a/src/views/Space/Delegates.vue
+++ b/src/views/Space/Delegates.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { _n, shorten } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
+import { Space } from '@/types';
+
+const props = defineProps<{ space: Space }>();
+
+const { loading, loadingMore, loaded, failed, hasMore, delegates, fetch, fetchMore } = useDelegates(
+  props.space.delegation_api_url
+);
+
+const currentNetwork = computed(() => {
+  if (!props.space.wallet) return null;
+
+  try {
+    return getNetwork(props.space.network);
+  } catch (err) {
+    return null;
+  }
+});
+
+async function handleEndReached() {
+  if (!hasMore.value) return;
+
+  await fetchMore();
+}
+
+onMounted(() => {
+  if (!props.space.delegation_api_url) return;
+
+  fetch();
+});
+</script>
+
+<template>
+  <div
+    v-if="!currentNetwork || !space.delegation_api_url"
+    class="p-4 flex items-center text-skin-link"
+  >
+    <IH-exclamation-circle class="inline-block mr-2" />
+    No delegation API configured.
+  </div>
+  <template v-else>
+    <div class="p-4 space-x-2 flex">
+      <div class="flex-auto" />
+      <UiTooltip title="Delegate">
+        <UiButton class="!px-0 w-[46px]">
+          <IS-user-plus class="inline-block" />
+        </UiButton>
+      </UiTooltip>
+    </div>
+    <div class="space-y-3">
+      <div>
+        <Label label="Delegates" sticky />
+        <UiLoading v-if="loading && !loaded" class="px-4 py-3 block" />
+        <div
+          v-else-if="loaded && delegates.length === 0"
+          class="px-4 py-3 flex items-center text-skin-link"
+        >
+          <IH-exclamation-circle class="inline-block mr-2" />
+          There are no delegates.
+        </div>
+        <div v-else-if="failed" class="px-4 py-3 flex items-center text-skin-link">
+          <IH-exclamation-circle class="inline-block mr-2" />
+          Failed to load delegates.
+        </div>
+        <BlockInfiniteScroller :loading-more="loadingMore" @end-reached="handleEndReached">
+          <a
+            v-for="delegate in delegates"
+            :key="delegate.id"
+            :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')"
+            target="_blank"
+            class="flex justify-between items-center mx-4 py-3 border-b text-skin-text"
+          >
+            <Stamp :id="delegate.id" type="avatar" :size="32" class="mr-3" />
+            <div class="flex-1 leading-[22px]">
+              <h4 class="text-skin-link" v-text="shorten(delegate.id)" />
+              <div class="text-sm" v-text="shorten(delegate.id)" />
+            </div>
+            <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px]">
+              <h4
+                class="text-skin-link"
+                v-text="`${delegate.tokenHoldersRepresentedAmount} delegator(s)`"
+              />
+              <div class="text-sm" v-text="`${delegate.delegatorsPercentage.toFixed(3)}%`" />
+            </div>
+            <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px]">
+              <h4 class="text-skin-link" v-text="_n(delegate.delegatedVotes)" />
+              <div class="text-sm" v-text="`${delegate.votesPercentage.toFixed(3)}%`" />
+            </div>
+          </a>
+        </BlockInfiniteScroller>
+      </div>
+    </div>
+  </template>
+</template>

--- a/src/views/Space/Delegates.vue
+++ b/src/views/Space/Delegates.vue
@@ -77,7 +77,9 @@ onMounted(() => {
               <h4 class="text-skin-link" v-text="shorten(delegate.id)" />
               <div class="text-sm" v-text="shorten(delegate.id)" />
             </div>
-            <div class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px]">
+            <div
+              class="flex-col items-end text-right leading-[22px] w-auto md:w-[180px] hidden md:block"
+            >
               <h4
                 class="text-skin-link"
                 v-text="`${delegate.tokenHoldersRepresentedAmount} delegator(s)`"


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/566

This PR adds adds delegates page that can be added to the space by configuring API url.

## Test plan

- Create new space or edit existing space profile to add delegation API URL (for example `https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2`).
- Go to space page.
- Go to Delegates page.

## Screenshots

![image](https://user-images.githubusercontent.com/1968722/236439318-90d87f23-5e08-4ba9-a73c-1ae461f9faab.png)
