### PR TITLE
refactor: use getProvider for evm network

### DIFF
--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -115,7 +115,7 @@ async function handleToChange(to: string) {
   showAbiInput.value = false;
   if (isAddress(to)) {
     loading.value = true;
-    const provider = getProvider('5');
+    const provider = getProvider(5);
     const code = await provider.getCode(to);
     if (code !== '0x') {
       console.log('Address is valid');

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -5,7 +5,7 @@ import { call } from '@/helpers/call';
 export async function getNames(addresses) {
   addresses = addresses.slice(0, 250).filter(isAddress);
   if (addresses.length === 0) return {};
-  const network = '1';
+  const network = 1;
   const provider = getProvider(network);
   const abi = [
     {

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -1,13 +1,16 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 
-const providers = {};
+const providers: Record<number, StaticJsonRpcProvider | undefined> = {};
 
-export function getProvider(networkId: string | number) {
-  const url = `https://brovider.xyz/${networkId}`;
+export function getProvider(networkId: number): StaticJsonRpcProvider {
+  const url = `https://rpc.brovider.xyz/${networkId}`;
 
-  if (!providers[networkId]) {
-    providers[networkId] = new StaticJsonRpcProvider({ url, timeout: 25000 });
+  let provider = providers[networkId];
+
+  if (!provider) {
+    provider = new StaticJsonRpcProvider({ url, timeout: 25000 });
+    providers[networkId] = provider;
   }
 
-  return providers[networkId];
+  return provider;
 }

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -3,7 +3,7 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers';
 const providers: Record<number, StaticJsonRpcProvider | undefined> = {};
 
 export function getProvider(networkId: number): StaticJsonRpcProvider {
-  const url = `https://rpc.brovider.xyz/${networkId}`;
+  const url = `https://rpc.snapshotx.xyz/${networkId}`;
 
   let provider = providers[networkId];
 

--- a/src/helpers/provider.ts
+++ b/src/helpers/provider.ts
@@ -8,7 +8,7 @@ export function getProvider(networkId: number): StaticJsonRpcProvider {
   let provider = providers[networkId];
 
   if (!provider) {
-    provider = new StaticJsonRpcProvider({ url, timeout: 25000 });
+    provider = new StaticJsonRpcProvider({ url, timeout: 25000 }, networkId);
     providers[networkId] = provider;
   }
 

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -1,8 +1,8 @@
 import { createApi } from '../common/graphqlApi';
 import { createActions } from './actions';
-import { createProvider } from './provider';
 import * as constants from './constants';
 import { pinGraph } from '@/helpers/graph';
+import { getProvider } from '@/helpers/provider';
 import networks from '@/helpers/networks.json';
 import { Network } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
@@ -10,7 +10,7 @@ import { NetworkID, Space } from '@/types';
 export function createEvmNetwork(networkId: NetworkID): Network {
   const chainId = 5;
 
-  const provider = createProvider(`https://rpc.brovider.xyz/${chainId}`);
+  const provider = getProvider(chainId);
   const api = createApi(constants.API_URL, networkId);
 
   const helpers = {

--- a/src/networks/evm/provider.ts
+++ b/src/networks/evm/provider.ts
@@ -1,5 +1,0 @@
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
-
-export function createProvider(RPC_URL: string) {
-  return new StaticJsonRpcProvider(RPC_URL);
-}


### PR DESCRIPTION
Closes #623

Currently we use two different StaticJsonRpcProviders that causes seperate eth_chanId requests. We can reuse single instance to avoid this.