### PR TITLE
refactor: make Editor respond to route changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,7 @@ watch(route, () => {
           'translate-x-[72px] lg:translate-x-0': uiStore.sidebarOpen
         }"
       >
-        <router-view :key="route.path" class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
+        <router-view class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
       </div>
     </div>
     <Notifications />

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,7 @@ watch(route, () => {
           'translate-x-[72px] lg:translate-x-0': uiStore.sidebarOpen
         }"
       >
-        <router-view class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
+        <router-view :key="route.path" class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
       </div>
     </div>
     <Notifications />

--- a/src/components/Modal/Drafts.vue
+++ b/src/components/Modal/Drafts.vue
@@ -9,12 +9,18 @@ defineEmits<{
   (e: 'close');
 }>();
 
+const router = useRouter();
 const { drafts, removeDraft } = useEditor();
 const { open } = toRefs(props);
 
 const spaceDrafts = computed(() =>
   drafts.value.filter(draft => draft.space === props.space && draft.networkId === props.networkId)
 );
+
+function handleRemoveDraft(id: string) {
+  router.replace({ name: 'editor' });
+  removeDraft(id);
+}
 </script>
 
 <template>
@@ -39,7 +45,7 @@ const spaceDrafts = computed(() =>
             {{ proposal.title || 'Untitled' }}
             <span class="text-skin-text">#{{ proposal.key }}</span>
           </router-link>
-          <a @click="removeDraft(proposal.id)">
+          <a @click="handleRemoveDraft(proposal.id)">
             <IH-trash class="mr-2" />
           </a>
         </div>

--- a/src/components/Modal/Drafts.vue
+++ b/src/components/Modal/Drafts.vue
@@ -9,6 +9,8 @@ defineEmits<{
   (e: 'close');
 }>();
 
+const { param } = useRouteParser('id');
+const route = useRoute();
 const router = useRouter();
 const { drafts, removeDraft } = useEditor();
 const { open } = toRefs(props);
@@ -18,7 +20,12 @@ const spaceDrafts = computed(() =>
 );
 
 function handleRemoveDraft(id: string) {
-  router.replace({ name: 'editor' });
+  const currentId = `${param.value}:${route.params.key}`;
+
+  if (currentId === id) {
+    router.replace({ name: 'editor' });
+  }
+
   removeDraft(id);
 }
 </script>

--- a/src/composables/useEditor.ts
+++ b/src/composables/useEditor.ts
@@ -29,9 +29,10 @@ function generateId() {
 
 function createDraft(
   spaceId: string,
-  payload?: Partial<Draft> & { id?: string; proposalId?: number }
+  payload?: Partial<Draft> & { proposalId?: number },
+  draftKey?: string
 ) {
-  const id = payload?.id || generateId();
+  const id = draftKey || generateId();
   const key = `${spaceId}:${id}`;
 
   proposals[key] = {

--- a/src/composables/useRouteParser.ts
+++ b/src/composables/useRouteParser.ts
@@ -1,0 +1,15 @@
+import { NetworkID } from '@/types';
+
+export function useRouteParser(paramName: string) {
+  const route = useRoute();
+
+  const param = computed(() => route.params[paramName] as string);
+  const networkId = computed(() => param.value.split(':')[0] as NetworkID);
+  const address = computed(() => param.value.split(':')[1]);
+
+  return {
+    param,
+    networkId,
+    address
+  };
+}

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -233,7 +233,12 @@ export default defineComponent({
         You do not have enough voting power to create proposal in this space.
       </UiAlert>
       <h4 class="eyebrow mb-3">Context</h4>
-      <SIString v-model="proposal.title" :definition="TITLE_DEFINITION" :error="formErrors.title" />
+      <SIString
+        :key="proposalKey"
+        v-model="proposal.title"
+        :definition="TITLE_DEFINITION"
+        :error="formErrors.title"
+      />
       <div class="flex">
         <Link
           :is-active="!previewEnabled"
@@ -253,11 +258,12 @@ export default defineComponent({
         <div class="s-label" v-text="'Description'" />
         <textarea v-model="proposal.body" maxlength="9600" class="s-input mb-3 h-[160px]" />
         <SIString
+          :key="proposalKey"
           v-model="proposal.discussion"
           :definition="DISCUSSION_DEFINITION"
           :error="formErrors.discussion"
         />
-        <Preview :url="proposal.discussion" />
+        <Preview :key="proposalKey" :url="proposal.discussion" />
       </div>
       <div v-if="space">
         <h4 class="eyebrow mb-3">Execution</h4>

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -3,7 +3,7 @@ import { useSpacesStore } from '@/stores/spaces';
 import { getNetwork } from '@/networks';
 import { omit, shortenAddress } from '@/helpers/utils';
 import { validateForm } from '@/helpers/validation';
-import { NetworkID, SelectedStrategy } from '@/types';
+import { SelectedStrategy } from '@/types';
 
 const TITLE_DEFINITION = {
   type: 'string',
@@ -19,17 +19,12 @@ const DISCUSSION_DEFINITION = {
 };
 
 const { proposals, createDraft } = useEditor();
-const { modalOpen: globalModalOpen } = useModal();
+const { param, networkId, address } = useRouteParser('id');
 const route = useRoute();
 const router = useRouter();
 const { propose, updateProposal } = useActions();
 const { web3 } = useWeb3();
 const spacesStore = useSpacesStore();
-
-const id = route.params.id as string;
-const [networkId, spaceId] = id.split(':');
-const key = route.params.key as string;
-const proposalKey = `${id}:${key}`;
 
 const modalOpen = ref(false);
 const previewEnabled = ref(false);
@@ -37,8 +32,28 @@ const sending = ref(false);
 const fetchingVotingPower = ref(true);
 const votingPowerValid = ref(false);
 
-const network = computed(() => getNetwork(networkId as NetworkID));
-const space = computed(() => spacesStore.spacesMap.get(id));
+const network = computed(() => getNetwork(networkId.value));
+const space = computed(() => spacesStore.spacesMap.get(param.value));
+const proposalKey = computed(() => {
+  const key = route.params.key as string;
+  return `${param.value}:${key}`;
+});
+const proposal = computed(() => {
+  if (!proposals[proposalKey.value]) {
+    createDraft(param.value, undefined, route.params.key as string);
+  }
+
+  return proposals[proposalKey.value];
+});
+const proposalData = computed(() => JSON.stringify(omit(proposal.value, ['updatedAt'])));
+const executionStrategy = computed({
+  get() {
+    return proposal.value.executionStrategy;
+  },
+  set(value: SelectedStrategy | null) {
+    proposal.value.executionStrategy = value;
+  }
+});
 const supportedExecutionStrategies = computed(() => {
   const spaceValue = space.value;
   if (!spaceValue) return null;
@@ -46,19 +61,6 @@ const supportedExecutionStrategies = computed(() => {
   return spaceValue.executors.filter(
     (_, i) => network.value.constants.SUPPORTED_EXECUTORS[spaceValue.executors_types[i]]
   );
-});
-const executionStrategy = computed({
-  get() {
-    return proposals[proposalKey].executionStrategy;
-  },
-  set(value: SelectedStrategy | null) {
-    proposals[proposalKey].executionStrategy = value;
-  }
-});
-const proposalData = computed(() => {
-  if (!proposals[proposalKey]) return null;
-
-  return JSON.stringify(omit(proposals[proposalKey], ['updatedAt']));
 });
 const formErrors = computed(() =>
   validateForm(
@@ -73,8 +75,8 @@ const formErrors = computed(() =>
       }
     },
     {
-      title: proposals[proposalKey].title,
-      discussion: proposals[proposalKey].discussion
+      title: proposal.value.title,
+      discussion: proposal.value.discussion
     },
     {
       skipEmptyOptionalFields: true
@@ -89,36 +91,31 @@ const canSubmit = computed(() => {
   );
 });
 
-if (!proposals[proposalKey]) {
-  createDraft(id, { id: key });
-}
-
 async function handleProposeClick() {
-  const proposal = proposals[proposalKey];
   if (!space.value) return;
 
   sending.value = true;
 
   try {
     let result;
-    if (proposal.proposalId) {
+    if (proposal.value.proposalId) {
       result = await updateProposal(
         space.value,
-        proposal.proposalId,
-        proposal.title,
-        proposal.body,
-        proposal.discussion,
-        proposal.executionStrategy?.address ?? null,
-        proposal.executionStrategy?.address ? proposal.execution : []
+        proposal.value.proposalId,
+        proposal.value.title,
+        proposal.value.body,
+        proposal.value.discussion,
+        proposal.value.executionStrategy?.address ?? null,
+        proposal.value.executionStrategy?.address ? proposal.value.execution : []
       );
     } else {
       result = await propose(
         space.value,
-        proposal.title,
-        proposal.body,
-        proposal.discussion,
-        proposal.executionStrategy?.address ?? null,
-        proposal.executionStrategy?.address ? proposal.execution : []
+        proposal.value.title,
+        proposal.value.body,
+        proposal.value.discussion,
+        proposal.value.executionStrategy?.address ?? null,
+        proposal.value.executionStrategy?.address ? proposal.value.execution : []
       );
     }
     if (result) router.back();
@@ -159,44 +156,51 @@ async function getVotingPower() {
   }
 }
 
-onMounted(() => {
-  spacesStore.fetchSpace(spaceId, networkId as NetworkID);
-
-  if (!key && route.name) {
-    globalModalOpen.value = false;
-
-    const draftId = createDraft(id);
-
-    router.replace({
-      name: route.name,
-      params: { id, key: draftId }
-    });
-  }
-});
-
-watch([space, () => web3.value.account], () => getVotingPower());
-
 watch(
-  () => proposals[proposalKey],
-  (to, from) => {
-    if (from && !to) {
-      router.replace({ name: 'editor' });
-    }
-  }
+  [networkId, address],
+  ([networkId, address]) => {
+    spacesStore.fetchSpace(address, networkId);
+  },
+  { immediate: true }
 );
-
+watch([space, () => web3.value.account], () => getVotingPower());
 watch(proposalData, () => {
-  if (!proposals[proposalKey]) return;
-
-  proposals[proposalKey].updatedAt = Date.now();
+  proposal.value.updatedAt = Date.now();
 });
 </script>
+
+<script lang="ts">
+import { NavigationGuard } from 'vue-router';
+const { createDraft } = useEditor();
+
+const handleRouteChange: NavigationGuard = to => {
+  if (to.params.key) {
+    return true;
+  }
+
+  const draftId = createDraft(to.params.id as string);
+
+  return {
+    ...to,
+    params: {
+      ...to.params,
+      key: draftId
+    }
+  };
+};
+
+export default defineComponent({
+  beforeRouteEnter: handleRouteChange,
+  beforeRouteUpdate: handleRouteChange
+});
+</script>
+
 <template>
   <div>
     <nav class="border-b bg-skin-bg fixed top-0 z-50 right-0 left-0 lg:left-[72px]">
       <div class="flex items-center h-[71px] mx-4">
         <div class="flex-auto space-x-2">
-          <router-link :to="{ name: 'space-overview', params: { id } }" class="mr-2">
+          <router-link :to="{ name: 'space-overview', params: { id: param } }" class="mr-2">
             <UiButton class="leading-3 w-[46px] !px-0">
               <IH-arrow-narrow-left class="inline-block" />
             </UiButton>
@@ -217,23 +221,19 @@ watch(proposalData, () => {
           >
             <span
               class="hidden mr-2 md:inline-block"
-              v-text="proposals[proposalKey].proposalId ? 'Update' : 'Publish'"
+              v-text="proposal.proposalId ? 'Update' : 'Publish'"
             />
             <IH-paper-airplane class="inline-block rotate-90" />
           </UiButton>
         </div>
       </div>
     </nav>
-    <Container v-if="proposals[proposalKey]" class="pt-5 s-box">
+    <Container v-if="proposal" class="pt-5 s-box">
       <UiAlert v-if="!fetchingVotingPower && !votingPowerValid" type="error" class="mb-4">
         You do not have enough voting power to create proposal in this space.
       </UiAlert>
       <h4 class="eyebrow mb-3">Context</h4>
-      <SIString
-        v-model="proposals[proposalKey].title"
-        :definition="TITLE_DEFINITION"
-        :error="formErrors.title"
-      />
+      <SIString v-model="proposal.title" :definition="TITLE_DEFINITION" :error="formErrors.title" />
       <div class="flex">
         <Link
           :is-active="!previewEnabled"
@@ -246,22 +246,18 @@ watch(proposalData, () => {
       <Markdown
         v-if="previewEnabled"
         class="px-3 py-2 border rounded-lg mb-5 min-h-[200px]"
-        :body="proposals[proposalKey].body"
+        :body="proposal.body"
       />
 
       <div v-else class="s-base mb-3">
         <div class="s-label" v-text="'Description'" />
-        <textarea
-          v-model="proposals[proposalKey].body"
-          maxlength="9600"
-          class="s-input mb-3 h-[160px]"
-        />
+        <textarea v-model="proposal.body" maxlength="9600" class="s-input mb-3 h-[160px]" />
         <SIString
-          v-model="proposals[proposalKey].discussion"
+          v-model="proposal.discussion"
           :definition="DISCUSSION_DEFINITION"
           :error="formErrors.discussion"
         />
-        <Preview :url="proposals[proposalKey].discussion" />
+        <Preview :url="proposal.discussion" />
       </div>
       <div v-if="space">
         <h4 class="eyebrow mb-3">Execution</h4>
@@ -289,7 +285,7 @@ watch(proposalData, () => {
         </div>
         <BlockExecutionEditable
           v-if="executionStrategy"
-          v-model="proposals[proposalKey].execution"
+          v-model="proposal.execution"
           :selected-execution-strategy="executionStrategy"
           :space="space"
           class="mb-4"
@@ -300,7 +296,7 @@ watch(proposalData, () => {
       <ModalDrafts
         :open="modalOpen"
         :network-id="networkId"
-        :space="spaceId"
+        :space="address"
         @close="modalOpen = false"
       />
     </teleport>


### PR DESCRIPTION
Currently Editor doesn't work with changing routes as it handles some set up at mount time only.
This PR makes this component work with dynamic routes that makes it possible for it to be reused across rerenders instead of being unmounted and remounted as currently (we do this by setting key on router component), but it's wasteful. We should instead make our views handle those changes properly:
- https://router.vuejs.org/guide/advanced/data-fetching.html#fetching-after-navigation

This commit only handles Editor, but there are other views that have the same issue (but are easier to refactor), so will be updated separately.

## Test plan

- Play with editor, nothing should be broken.