### PR TITLE
refactor: handle route params with reactivity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,7 @@ watch(route, () => {
           'translate-x-[72px] lg:translate-x-0': uiStore.sidebarOpen
         }"
       >
-        <router-view :key="route.path" class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
+        <router-view class="flex-auto mt-[72px] ml-0 lg:ml-[72px]" />
       </div>
     </div>
     <Notifications />

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
 import { useUiStore } from '@/stores/ui';
 import { useSpacesStore } from '@/stores/spaces';
-import type { NetworkID } from '@/types';
 
+const { param, networkId, address } = useRouteParser('id');
 const uiStore = useUiStore();
-const route = useRoute();
 const spacesStore = useSpacesStore();
-const id = route.params.id as string;
-const [networkId, spaceId] = id.split(':');
 
-onMounted(() => {
-  spacesStore.fetchSpace(spaceId, networkId as NetworkID);
+const space = computed(() => spacesStore.spacesMap.get(param.value));
+
+watch([networkId, address], ([networkId, address]) => spacesStore.fetchSpace(address, networkId), {
+  immediate: true
 });
 </script>
 
@@ -21,8 +20,8 @@ onMounted(() => {
         class="ml-0 lg:ml-[240px] mr-0 xl:mr-[240px]"
         :class="{ 'translate-x-[240px] lg:translate-x-0': uiStore.sidebarOpen }"
       >
-        <UiLoading v-if="!spacesStore.spacesMap.has(id)" class="block p-4" />
-        <router-view v-else :space="spacesStore.spacesMap.get(id)" />
+        <UiLoading v-if="!space" class="block p-4" />
+        <router-view v-else :space="space" />
       </div>
       <div class="invisible xl:visible fixed w-[240px] border-l bottom-0 top-[72px] right-0" />
     </div>

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -1,30 +1,25 @@
 <script setup lang="ts">
 import { useUsersStore } from '@/stores/users';
 import { shortenAddress } from '@/helpers/utils';
-import type { NetworkID } from '@/types';
 
-const route = useRoute();
+const { networkId, address } = useRouteParser('id');
 const usersStore = useUsersStore();
-const id = route.params.id as string;
-const [networkId, userId] = id.split(':');
 
-onMounted(() => {
-  usersStore.fetchUser(userId, networkId as NetworkID);
-});
+const user = computed(() => usersStore.getUser(address.value));
 
-const user = computed(() => {
-  return usersStore.getUser(userId);
+watch([networkId, address], () => usersStore.fetchUser(address.value, networkId.value), {
+  immediate: true
 });
 </script>
 
 <template>
-  <UiLoading v-if="!usersStore.users[userId]?.loaded" class="block text-center p-4" />
-  <div v-else-if="user">
+  <UiLoading v-if="!user" class="block text-center p-4" />
+  <div v-else>
     <div class="relative bg-skin-border h-[140px] -mb-[70px] top-[-1px]" />
     <Container slim>
       <div class="text-center mb-4 relative">
-        <Stamp :id="userId" :size="90" class="mb-2 border-[4px] border-skin-bg !bg-skin-border" />
-        <h1>{{ shortenAddress(userId) }}</h1>
+        <Stamp :id="user.id" :size="90" class="mb-2 border-[4px] border-skin-bg !bg-skin-border" />
+        <h1>{{ shortenAddress(user.id) }}</h1>
         <div>
           <b class="text-skin-link">{{ user.proposal_count }}</b> proposals ·
           <b class="text-skin-link">{{ user.vote_count }}</b> votes


### PR DESCRIPTION
Depends on https://github.com/snapshot-labs/sx-ui/pull/634

This is continuation of Editor refactor, this time removing static handling of route params in other components.

With those changes we can now remove workaround for :key on router to force remounts and instead can reuse when routes change.

## Test plan

- Play with the app, nothing should break.