### PR TITLE
feat: add composable based resolver

### DIFF
--- a/src/components/Modal/Drafts.vue
+++ b/src/components/Modal/Drafts.vue
@@ -9,7 +9,6 @@ defineEmits<{
   (e: 'close');
 }>();
 
-const { param } = useRouteParser('id');
 const route = useRoute();
 const router = useRouter();
 const { drafts, removeDraft } = useEditor();
@@ -20,7 +19,7 @@ const spaceDrafts = computed(() =>
 );
 
 function handleRemoveDraft(id: string) {
-  const currentId = `${param.value}:${route.params.key}`;
+  const currentId = `${props.networkId}:${props.space}:${route.params.key}`;
 
   if (currentId === id) {
     router.replace({ name: 'editor' });

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -16,9 +16,13 @@ const route = useRoute();
 const uiStore = useUiStore();
 const spacesStore = useSpacesStore();
 
+const { param } = useRouteParser('id');
+const { resolved, address, networkId } = useResolve(param);
 const currentRouteName = computed(() => String(route.matched[0]?.name));
 const space = computed(() =>
-  currentRouteName.value === 'space' ? spacesStore.spacesMap.get(route.params.id as string) : null
+  currentRouteName.value === 'space' && resolved.value
+    ? spacesStore.spacesMap.get(`${networkId.value}:${address.value}`)
+    : null
 );
 const { treasury } = useTreasury(space);
 

--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -4,6 +4,7 @@ import type { Proposal as ProposalType, Choice } from '@/types';
 
 const props = defineProps<{ proposal: ProposalType }>();
 
+const route = useRoute();
 const { vote } = useActions();
 const modalOpenVotes = ref(false);
 const modalOpenTimeline = ref(false);
@@ -28,7 +29,7 @@ async function handleVoteClick(choice: Choice) {
             name: 'proposal',
             params: {
               id: proposal.proposal_id,
-              space: `${proposal.network}:${proposal.space.id}`
+              space: `${route.params.id}`
             }
           }"
           class="block max-w-fit"

--- a/src/composables/useResolve.ts
+++ b/src/composables/useResolve.ts
@@ -1,0 +1,31 @@
+import { resolver } from '@/helpers/resolver';
+import { NetworkID } from '@/types';
+
+export function useResolve(id: Ref<string>) {
+  const resolved = ref(false);
+  const networkId: Ref<NetworkID | null> = ref(null);
+  const address: Ref<string | null> = ref(null);
+
+  watch(
+    id,
+    async id => {
+      if (!id) return;
+
+      resolved.value = false;
+
+      const resolvedName = await resolver.resolveName(id);
+      if (resolvedName) {
+        networkId.value = resolvedName.networkId;
+        address.value = resolvedName.address;
+        resolved.value = true;
+      }
+    },
+    { immediate: true }
+  );
+
+  return {
+    resolved,
+    networkId,
+    address
+  };
+}

--- a/src/helpers/resolver.ts
+++ b/src/helpers/resolver.ts
@@ -1,0 +1,71 @@
+import { getProvider } from '@/helpers/provider';
+import { NetworkID } from '@/types';
+
+const provider = getProvider(5);
+
+type ResolvedName = {
+  networkId: NetworkID;
+  address: string;
+};
+
+function memoize<T extends any[], U>(fn: (...args: T) => U) {
+  const cache = new Map<string, any>();
+
+  return (...args: T): U => {
+    const key = JSON.stringify(args);
+
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+
+    const result = fn(...args);
+    cache.set(key, result);
+
+    return result;
+  };
+}
+
+function createResolver() {
+  const cache = new Map<string, ResolvedName | null>();
+
+  function resolveStatic(id: string): ResolvedName | null {
+    const parts = id.split(':');
+
+    return {
+      networkId: parts[0] as NetworkID,
+      address: parts[1]
+    };
+  }
+
+  async function resolveEns(id: string): Promise<ResolvedName | null> {
+    const resolvedAddress = await provider.resolveName(id);
+
+    if (!resolvedAddress) {
+      return null;
+    }
+
+    return {
+      networkId: 'gor',
+      address: resolvedAddress.toLocaleLowerCase()
+    };
+  }
+
+  async function resolveName(id: string) {
+    if (cache.has(id)) {
+      return cache.get(id);
+    }
+
+    const resolved = id.endsWith('.eth') ? await resolveEns(id) : resolveStatic(id);
+    if (resolved) {
+      cache.set(id, resolved);
+    }
+
+    return resolved;
+  }
+
+  return {
+    resolveName: memoize(resolveName)
+  };
+}
+
+export const resolver = createResolver();

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -2,15 +2,28 @@
 import { useUiStore } from '@/stores/ui';
 import { useSpacesStore } from '@/stores/spaces';
 
-const { param, networkId, address } = useRouteParser('id');
+const { param } = useRouteParser('id');
+const { resolved, address, networkId } = useResolve(param);
 const uiStore = useUiStore();
 const spacesStore = useSpacesStore();
 
-const space = computed(() => spacesStore.spacesMap.get(param.value));
+const space = computed(() => {
+  if (!resolved.value) return null;
 
-watch([networkId, address], ([networkId, address]) => spacesStore.fetchSpace(address, networkId), {
-  immediate: true
+  return spacesStore.spacesMap.get(`${networkId.value}:${address.value}`);
 });
+
+watch(
+  [resolved, networkId, address],
+  ([resolved, networkId, address]) => {
+    if (!resolved || !networkId || !address) return;
+
+    spacesStore.fetchSpace(address, networkId);
+  },
+  {
+    immediate: true
+  }
+);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/389

This PR implements ENS resolver that uses composable to perform resolving.

I experimented with different approaches, but neither seems super clean.
1. composable approach (this PR) - underlying app uses raw NetworkID/address pair still, conversion is done wherever we accept domain from user. Benefits are that the rest of the app doesn't need to worry about different domain names. Con is that you have to resolve (by using `useResolve` composable) in all places that you expect to see domains.
2. store approach - we could modify our stores to accept IDs instead of NetworkID/address pairs when fetching and reading data (`fetchSpace(id: string)`, `getSpace(id: string)`) and let those stores to perform conversion (resolve on fetch, lookup from `namesStore` when getting values). The issues I've found with this approach are:
    1. quite often we still need to resolve networkId/address at view level so we can't just stick with string ids there (for example some components need Network access, or need to know the actual address of the space).
    2. with above it's unclear what where should we actually initiate resolver to fire - it has to be initiated by `fetchSpace`, because it needs it to work, but if view component also needs networkId/address combo and just uses `namesStore.getName('ethdomain.eth')`  (static helper that reads it from store without actually resolving itself) does it also need to trigger `namesStore.resolveName`? It doesn't have to if we call fetchSpace in the same place (which was the case in all cases I tried), but depending on this staying constant behavior seems wrong.
 
 I think that approach 1. is overall nicer.
 
 Known edgecases/UX issues:
- If you create draft on editor accessed through ENS domain and you select that draft from Draft modal it will navigate you to gor:0x0000 variant.
- Same with favorites - favorites bar only store gor:0x0000 addresses.
- If you try to access draft via URL with ENS domain directly (not from space where ENS was already resolved like http://localhost:8080/#/s1.sekhmet.eth/create/p35t9) it will take a while to load as it needs to resolve name first.
 
 ## Test plan
 
 - http://localhost:8080/#/s1.sekhmet.eth
 - Try to find places where it breaks (editor, editing proposals, drafts, etc.)