### PR TITLE
feat: disable Confirm button when transaction is invalid

### DIFF
--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -89,7 +89,10 @@ const errors = computed(() => {
 });
 const argsErrors = computed(() => validateForm(definition.value, form.args));
 const formValid = computed(
-  () => Object.keys(errors.value).length === 0 && Object.keys(argsErrors.value).length === 0
+  () =>
+    form.abi.length > 0 &&
+    Object.keys(errors.value).length === 0 &&
+    Object.keys(argsErrors.value).length === 0
 );
 
 function handlePickerClick(field: string) {

--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -88,6 +88,9 @@ const errors = computed(() => {
   return formErrors;
 });
 const argsErrors = computed(() => validateForm(definition.value, form.args));
+const formValid = computed(
+  () => Object.keys(errors.value).length === 0 && Object.keys(argsErrors.value).length === 0
+);
 
 function handlePickerClick(field: string) {
   showPicker.value = true;
@@ -274,7 +277,7 @@ watch(
       </div>
     </div>
     <template v-if="!showPicker" #footer>
-      <UiButton class="w-full" @click="handleSubmit">Confirm</UiButton>
+      <UiButton class="w-full" :disabled="!formValid" @click="handleSubmit">Confirm</UiButton>
     </template>
   </UiModal>
 </template>

--- a/src/components/Modal/Transaction.vue
+++ b/src/components/Modal/Transaction.vue
@@ -67,6 +67,10 @@ const errors = computed(() => {
           type: 'string',
           format: 'address'
         },
+        abi: {
+          type: 'string',
+          format: 'abi'
+        },
         ...(currentMethod.value?.payable
           ? {
               amount: {
@@ -78,7 +82,7 @@ const errors = computed(() => {
       },
       additionalProperties: true
     },
-    { to: form.to, amount: form.amount }
+    { to: form.to, abi: showAbiInput.value ? abiStr.value : undefined, amount: form.amount }
   );
 
   if (addressInvalid.value) {
@@ -173,6 +177,7 @@ watch(
 watch(abiStr, value => {
   try {
     const abi = JSON.parse(value);
+    if (abi.length === 0) return;
     new Interface(abi);
     form.abi = abi;
     showAbiInput.value = false;
@@ -250,10 +255,16 @@ watch(
           @pick="handlePickerClick('to')"
         />
       </div>
-      <div v-if="showAbiInput" class="s-base">
-        <div class="s-label" v-text="'ABI'" />
-        <textarea v-model="abiStr" class="s-input mb-3 h-[140px]" />
-      </div>
+      <SIText
+        v-if="showAbiInput"
+        v-model="abiStr"
+        :error="errors.abi"
+        :definition="{
+          type: 'string',
+          format: 'abi',
+          title: 'ABI'
+        }"
+      />
       <div v-if="methods.length > 0" class="s-base">
         <div class="s-label" v-text="'Method'" />
         <select v-model="form.method" class="s-input h-[45px]">

--- a/src/components/S/IBoolean.vue
+++ b/src/components/S/IBoolean.vue
@@ -25,6 +25,13 @@ const inputValue = computed({
     emit('update:modelValue', newValue);
   }
 });
+
+watch(
+  () => props.modelValue,
+  () => {
+    dirty.value = true;
+  }
+);
 </script>
 
 <template>

--- a/src/components/S/INumber.vue
+++ b/src/components/S/INumber.vue
@@ -25,6 +25,13 @@ const inputValue = computed({
     emit('update:modelValue', newValue);
   }
 });
+
+watch(
+  () => props.modelValue,
+  () => {
+    dirty.value = true;
+  }
+);
 </script>
 
 <template>

--- a/src/components/S/ISelect.vue
+++ b/src/components/S/ISelect.vue
@@ -31,6 +31,13 @@ const inputValue = computed({
     emit('update:modelValue', newValue);
   }
 });
+
+watch(
+  () => props.modelValue,
+  () => {
+    dirty.value = true;
+  }
+);
 </script>
 
 <template>

--- a/src/components/S/IString.vue
+++ b/src/components/S/IString.vue
@@ -31,6 +31,13 @@ const inputValue = computed({
     emit('update:modelValue', newValue);
   }
 });
+
+watch(
+  () => props.modelValue,
+  () => {
+    dirty.value = true;
+  }
+);
 </script>
 
 <template>

--- a/src/components/S/IText.vue
+++ b/src/components/S/IText.vue
@@ -31,6 +31,13 @@ const inputValue = computed({
     emit('update:modelValue', newValue);
   }
 });
+
+watch(
+  () => props.modelValue,
+  () => {
+    dirty.value = true;
+  }
+);
 </script>
 
 <template>

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -154,11 +154,13 @@ export function abiToDefinition(abi) {
   const definition = {
     title: abi.name,
     type: 'object',
-    properties: {},
-    additionalProperties: false
+    required: [] as string[],
+    additionalProperties: false,
+    properties: {}
   };
   abi.inputs.forEach(input => {
     definition.properties[input.name] = {};
+    definition.required.push(input.name);
     let type = 'string';
     if (input.type === 'bool') type = 'boolean';
     if (input.type === 'uint256') {

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -5,6 +5,7 @@ import { isAddress } from '@ethersproject/address';
 import { parseUnits } from '@ethersproject/units';
 import { Zero, MinInt256, MaxInt256, MaxUint256 } from '@ethersproject/constants';
 import { BigNumber } from '@ethersproject/bignumber';
+import { Interface } from '@ethersproject/abi';
 
 function getErrorMessage(errorObject: ErrorObject): string {
   if (!errorObject.message) return 'Invalid field.';
@@ -15,6 +16,8 @@ function getErrorMessage(errorObject: ErrorObject): string {
         return 'Must be a valid URL.';
       case 'address':
         return 'Must be a valid address.';
+      case 'abi':
+        return 'Must be a valid ABI.';
       case 'uint256':
         return 'Must be a positive integer.';
       case 'int256':
@@ -47,6 +50,22 @@ export function validateForm(
         return !!validateAndParseAddress(value);
       } catch (err) {
         return isAddress(value);
+      }
+    }
+  });
+
+  ajv.addFormat('abi', {
+    validate: (value: string) => {
+      if (!value) return false;
+
+      try {
+        const parsed = JSON.parse(value);
+        if (parsed.length === 0) return false;
+
+        new Interface(parsed);
+        return true;
+      } catch {
+        return false;
       }
     }
   });


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/639

This PR disabled Confirm button when transaction is invalid:
1. contract address is invalid
2. ABI is not defined (not found or user input doesn't work)
3. method values are invalid

Had to make some adjustments to make it work:
1. Update dirty flag on inputs when value changes from the outside.
2. Make `abiToDefinition` put all inputs to required property.

## Test plan

- Go to create proposal page, select execution -> Transaction.
- Input address that is not contract, error message is shown, button is disabled.
- Input address that is a contract, select method with inputs, do not file them in, button is disabled.
- Correct errors in the form, confirm button is enabled.

## Screenshots

<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/b9b3c62a-ef48-4266-86d9-cc5c1585a61b" width="400" />


<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/9234b805-d742-45d5-9674-c25f965fca33" width="400" />
