### PR TITLE
feat: make VP indicator on proposal page open modal

### DIFF
--- a/src/components/VotingPowerIndicator.vue
+++ b/src/components/VotingPowerIndicator.vue
@@ -27,11 +27,19 @@ const formattedVotingPower = computed(() => {
 
   return value;
 });
+
+function handleModalOpen() {
+  modalOpen.value = true;
+}
 </script>
 
 <template>
   <div>
-    <slot :formatted-voting-power="formattedVotingPower">
+    <slot
+      :voting-power="votingPower"
+      :formatted-voting-power="formattedVotingPower"
+      :on-click="handleModalOpen"
+    >
       <UiTooltip title="Voting power">
         <UiButton
           v-if="web3.account && web3.type !== 'argentx'"
@@ -40,7 +48,7 @@ const formattedVotingPower = computed(() => {
             '!px-0 w-[46px]': loading
           }"
           class="flex flex-row items-center justify-center"
-          @click="modalOpen = true"
+          @click="handleModalOpen"
         >
           <IH-lightning-bolt class="inline-block" />
           <span class="ml-1">{{ formattedVotingPower }}</span>

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -245,9 +245,9 @@ watch(
           <h4 class="block eyebrow">Your voting power</h4>
           <div class="pt-2">
             <UiLoading v-if="loadingVotingPower" />
-            <div v-else class="text-skin-link text-lg">
+            <button v-else class="text-skin-link text-lg" @click="props.onClick">
               {{ props.formattedVotingPower }}
-            </div>
+            </button>
           </div>
         </VotingPowerIndicator>
         <h4 class="block eyebrow mb-2 mt-4 first:mt-1">Cast your vote</h4>


### PR DESCRIPTION
## Summary

This PR allows voting power modal to open when you click VP on proposal page.

## Test plan
- Go to proposal page.
- Click on VP amount.
- Modal opens.

## Screenshot

<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/003194dd-a2d8-42aa-b5f8-17ba2ea36759" width="700" />

