### PR TITLE
feat: fetch starred spaces

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -13,7 +13,7 @@ const spacesStore = useSpacesStore();
       <IH-stop class="inline-block my-4 w-[32px] h-[32px] text-skin-link" />
     </router-link>
     <draggable
-      v-model="spacesStore.starredSpacesIds"
+      v-model="spacesStore.starredSpaces"
       :delay="100"
       :delay-on-touch-only="true"
       :touch-start-threshold="35"
@@ -22,11 +22,11 @@ const spacesStore = useSpacesStore();
     >
       <template #item="{ element }">
         <router-link
-          :to="{ name: 'space-overview', params: { id: element } }"
+          :to="{ name: 'space-overview', params: { id: `${element.network}:${element.id}` } }"
           class="block"
           @click="uiStore.sidebarOpen = false"
         >
-          <Stamp :id="element.split(':')[1]" :size="32" type="space-sx" class="!rounded-[4px]" />
+          <Stamp :id="element.id" :size="32" type="space-sx" class="!rounded-[4px]" />
         </router-link>
       </template>
     </draggable>

--- a/src/composables/useSpaces.ts
+++ b/src/composables/useSpaces.ts
@@ -47,6 +47,24 @@ export function useSpaces() {
     Object.values(networksMap.value).some(record => record.hasMoreSpaces === true)
   );
 
+  async function getSpaces(filter?: SpacesFilter) {
+    const results = await Promise.all(
+      enabledNetworks.map(async id => {
+        const network = getNetwork(id);
+
+        return network.api.loadSpaces(
+          {
+            skip: 0,
+            limit: SPACES_LIMIT
+          },
+          filter
+        );
+      })
+    );
+
+    return results.flat();
+  }
+
   async function _fetchSpaces(overwrite: boolean, filter?: SpacesFilter) {
     const results = await Promise.all(
       enabledNetworks.map(async id => {
@@ -124,6 +142,7 @@ export function useSpaces() {
     spaces,
     spacesMap,
     hasMoreSpaces,
+    getSpaces,
     fetch,
     fetchMore
   };

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -15,7 +15,8 @@ import type {
 
 export type PaginationOpts = { limit: number; skip?: number };
 export type SpacesFilter = {
-  controller: string;
+  controller?: string;
+  id_in?: string[];
 };
 export type Connector =
   | 'argentx'


### PR DESCRIPTION
To display avatars with ?cb parameter we need to know actual URL of avatar to detect changes of avatars.

Currently it's impossible to compute that parameter as we only have space IDs, we need to fetch Space data from API to be able to compute it.

## Test plan
- Add spaces to favorites, remove it, reorder them - it works as expected.