### PR TITLE
feat: add cache bust query parameter for space images

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -26,7 +26,7 @@ const spacesStore = useSpacesStore();
           class="block"
           @click="uiStore.sidebarOpen = false"
         >
-          <Stamp :id="element.id" :size="32" type="space-sx" class="!rounded-[4px]" />
+          <SpaceAvatar :space="element" :size="32" class="!rounded-[4px]" />
         </router-link>
       </template>
     </draggable>

--- a/src/components/SpaceAvatar.vue
+++ b/src/components/SpaceAvatar.vue
@@ -11,9 +11,11 @@ const props = withDefaults(
   }
 );
 
-const avatarHash = computed(() => sha3.sha3_256(props.space.avatar).slice(0, 16));
+const cb = computed(() =>
+  props.space.avatar ? sha3.sha3_256(props.space.avatar).slice(0, 16) : undefined
+);
 </script>
 
 <template>
-  <Stamp :id="space.id" :size="size" :cb="avatarHash" type="space-sx" />
+  <Stamp :id="space.id" :size="size" :cb="cb" type="space-sx" />
 </template>

--- a/src/components/SpaceAvatar.vue
+++ b/src/components/SpaceAvatar.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import sha3 from 'js-sha3';
+
+const props = withDefaults(
+  defineProps<{
+    space: { id: string; avatar: string };
+    size: number;
+  }>(),
+  {
+    size: 22
+  }
+);
+
+const avatarHash = computed(() => sha3.sha3_256(props.space.avatar).slice(0, 16));
+</script>
+
+<template>
+  <Stamp :id="space.id" :size="size" :cb="avatarHash" type="space-sx" />
+</template>

--- a/src/components/SpaceItem.vue
+++ b/src/components/SpaceItem.vue
@@ -22,12 +22,7 @@ const spacesStore = useSpacesStore();
       />
       <IH-star v-else class="inline-block" />
     </button>
-    <Stamp
-      :id="space.id"
-      :size="32"
-      type="space-sx"
-      class="border-skin-bg !bg-skin-border rounded-sm mb-2"
-    />
+    <SpaceAvatar :space="space" :size="32" class="border-skin-bg !bg-skin-border rounded-sm mb-2" />
     <h3 class="truncate" v-text="space.name" />
     <h5 class="absolute bottom-4">
       <b class="text-skin-link" v-text="space.proposal_count" /> proposals ·

--- a/src/components/Stamp.vue
+++ b/src/components/Stamp.vue
@@ -1,20 +1,26 @@
-<script setup>
-defineProps({
-  type: {
-    type: String,
-    default: 'avatar'
-  },
-  id: String,
-  size: {
-    type: Number,
-    default: 22
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    type?: 'avatar' | 'space' | 'space-sx' | 'token';
+    id: string;
+    size?: number;
+    cb?: string;
+  }>(),
+  {
+    type: 'avatar',
+    size: 22
   }
+);
+
+const src = computed(() => {
+  const cacheParam = props.cb ? `&cb=${props.cb}` : '';
+  return `https://cdn.stamp.fyi/${props.type}/${props.id}?s=${Number(props.size) * 2}${cacheParam}`;
 });
 </script>
 
 <template>
   <img
-    :src="`https://stamp.fyi/${type}/${id}?s=${size * 2}`"
+    :src="src"
     class="rounded-full inline-block bg-[color:var(--border-color)]"
     :style="{
       width: `${size}px`,

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -249,6 +249,7 @@ export const SPACES_QUERY = gql`
     spaces(first: $first, skip: $skip, orderBy: vote_count, orderDirection: desc, where: $where) {
       id
       name
+      avatar
       about
       external_url
       github

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -81,8 +81,8 @@ const grouped = computed(() => {
     <div class="px-4">
       <div class="mb-4 relative">
         <router-link :to="{ name: 'space-overview' }">
-          <Stamp
-            :id="space.id"
+          <SpaceAvatar
+            :space="space"
             :size="90"
             type="space-sx"
             class="mb-2 border-[4px] border-skin-bg !bg-skin-border !rounded-lg"


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/640
Depends on: https://github.com/snapshot-labs/sx-ui/pull/645

This won't currently prevent old images from being used still as `cb` is ignored for AWS cache right now (pending https://github.com/snapshot-labs/stamp/pull/55)
You can test just the presence of `cb` parameter on space URLs (user URLs are not currently handled as there are plenty of places where we don't have access to real avatar URL to compute hash so for now it just handles spaces).

## Test plan
- Check different space image URLs.
- They have &cb parameter.
