### PR TITLE
fix: hide empty execution block

### DIFF
--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -294,7 +294,14 @@ export default defineComponent({
         />
         <Preview :key="proposalKey || ''" :url="proposal.discussion" />
       </div>
-      <div v-if="space && network">
+      <div
+        v-if="
+          space &&
+          network &&
+          supportedExecutionStrategies &&
+          supportedExecutionStrategies.length > 0
+        "
+      >
         <h4 class="eyebrow mb-3">Execution</h4>
         <div class="flex flex-col gap-2 mb-3">
           <ExecutionButton


### PR DESCRIPTION
For spaces with no executions we shouldn't show execution block at all - now it just shows empty Execution header.

## Test plan
- Go to editor here http://localhost:8080/#/gor:0xfaa1e9cec71a2b56387aac1b368ef1a852891208