### PR TITLE
feat: add WalletConnect support with direct transactions

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "SnapshotX",
-  "name": "SnapshotX",
+  "short_name": "Snapshot X",
+  "name": "Snapshot X",
   "description": "Where decisions get made",
   "iconPath": "favicon-temp.svg",
   "start_url": ".",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,10 @@
+{
+  "short_name": "SnapshotX",
+  "name": "SnapshotX",
+  "description": "Where decisions get made",
+  "iconPath": "favicon-temp.svg",
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}

--- a/src/components/Ui/Alert.vue
+++ b/src/components/Ui/Alert.vue
@@ -18,7 +18,9 @@ const emit = defineEmits<{
       'bg-rose-100 border-rose-300 text-rose-500 dark:bg-rose-700 dark:border-rose-700 dark:text-neutral-100':
         type === 'error',
       'bg-yellow-100 border-yellow-300 text-yellow-600 dark:bg-amber-500 dark:border-amber-500 dark:text-neutral-100':
-        type === 'warning'
+        type === 'warning',
+      'bg-lime-100 border-lime-300 text-lime-600 dark:bg-emerald-500 dark:border-emerald-500 dark:text-neutral-100':
+        type === 'success'
     }"
   >
     <slot />

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -34,10 +34,19 @@ export function useActions() {
     };
   }
 
+  function handleSafeEnvelope(envelope: any) {
+    if (envelope !== null) return false;
+
+    uiStore.addNotification('success', 'Transaction set up.');
+    return true;
+  }
+
   async function wrapPromise(networkId: NetworkID, promise: Promise<any>) {
     const network = getNetwork(networkId);
 
     const envelope = await promise;
+
+    if (handleSafeEnvelope(envelope)) return;
 
     // TODO: unify send/soc to both return txHash under same property
     if (envelope.signatureData || envelope.sig) {
@@ -299,6 +308,8 @@ export function useActions() {
     const receipt = await network.actions.setVotingDelay(auth.web3, space, votingDelay);
     console.log('Receipt', receipt);
 
+    if (handleSafeEnvelope(receipt)) return;
+
     uiStore.addPendingTransaction(receipt.hash, 'gor');
   }
 
@@ -308,6 +319,8 @@ export function useActions() {
     const network = getNetwork(space.network);
     const receipt = await network.actions.setMinVotingDuration(auth.web3, space, minVotingDuration);
     console.log('Receipt', receipt);
+
+    if (handleSafeEnvelope(receipt)) return;
 
     uiStore.addPendingTransaction(receipt.hash, 'gor');
   }
@@ -319,6 +332,8 @@ export function useActions() {
     const receipt = await network.actions.setMaxVotingDuration(auth.web3, space, maxVotingDuration);
     console.log('Receipt', receipt);
 
+    if (handleSafeEnvelope(receipt)) return;
+
     uiStore.addPendingTransaction(receipt.hash, 'gor');
   }
 
@@ -328,6 +343,8 @@ export function useActions() {
     const network = getNetwork(space.network);
     const receipt = await network.actions.transferOwnership(auth.web3, space, owner);
     console.log('Receipt', receipt);
+
+    if (handleSafeEnvelope(receipt)) return;
 
     uiStore.addPendingTransaction(receipt.hash, 'gor');
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,17 @@ import router from '@/router';
 import '@/helpers/auth';
 import '@/style.scss';
 
-if (top?.location !== location) document.documentElement.style.display = 'none';
+const knownHosts = ['app.safe.global', 'pilot.gnosisguild.org'];
+const parentUrl =
+  window.location != window.parent.location
+    ? document.referrer ||
+      document.location.ancestorOrigins[document.location.ancestorOrigins.length - 1]
+    : document.location.href;
+const parentHost = new URL(parentUrl).host;
+if (window !== window.parent && !knownHosts.includes(parentHost)) {
+  document.documentElement.style.display = 'none';
+  throw new Error(`Unknown host: ${parentHost}`);
+}
 
 const pinia = createPinia();
 const app = createApp({ render: () => h(App) })

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -35,6 +35,11 @@ export function createActions(
     manaUrl
   });
 
+  const getIsContract = async (address: string) => {
+    const code = await provider.getCode(address);
+    return code !== '0x';
+  };
+
   return {
     async predictSpaceAddress(web3: Web3Provider, { salt }) {
       await verifyNetwork(web3, chainId);
@@ -149,8 +154,7 @@ export function createActions(
     ) => {
       await verifyNetwork(web3, chainId);
 
-      const code = await provider.getCode(account);
-      const isContract = code !== '0x';
+      const isContract = await getIsContract(account);
 
       const { useRelayer, authenticator, strategies } = pickAuthenticatorAndStrategies(
         space.authenticators,
@@ -186,12 +190,17 @@ export function createActions(
         });
       }
 
-      return client.propose({
-        signer: web3.getSigner(),
-        envelope: {
-          data
+      return client.propose(
+        {
+          signer: web3.getSigner(),
+          envelope: {
+            data
+          }
+        },
+        {
+          noWait: isContract
         }
-      });
+      );
     },
     async updateProposal(
       web3: Web3Provider,
@@ -204,8 +213,7 @@ export function createActions(
     ) {
       await verifyNetwork(web3, chainId);
 
-      const code = await provider.getCode(account);
-      const isContract = code !== '0x';
+      const isContract = await getIsContract(account);
 
       const { useRelayer, authenticator } = pickAuthenticatorAndStrategies(
         space.authenticators,
@@ -241,20 +249,22 @@ export function createActions(
         });
       }
 
-      return client.updateProposal({
-        signer: web3.getSigner(),
-        envelope: {
-          data
-        }
-      });
+      return client.updateProposal(
+        {
+          signer: web3.getSigner(),
+          envelope: {
+            data
+          }
+        },
+        { noWait: isContract }
+      );
     },
     vote: async (web3: Web3Provider, account: string, proposal: Proposal, choice: number) => {
       await verifyNetwork(web3, chainId);
 
       if (choice < 1 || choice > 3) throw new Error('Invalid chocie');
 
-      const code = await provider.getCode(account);
-      const isContract = code !== '0x';
+      const isContract = await getIsContract(account);
 
       const { useRelayer, authenticator, strategies } = pickAuthenticatorAndStrategies(
         proposal.space.authenticators,
@@ -283,12 +293,15 @@ export function createActions(
         });
       }
 
-      return client.vote({
-        signer: web3.getSigner(),
-        envelope: {
-          data
-        }
-      });
+      return client.vote(
+        {
+          signer: web3.getSigner(),
+          envelope: {
+            data
+          }
+        },
+        { noWait: isContract }
+      );
     },
     finalizeProposal: () => null,
     receiveProposal: () => null,
@@ -324,38 +337,62 @@ export function createActions(
     setVotingDelay: async (web3: Web3Provider, space: Space, votingDelay: number) => {
       await verifyNetwork(web3, chainId);
 
-      return client.setVotingDelay({
-        signer: web3.getSigner(),
-        space: space.id,
-        votingDelay
-      });
+      const address = await web3.getSigner().getAddress();
+      const isContract = await getIsContract(address);
+
+      return client.setVotingDelay(
+        {
+          signer: web3.getSigner(),
+          space: space.id,
+          votingDelay
+        },
+        { noWait: isContract }
+      );
     },
     setMinVotingDuration: async (web3: Web3Provider, space: Space, minVotingDuration: number) => {
       await verifyNetwork(web3, chainId);
 
-      return client.setMinVotingDuration({
-        signer: web3.getSigner(),
-        space: space.id,
-        minVotingDuration
-      });
+      const address = await web3.getSigner().getAddress();
+      const isContract = await getIsContract(address);
+
+      return client.setMinVotingDuration(
+        {
+          signer: web3.getSigner(),
+          space: space.id,
+          minVotingDuration
+        },
+        { noWait: isContract }
+      );
     },
     setMaxVotingDuration: async (web3: Web3Provider, space: Space, maxVotingDuration: number) => {
       await verifyNetwork(web3, chainId);
 
-      return client.setMaxVotingDuration({
-        signer: web3.getSigner(),
-        space: space.id,
-        maxVotingDuration
-      });
+      const address = await web3.getSigner().getAddress();
+      const isContract = await getIsContract(address);
+
+      return client.setMaxVotingDuration(
+        {
+          signer: web3.getSigner(),
+          space: space.id,
+          maxVotingDuration
+        },
+        { noWait: isContract }
+      );
     },
     transferOwnership: async (web3: Web3Provider, space: Space, owner: string) => {
       await verifyNetwork(web3, chainId);
 
-      return client.transferOwnership({
-        signer: web3.getSigner(),
-        space: space.id,
-        owner
-      });
+      const address = await web3.getSigner().getAddress();
+      const isContract = await getIsContract(address);
+
+      return client.transferOwnership(
+        {
+          signer: web3.getSigner(),
+          space: space.id,
+          owner
+        },
+        { noWait: isContract }
+      );
     },
     send: (envelope: any) => ethSigClient.send(envelope),
     getVotingPower: async (

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -149,9 +149,13 @@ export function createActions(
     ) => {
       await verifyNetwork(web3, chainId);
 
+      const code = await provider.getCode(account);
+      const isContract = code !== '0x';
+
       const { useRelayer, authenticator, strategies } = pickAuthenticatorAndStrategies(
         space.authenticators,
-        space.voting_power_validation_strategy_strategies
+        space.voting_power_validation_strategy_strategies,
+        isContract
       );
 
       let selectedExecutionStrategy;
@@ -200,9 +204,13 @@ export function createActions(
     ) {
       await verifyNetwork(web3, chainId);
 
+      const code = await provider.getCode(account);
+      const isContract = code !== '0x';
+
       const { useRelayer, authenticator } = pickAuthenticatorAndStrategies(
         space.authenticators,
-        space.voting_power_validation_strategy_strategies
+        space.voting_power_validation_strategy_strategies,
+        isContract
       );
 
       let selectedExecutionStrategy;
@@ -245,9 +253,13 @@ export function createActions(
 
       if (choice < 1 || choice > 3) throw new Error('Invalid chocie');
 
+      const code = await provider.getCode(account);
+      const isContract = code !== '0x';
+
       const { useRelayer, authenticator, strategies } = pickAuthenticatorAndStrategies(
         proposal.space.authenticators,
-        proposal.strategies
+        proposal.strategies,
+        isContract
       );
 
       let convertedChoice: Choice = 0;

--- a/src/networks/evm/helpers.ts
+++ b/src/networks/evm/helpers.ts
@@ -29,14 +29,19 @@ export function getExecutionData(
   });
 }
 
-export function pickAuthenticatorAndStrategies(authenticators: string[], strategies: string[]) {
+export function pickAuthenticatorAndStrategies(
+  authenticators: string[],
+  strategies: string[],
+  isContract = false
+) {
   const supportedAuthenticators = authenticators.filter(
     authenticator => SUPPORTED_AUTHENTICATORS[authenticator]
   );
 
-  const authenticator =
-    supportedAuthenticators.find(authenticator => RELAYER_AUTHENTICATORS[authenticator]) ||
-    supportedAuthenticators[0];
+  const authenticator = isContract
+    ? supportedAuthenticators.find(authenticator => !RELAYER_AUTHENTICATORS[authenticator])
+    : supportedAuthenticators.find(authenticator => RELAYER_AUTHENTICATORS[authenticator]) ||
+      supportedAuthenticators[0];
 
   const selectedStrategies = strategies
     .map((strategy, index) => ({ address: strategy, index } as const))

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 // UI
-export type NotificationType = 'error' | 'warning';
+export type NotificationType = 'error' | 'warning' | 'success';
 
 export type NetworkID = 'gor' | 'sn-tn2';
 export type Choice = 1 | 2 | 3;


### PR DESCRIPTION
This makes it possible to use Safe with WalletConnect to propose/vote with spaces that have Ethereum transaction authenticator supported as well as manage space settings.

Closes: https://github.com/snapshot-labs/sx-ui/issues/605
Depends on https://github.com/snapshot-labs/sx-ui/pull/652
Depends on https://github.com/snapshot-labs/sx.js/pull/194

## Test plan
- Test different spaces:
- Ethereum signature only: http://localhost:8080/#/gor:0x65e4329e8c0fba31883b98e2cf3e81d3cdcac780/settings
- Ethereum transaction only: http://localhost:8080/#/gor:0xfaa1e9cec71a2b56387aac1b368ef1a852891208
- Both: http://localhost:8080/#/gor:0x2b5e7ac0e76dcb41d3e506d58c9997d42d133e07