### PR TITLE
feat: add addEthereumChain call for Linea

### DIFF
--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -25,7 +25,12 @@ export function useActions() {
       try {
         return await fn(...args);
       } catch (e) {
-        if (e.code !== 'ACTION_REJECTED' && e.message !== 'User abort') {
+        const isUserAbortError =
+          e.code === 4001 ||
+          e.message === 'User rejected the request.' ||
+          e.code === 'ACTION_REJECTED';
+
+        if (!isUserAbortError) {
           uiStore.addNotification('error', 'Something went wrong. Please try again later.');
         }
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -10,6 +10,18 @@ import { upload as pin } from '@snapshot-labs/pineapple';
 import type { SpaceMetadata } from '@/types';
 
 const IPFS_GATEWAY: string = import.meta.env.VITE_IPFS_GATEWAY || 'https://cloudflare-ipfs.com';
+const ADDABLE_NETWORKS = {
+  59140: {
+    chainName: 'Linea Goerli test network',
+    nativeCurrency: {
+      name: 'LineaETH',
+      symbol: 'ETH',
+      decimals: 18
+    },
+    rpcUrls: ['https://rpc.goerli.linea.build'],
+    blockExplorerUrls: ['https://explorer.goerli.linea.build']
+  }
+};
 
 dayjs.extend(relativeTime);
 dayjs.extend(updateLocale);
@@ -217,10 +229,36 @@ export async function verifyNetwork(web3Provider: Web3Provider, chainId: number)
   const network = await web3Provider.getNetwork();
   if (network.chainId === chainId) return;
 
-  await web3Provider.provider.request({
-    method: 'wallet_switchEthereumChain',
-    params: [{ chainId: `0x${chainId.toString(16)}` }]
-  });
+  const encodedChainId = `0x${chainId.toString(16)}`;
+
+  try {
+    await web3Provider.provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: encodedChainId }]
+    });
+  } catch (err) {
+    if (err.code !== 4902 || !ADDABLE_NETWORKS) throw new Error(err.message);
+
+    await web3Provider.provider.request({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: encodedChainId,
+          chainName: ADDABLE_NETWORKS[chainId].chainName,
+          nativeCurrency: ADDABLE_NETWORKS[chainId].nativeCurrency,
+          rpcUrls: ADDABLE_NETWORKS[chainId].rpcUrls,
+          blockExplorerUrls: ADDABLE_NETWORKS[chainId].blockExplorerUrls
+        }
+      ]
+    });
+
+    const network = await web3Provider.getNetwork();
+    if (network.chainId !== chainId) {
+      const error = new Error('User rejected network change after it being added');
+      (error as any).code = 4001;
+      throw error;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This PR will automatically add Linea to Metamask if it's not already added, without it it will fail with no feedback.

## Test plan
- Start with Metamask with no linea added (you can remove it in settings if it's not active).
- Try voting/proposing.
- You get prompted to add it.
- Try exiting at different stages of the flow (adding network, switching network, confirming transaction).
- Send transaction to vote/propose.
- Nothing breaks.
