### PR TITLE
feat: add proposal cancellation support

### DIFF
--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -58,6 +58,7 @@ async function handleVoteClick(choice: Choice) {
         <Vote :proposal="proposal">
           <template #unsupported><div /></template>
           <template #waiting><div /></template>
+          <template #cancelled><div /></template>
           <template #voted-pending><div /></template>
           <template #voted>
             <Results :proposal="proposal" />

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -43,6 +43,8 @@ const isSupported = computed(() => {
     Proposal voting window has ended
   </slot>
 
+  <slot v-else-if="proposal.cancelled" name="cancelled">This proposal has been cancelled</slot>
+
   <slot v-else-if="!isSupported" name="unsupported">
     Voting for this proposal is not supported
   </slot>

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -259,6 +259,19 @@ export function useActions() {
     return true;
   }
 
+  async function cancelProposal(proposal: Proposal) {
+    if (!web3.value.account) return await forceLogin();
+    if (web3.value.type === 'argentx') throw new Error('ArgentX is not supported');
+
+    const network = getNetwork(proposal.network);
+    const receipt = await network.actions.cancelProposal(auth.web3, proposal);
+    console.log('Receipt', receipt);
+
+    if (handleSafeEnvelope(receipt)) return;
+
+    uiStore.addPendingTransaction(receipt.hash, proposal.network);
+  }
+
   async function finalizeProposal(proposal: Proposal) {
     if (!web3.value.account) return await forceLogin();
     if (web3.value.type === 'argentx') throw new Error('ArgentX is not supported');
@@ -366,6 +379,7 @@ export function useActions() {
     vote: wrapWithErrors(vote),
     propose: wrapWithErrors(propose),
     updateProposal: wrapWithErrors(updateProposal),
+    cancelProposal: wrapWithErrors(cancelProposal),
     finalizeProposal: wrapWithErrors(finalizeProposal),
     receiveProposal: wrapWithErrors(receiveProposal),
     executeTransactions: wrapWithErrors(executeTransactions),

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -63,6 +63,7 @@ function formatProposal(
     ...proposal,
     space: {
       id: proposal.space.id,
+      controller: proposal.space.controller,
       authenticators: proposal.space.authenticators,
       voting_power_symbol: proposal.space.metadata.voting_power_symbol,
       executors: proposal.space.metadata.executors,

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -48,6 +48,7 @@ const PROPOSAL_FRAGMENT = gql`
     proposal_id
     space {
       id
+      controller
       authenticators
       metadata {
         id
@@ -94,6 +95,7 @@ const PROPOSAL_FRAGMENT = gql`
     vote_count
     executed
     completed
+    cancelled
   }
 `;
 
@@ -111,7 +113,12 @@ export const PROPOSALS_QUERY = gql`
     proposals(
       first: $first
       skip: $skip
-      where: { metadata_: {}, space: $space, metadata_: { title_contains_nocase: $searchQuery } }
+      where: {
+        metadata_: {}
+        space: $space
+        cancelled: false
+        metadata_: { title_contains_nocase: $searchQuery }
+      }
       orderBy: created
       orderDirection: desc
     ) {
@@ -125,7 +132,7 @@ export const PROPOSALS_SUMMARY_QUERY = gql`
   query ($first: Int!, $space: String!, $threshold: Int) {
     active: proposals(
       first: $first
-      where: { space: $space, metadata_: {}, max_end_gte: $threshold }
+      where: { space: $space, metadata_: {}, cancelled: false, max_end_gte: $threshold }
       orderBy: created
       orderDirection: desc
     ) {
@@ -134,7 +141,7 @@ export const PROPOSALS_SUMMARY_QUERY = gql`
 
     expired: proposals(
       first: $first
-      where: { space: $space, metadata_: {}, max_end_lt: $threshold }
+      where: { space: $space, metadata_: {}, cancelled: false, max_end_lt: $threshold }
       orderBy: created
       orderDirection: desc
     ) {

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -52,6 +52,7 @@ export type ApiProposal = {
   };
   space: {
     id: string;
+    controller: string;
     metadata: {
       voting_power_symbol: string;
       executors: string[];
@@ -88,4 +89,5 @@ export type ApiProposal = {
   has_veto_period_ended: boolean;
   executed: boolean;
   completed: boolean;
+  cancelled: boolean;
 };

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -263,6 +263,21 @@ export function createActions(
         { noWait: isContract }
       );
     },
+    cancelProposal: async (web3: Web3Provider, proposal: Proposal) => {
+      await verifyNetwork(web3, chainId);
+
+      const address = await web3.getSigner().getAddress();
+      const isContract = await getIsContract(address);
+
+      return client.cancel(
+        {
+          signer: web3.getSigner(),
+          space: proposal.space.id,
+          proposal: proposal.proposal_id
+        },
+        { noWait: isContract }
+      );
+    },
     vote: async (web3: Web3Provider, account: string, proposal: Proposal, choice: number) => {
       await verifyNetwork(web3, chainId);
 

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -151,6 +151,9 @@ export function createActions(
     updateProposal: () => {
       throw new Error('Not implemented');
     },
+    cancelProposal: () => {
+      throw new Error('Not implemented');
+    },
     vote: async (web3: Web3Provider, account: string, proposal: Proposal, choice: number) => {
       await verifyNetwork(web3, l1ChainId);
 

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -106,6 +106,7 @@ export type NetworkActions = {
     executionStrategy: string | null,
     transactions: MetaTransaction[]
   );
+  cancelProposal(web3: Web3Provider, proposal: Proposal);
   vote(web3: Web3Provider, account: string, proposal: Proposal, choice: Choice);
   finalizeProposal(web3: Web3Provider, proposal: Proposal);
   receiveProposal(web3: Web3Provider, proposal: Proposal);

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export type Proposal = {
   quorum: number;
   space: {
     id: string;
+    controller: string;
     voting_power_symbol: string;
     authenticators: string[];
     executors: string[];
@@ -116,6 +117,7 @@ export type Proposal = {
   has_veto_period_ended: boolean;
   executed: boolean;
   completed: boolean;
+  cancelled: boolean;
 };
 
 export type User = {


### PR DESCRIPTION
This PR allows to cancel proposals.

Depends on: https://github.com/snapshot-labs/sx-subgraph/pull/27 (needs to be added to all subgraphs), see test plan how to test before it's deployed.

## Test plan
- Disable all networks but `gor`.
- Change `gor` apiUrl to https://api.studio.thegraph.com/query/41343/sekhmet-sx-goerli/version/latest.
- Create proposal.
- Go to that proposal as space owner.
- You can cancel it.
- Once cancelled it won't show up in proposal list.