### PR TITLE
feat: block voting again for same proposal

### DIFF
--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -58,6 +58,7 @@ async function handleVoteClick(choice: Choice) {
         <Vote :proposal="proposal">
           <template #unsupported><div /></template>
           <template #waiting><div /></template>
+          <template #voted-pending><div /></template>
           <template #voted>
             <Results :proposal="proposal" />
           </template>

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { _t } from '@/helpers/utils';
+import { useUiStore } from '@/stores/ui';
 import { getNetwork } from '@/networks';
-import type { Proposal as ProposalType } from '@/types';
+import { Proposal as ProposalType } from '@/types';
 
 const props = defineProps<{ proposal: ProposalType }>();
 
+const uiStore = useUiStore();
 const { votes } = useAccount();
 
 const isSupported = computed(() => {
@@ -30,6 +32,9 @@ const isSupported = computed(() => {
     You have already voted for this proposal
   </slot>
 
+  <slot v-else-if="uiStore.pendingVotes[proposal.id]" name="voted-pending">
+    You have already voted for this proposal
+  </slot>
   <slot v-else-if="proposal.has_started" name="waiting">
     Voting for this proposal hasn't started yet. Voting will start {{ _t(proposal.start) }}.
   </slot>

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -163,6 +163,8 @@ export function useActions() {
       proposal.network,
       network.actions.vote(auth.web3, web3.value.account, proposal, choice)
     );
+
+    uiStore.addPendingVote(proposal.id);
   }
 
   async function propose(

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -24,7 +24,8 @@ export const useUiStore = defineStore('ui', {
   state: () => ({
     sidebarOpen: false,
     notifications: [] as Notification[],
-    pendingTransactions: [] as PendingTransaction[]
+    pendingTransactions: [] as PendingTransaction[],
+    pendingVotes: {} as Record<string, boolean>
   }),
   actions: {
     async toggleSidebar() {
@@ -69,6 +70,9 @@ export const useUiStore = defineStore('ui', {
           updateStorage(this.pendingTransactions);
         }
       });
+    },
+    async addPendingVote(proposalId: string) {
+      this.pendingVotes[proposalId] = true;
     }
   }
 });


### PR DESCRIPTION
This commit adds pendingVotes in state (it's lost on refresh), so after voting you can't vote for the same proposal again.

This is simple workaround to make UX better. In the future we probably should have better way to handle it where pending vote gets treated same as real ones with a way to handle cases where pending vote actually doesn't execute (transaction failure etc.)