### PR TITLE
feat: resolve ENS name for votes

### DIFF
--- a/src/components/Modal/Votes.vue
+++ b/src/components/Modal/Votes.vue
@@ -99,7 +99,7 @@ watch(
               :to="{ name: 'user', params: { id: vote.voter.id } }"
               @click="$emit('close')"
             >
-              {{ shortenAddress(vote.voter.id) }}
+              {{ vote.voter.name || shortenAddress(vote.voter.id) }}
             </router-link>
             <div class="absolute right-4 top-3 text-skin-link" v-text="choices[vote.choice]" />
           </div>

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -10,6 +10,7 @@ import {
   USER_QUERY
 } from './queries';
 import { PaginationOpts, SpacesFilter, NetworkApi } from '@/networks/types';
+import { getNames } from '@/helpers/ens';
 import { Space, Proposal, Vote, User, Transaction, NetworkID } from '@/types';
 import { ApiSpace, ApiProposal } from './types';
 
@@ -117,7 +118,13 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         }
       });
 
-      return data.votes;
+      const addresses = data.votes.map(vote => vote.voter.id);
+      const names = await getNames(addresses);
+
+      return data.votes.map(vote => {
+        vote.voter.name = names[vote.voter.id] || null;
+        return vote;
+      });
     },
     loadUserVotes: async (voter: string): Promise<{ [key: string]: Vote }> => {
       const { data } = await apollo.query({

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,7 @@ export type Vote = {
   id: string;
   voter: {
     id: string;
+    name?: string;
   };
   space: {
     id: string;

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -156,9 +156,7 @@ watch(
           >
             <Stamp :id="proposal.author.id" :size="32" class="mr-1" />
             <div class="flex flex-col ml-2 leading-4 gap-1">
-              <span class="text-md">
-                {{ shortenAddress(proposal.author.id) }}
-              </span>
+              {{ shortenAddress(proposal.author.id) }}
               <span class="text-skin-text text-[16px]" v-text="_rt(proposal.created)" />
             </div>
           </router-link>


### PR DESCRIPTION
Display ENS names for the votes modal.

**Test**
- Go to http://localhost:8080/#/gor:0xae56be6b3754e5e89de438f6202df07c7aa86845/proposal/3
- Load votes
- ENS domains should appear