### PR TITLE
feat: add Space cover support

### DIFF
--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -7,6 +7,10 @@ const props = withDefaults(
     showTitle?: boolean;
     form: any;
     id?: string;
+    space?: {
+      id: string;
+      cover: string;
+    };
   }>(),
   {
     showTitle: true
@@ -138,7 +142,8 @@ onMounted(() => {
 
 <template>
   <h3 v-if="showTitle" class="mb-4">Space profile</h3>
-  <div class="s-box">
+  <SIStampCover v-model="(form as any).cover" :space="space" />
+  <div class="s-box p-4 -mt-[80px]">
     <SIObject
       :model-value="form"
       :error="formErrors"

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -5,6 +5,7 @@ import type { Space, SpaceMetadata, NetworkID } from '@/types';
 const DEFAULT_FORM_STATE: SpaceMetadata = {
   name: '',
   avatar: '',
+  cover: '',
   description: '',
   externalUrl: '',
   twitter: '',
@@ -97,23 +98,22 @@ watch(
         </div>
       </template>
     </template>
-    <div v-if="!showPicker" class="relative bg-skin-border h-[100px] -mb-[50px]" />
     <BlockContactPicker
       v-if="showPicker"
       :loading="false"
       :search-value="searchValue"
       @pick="handlePickerSelect"
     />
-    <div v-else class="p-4 -mt-[80px]">
-      <BlockSpaceFormProfile
-        :id="space.id"
-        :show-title="false"
-        :form="form"
-        @pick="showPicker = true"
-        @no-network="form.walletAddress = null"
-        @errors="v => (formErrors = v)"
-      />
-    </div>
+    <BlockSpaceFormProfile
+      v-else
+      :id="space.id"
+      :space="space"
+      :show-title="false"
+      :form="form"
+      @pick="showPicker = true"
+      @no-network="form.walletAddress = null"
+      @errors="v => (formErrors = v)"
+    />
     <template v-if="!showPicker" #footer>
       <UiButton
         class="w-full"

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -5,7 +5,7 @@ const uiStore = useUiStore();
 </script>
 
 <template>
-  <div class="fixed bottom-4 left-0 right-0 z-50">
+  <div class="fixed bottom-4 left-0 right-0 z-[52]">
     <UiAlert
       v-for="notification in uiStore.notifications"
       :key="notification.id"

--- a/src/components/S/IStampCover.vue
+++ b/src/components/S/IStampCover.vue
@@ -3,9 +3,12 @@ import { useUiStore } from '@/stores/ui';
 import { getUrl, imageUpload } from '@/helpers/utils';
 
 const props = defineProps<{
-  modelValue?: string;
+  space?: {
+    id: string;
+    cover: string;
+  };
+  modelValue?: string | null;
   error?: string;
-  definition: any;
 }>();
 
 const emit = defineEmits<{
@@ -51,27 +54,23 @@ async function handleFileChange(e: Event) {
 <template>
   <div
     v-bind="$attrs"
-    class="relative group max-w-max cursor-pointer mb-3 border-[4px] border-skin-bg rounded-lg overflow-hidden bg-skin-border"
+    class="relative bg-skin-border h-[100px] -mb-[50px] overflow-hidden cursor-pointer group"
     @click="openFilePicker()"
   >
     <img
       v-if="imgUrl"
       :src="imgUrl"
-      class="w-[80px] h-[80px] object-cover group-hover:opacity-80"
+      class="min-h-full object-cover group-hover:opacity-80"
       :class="{
         'opacity-80': isUploadingImage
       }"
     />
-    <Stamp
-      v-else
-      :id="definition.default"
-      :size="80"
-      class="pointer-events-none !rounded-none group-hover:opacity-80"
-      type="space-sx"
-      :class="{
-        'opacity-80': isUploadingImage
-      }"
+    <SpaceCover
+      v-else-if="props.space?.cover"
+      :space="props.space"
+      class="pointer-events-none !rounded-none min-h-full object-cover group-hover:opacity-80"
     />
+
     <div
       class="pointer-events-none absolute group-hover:visible inset-0 z-10 flex flex-row w-full h-full items-center content-center justify-center"
     >

--- a/src/components/SpaceCover.vue
+++ b/src/components/SpaceCover.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import sha3 from 'js-sha3';
+
+const props = defineProps<{
+  space: { id: string; cover: string };
+}>();
+
+const cb = computed(() =>
+  props.space.cover ? sha3.sha3_256(props.space.cover).slice(0, 16) : undefined
+);
+</script>
+
+<template>
+  <Stamp :id="space.id" :width="1500" :height="150" :cb="cb" type="space-cover-sx" />
+</template>

--- a/src/components/Stamp.vue
+++ b/src/components/Stamp.vue
@@ -3,9 +3,11 @@ import { getStampUrl } from '@/helpers/utils';
 
 withDefaults(
   defineProps<{
-    type?: 'avatar' | 'space' | 'space-sx' | 'token';
+    type?: 'avatar' | 'space' | 'space-sx' | 'space-cover-sx' | 'token';
     id: string;
     size?: number;
+    width?: number;
+    height?: number;
     cb?: string;
   }>(),
   {
@@ -17,11 +19,15 @@ withDefaults(
 
 <template>
   <img
-    :src="getStampUrl(type, id, size, cb)"
+    :src="getStampUrl(type, id, width && height ? { width, height } : size, cb)"
     class="rounded-full inline-block bg-[color:var(--border-color)]"
-    :style="{
-      width: `${size}px`,
-      height: `${size}px`
-    }"
+    :style="
+      !width && !height
+        ? {
+            width: `${size}px`,
+            height: `${size}px`
+          }
+        : {}
+    "
   />
 </template>

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -8,6 +8,7 @@ describe('utils', () => {
       const metadata = createErc1155Metadata({
         name: 'Test',
         avatar: '',
+        cover: '',
         description: 'Test description',
         externalUrl: 'https://test.com',
         github: 'snapshot-labs',
@@ -27,6 +28,7 @@ describe('utils', () => {
         external_url: 'https://test.com',
         properties: {
           voting_power_symbol: 'VOTE',
+          cover: '',
           github: 'snapshot-labs',
           twitter: 'SnapshotLabs',
           discord: 'snapshot',

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -287,6 +287,7 @@ export function createErc1155Metadata(
       delegation_api_type: metadata.delegationApiType,
       delegation_api_url: metadata.delegationApiUrl,
       voting_power_symbol: metadata.votingPowerSymbol,
+      cover: metadata.cover,
       github: metadata.github,
       twitter: metadata.twitter,
       discord: metadata.discord,
@@ -313,14 +314,21 @@ export function getCacheHash(value?: string) {
 }
 
 export function getStampUrl(
-  type: 'avatar' | 'space' | 'space-sx' | 'token',
+  type: 'avatar' | 'space' | 'space-sx' | 'space-cover-sx' | 'token',
   id: string,
-  size: number,
+  size: number | { width: number; height: number },
   hash?: string
 ) {
+  let sizeParam = '';
+  if (typeof size === 'number') {
+    sizeParam = `?s=${size * 2}`;
+  } else {
+    sizeParam = `?w=${size.width}&h=${size.height}`;
+  }
+
   const cacheParam = hash ? `&cb=${hash}` : '';
 
-  return `https://cdn.stamp.fyi/${type}/${id}?s=${size * 2}${cacheParam}`;
+  return `https://cdn.stamp.fyi/${type}/${id}${sizeParam}${cacheParam}`;
 }
 
 export async function imageUpload(file: File) {

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -33,6 +33,7 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     network: networkId,
     name: space.metadata.name,
     avatar: space.metadata.avatar,
+    cover: space.metadata.cover,
     about: space.metadata.about,
     external_url: space.metadata.external_url,
     github: space.metadata.github,

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -6,6 +6,7 @@ const SPACE_FRAGMENT = gql`
     metadata {
       name
       avatar
+      cover
       about
       external_url
       github

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -11,6 +11,7 @@ export type ApiSpace = {
   metadata: {
     name: string;
     avatar: string;
+    cover: string;
     about?: string;
     external_url: string;
     twitter: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type SelectedStrategy = {
 export type SpaceMetadata = {
   name: string;
   avatar: string;
+  cover: string;
   description: string;
   externalUrl: string;
   twitter: string;
@@ -43,6 +44,7 @@ export type Space = {
   network: NetworkID;
   name: string;
   avatar: string;
+  cover: string;
   about?: string;
   external_url: string;
   delegation_api_type: string | null;

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -64,6 +64,7 @@ const metadataForm: SpaceMetadata = reactive(
   clone({
     name: '',
     avatar: '',
+    cover: '',
     description: '',
     externalUrl: '',
     twitter: '',

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -62,7 +62,12 @@ watchEffect(() => {
 
 <template>
   <div>
-    <div class="relative bg-skin-border h-[140px] -mb-[70px] top-[-1px]">
+    <div class="relative bg-skin-border h-[140px] -mb-[70px] top-[-1px] overflow-hidden">
+      <SpaceCover
+        v-if="props.space.cover"
+        :space="props.space"
+        class="!rounded-none w-full min-h-full object-cover"
+      />
       <div class="absolute right-4 top-4 space-x-2">
         <router-link :to="{ name: 'editor' }">
           <UiTooltip title="New proposal">

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -62,12 +62,14 @@ watchEffect(() => {
 
 <template>
   <div>
-    <div class="relative bg-skin-border h-[140px] -mb-[70px] top-[-1px] overflow-hidden">
-      <SpaceCover
-        v-if="props.space.cover"
-        :space="props.space"
-        class="!rounded-none w-full min-h-full object-cover"
-      />
+    <div class="relative bg-skin-border h-[140px] -mb-[70px] top-[-1px]">
+      <div class="w-full h-[140px] overflow-hidden">
+        <SpaceCover
+          v-if="props.space.cover"
+          :space="props.space"
+          class="!rounded-none w-full min-h-full object-cover"
+        />
+      </div>
       <div class="absolute right-4 top-4 space-x-2">
         <router-link :to="{ name: 'editor' }">
           <UiTooltip title="New proposal">


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/580
Closes: https://github.com/snapshot-labs/sx-ui/issues/658

Depends on: https://github.com/snapshot-labs/stamp/pull/56
Depends on: https://github.com/pulls

## Test plan

- Use local stamp from PR and change URL in Stamp.vue
- Change goerli API URL to https://api.studio.thegraph.com/query/41343/sekhmet-sx-goerli/version/latest
- Disable all other networks.
- You can see cover photo there.
- You can add cover photos to your own spaces.

## Screenshots

<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/aebf6bc8-9add-45c7-8120-37f7045f004a" width="600" />
<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/4c533248-ee38-41e9-a2a4-35dd14ceb591" width="400" />
<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/42b449fd-bc90-4f00-9a3f-42d440c8f939" width="600" />

## Further comments

We might want to lift size limit on pineapple too, some images will fail to upload now.