### PR TITLE
feat: clear pending transactions after 5 minutes

### DIFF
--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -15,7 +15,7 @@ type PendingTransaction = {
   createdAt: number;
 };
 
-const PENDING_TRANSACTIONS_TIMEOUT = 5 * 60 * 1000;
+const PENDING_TRANSACTIONS_TIMEOUT = 10 * 60 * 1000;
 const PENDING_TRANSACTIONS_STORAGE_KEY = 'pendingTransactions';
 
 function updateStorage(pendingTransactions: PendingTransaction[]) {


### PR DESCRIPTION
## Test plan

- Change txId to `0xe1d29d7207d7fb4b834e4f56c66554b101dfdb7d835809791c01c9193eec3c59` in addPendingTransaction.
- Do some action (Mana looks broken now so check something else).
- Refresh page after 5 minutes, pending transaction is cleared.