### PR TITLE
feat: link to token/NFTs from treasury

### DIFF
--- a/src/helpers/alchemy/index.ts
+++ b/src/helpers/alchemy/index.ts
@@ -4,8 +4,14 @@ export * from './types';
 
 const apiKey = import.meta.env.VITE_ALCHEMY_API_KEY;
 
+const NETWORKS = {
+  1: 'mainnet',
+  5: 'goerli',
+  11155111: 'sepolia'
+};
+
 function getApiUrl(networkId: number) {
-  const network = networkId === 5 ? 'goerli' : 'mainnet';
+  const network = NETWORKS[networkId] ?? 'mainnet';
 
   return `https://eth-${network}.g.alchemy.com/v2/${apiKey}`;
 }

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -48,8 +48,9 @@ export function createEvmNetwork(networkId: NetworkID): Network {
         }, interval);
       }),
     getExplorerUrl: (id, type) => {
-      let dataType: 'tx' | 'address' = 'tx';
-      if (['address', 'contract'].includes(type)) dataType = 'address';
+      let dataType: 'tx' | 'address' | 'token' = 'tx';
+      if (type === 'token') dataType = 'token';
+      else if (['address', 'contract'].includes(type)) dataType = 'address';
 
       return `${networks[chainId].explorer}/${dataType}/${id}`;
     }

--- a/src/networks/starknet/index.ts
+++ b/src/networks/starknet/index.ts
@@ -30,8 +30,9 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
         }, interval);
       }),
     getExplorerUrl: (id, type) => {
-      let dataType: 'tx' | 'contract' = 'tx';
-      if (['address', 'contract'].includes(type)) dataType = 'contract';
+      let dataType: 'tx' | 'contract' | 'token' = 'tx';
+      if (type === 'token') dataType = 'token';
+      else if (['address', 'contract'].includes(type)) dataType = 'contract';
 
       return `https://testnet-2.starkscan.co/${dataType}/${id}`;
     }

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -145,7 +145,7 @@ export type NetworkHelpers = {
   pin: (content: any) => Promise<{ cid: string; provider: string }>;
   waitForTransaction(txId: string): Promise<any>;
   waitForSpace(spaceAddress: string, interval?: number): Promise<Space>;
-  getExplorerUrl(id: string, type: 'transaction' | 'address' | 'contract'): string;
+  getExplorerUrl(id: string, type: 'transaction' | 'address' | 'contract' | 'token'): string;
 };
 
 export type Network = {

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -161,11 +161,23 @@ watchEffect(() => {
             <IH-exclamation-circle class="inline-block mr-2" />
             There are no tokens in treasury.
           </div>
-          <div v-for="(asset, i) in sortedAssets" :key="i" class="mx-4 py-3 border-b flex">
+          <a
+            v-for="(asset, i) in sortedAssets"
+            :key="i"
+            :href="
+              (asset.contractAddress === ETH_CONTRACT
+                ? treasuryExplorerUrl
+                : sanitizeUrl(
+                    currentNetwork.helpers.getExplorerUrl(asset.contractAddress, 'token')
+                  )) || '#'
+            "
+            target="_blank"
+            class="mx-4 py-3 border-b flex"
+          >
             <div class="flex-auto flex items-center min-w-0">
               <Stamp :id="asset.contractAddress" type="token" :size="32" />
               <div class="flex flex-col ml-3 leading-[22px] min-w-0 pr-2 md:pr-0">
-                <h4 class="text-skin-link" v-text="asset.symbol" />
+                <h4 v-text="asset.symbol" />
                 <div class="text-sm truncate" v-text="asset.name" />
               </div>
             </div>
@@ -186,7 +198,7 @@ watchEffect(() => {
               />
               <div v-if="asset.price" class="text-sm" v-text="`$${_n(asset.price)}`" />
             </div>
-          </div>
+          </a>
         </div>
         <div v-else-if="page === 'nfts'">
           <div
@@ -198,10 +210,16 @@ watchEffect(() => {
           </div>
           <UiLoading v-if="nftsLoading && !nftsLoaded" class="px-4 py-3 block" />
           <div class="flex flex-row flex-wrap gap-4 p-4">
-            <div v-for="(nft, i) in nfts" :key="i" class="block max-w-[120px]">
+            <a
+              v-for="(nft, i) in nfts"
+              :key="i"
+              :href="sanitizeUrl(nft.permalink) || '#'"
+              target="_blank"
+              class="block max-w-[120px]"
+            >
               <NftPreview :item="nft" class="w-full" />
               <div class="mt-2 text-sm truncate">{{ nft.displayTitle }}</div>
-            </div>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/632

ETH redirects to treasury page itself.


## Test plan
- Go to here: http://localhost:8080/#/sep:0x8e7793c005bb37c7b7b47c1ae980dc6ddd2edbf5/treasury
- You can open tokens and NFTs by clicking them on explorers.