### PR TITLE
feat: validate min max voting duration with each other

### DIFF
--- a/src/components/Block/SpaceFormVoting.vue
+++ b/src/components/Block/SpaceFormVoting.vue
@@ -59,6 +59,11 @@ const definition = {
 const formErrors = computed(() => {
   const errors = validateForm(definition, props.form);
 
+  if (props.form.minVotingDuration > props.form.maxVotingDuration) {
+    errors.maxVotingDuration =
+      'Max. voting duration must be equal to or greater than min. voting duration.';
+  }
+
   emit('errors', errors);
 
   return errors;

--- a/src/components/S/IDuration.vue
+++ b/src/components/S/IDuration.vue
@@ -33,17 +33,25 @@ watch(
 
 <template>
   <div>
-    <div v-text="definition.title" />
-    <div class="flex">
-      <SBase :definition="{ title: 'Days' }" class="flex-1">
+    <div :class="{ 'text-red': error }" v-text="definition.title" />
+    <div class="flex !mb-0" :class="{ 's-error': error }">
+      <SBase :definition="{ title: 'Days' }" class="flex-1" :error="error">
         <input v-model="days" class="s-input !rounded-r-none" type="number" min="0" />
       </SBase>
-      <SBase :definition="{ title: 'Hours' }" class="flex-1">
-        <input v-model="hours" class="s-input !rounded-none" type="number" min="0" />
+      <SBase :definition="{ title: 'Hours' }" class="flex-1" :error="error">
+        <input v-model="hours" class="s-input !rounded-none !border-l-0" type="number" min="0" />
       </SBase>
-      <SBase :definition="{ title: 'Minutes' }" class="flex-1">
-        <input v-model="minutes" class="s-input !rounded-l-none" type="number" min="0" />
+      <SBase :definition="{ title: 'Minutes' }" class="flex-1" :error="error">
+        <input
+          v-model="minutes"
+          class="s-input !rounded-l-none !border-l-0"
+          type="number"
+          min="0"
+        />
       </SBase>
+    </div>
+    <div v-if="error" class="s-base s-error">
+      <span class="s-input-error-message">{{ error }}</span>
     </div>
   </div>
 </template>

--- a/src/components/Ui/Editable.vue
+++ b/src/components/Ui/Editable.vue
@@ -16,6 +16,7 @@ const props = withDefaults(
     editable: boolean;
     loading?: boolean;
     definition: Definition;
+    customErrorValidation?: (value: string | number) => string | undefined;
   }>(),
   { loading: false }
 );
@@ -38,8 +39,8 @@ const Component = computed(() => {
       return SIString;
   }
 });
-const formErrors = computed(() =>
-  validateForm(
+const formErrors = computed(() => {
+  const errors = validateForm(
     {
       type: 'object',
       title: 'Editable',
@@ -52,8 +53,14 @@ const formErrors = computed(() =>
     {
       value: inputValue.value
     }
-  )
-);
+  );
+
+  const customError = props.customErrorValidation?.(inputValue.value);
+  if (customError) errors.value = customError;
+
+  return errors;
+});
+
 function handleSave() {
   emit('save', inputValue.value);
   editing.value = false;
@@ -84,7 +91,8 @@ function handleSave() {
         <div
           class="flex gap-2 relative"
           :class="{
-            'top-[-15px]': !!formErrors.value,
+            'top-[-19.5px]': definition.format !== 'duration' && !!formErrors.value,
+            'top-[-18.5px]': definition.format === 'duration' && !!formErrors.value,
             'top-[-6px]': definition.format === 'duration'
           }"
         >

--- a/src/style.scss
+++ b/src/style.scss
@@ -63,7 +63,7 @@ body {
 
 .mono {
   font-size: 44px;
-  font-family: "Space Mono", Helvetica, Arial, sans-serif;
+  font-family: 'Space Mono', Helvetica, Arial, sans-serif;
   letter-spacing: -1px;
   font-weight: 700;
   line-height: 1.1em;
@@ -209,7 +209,8 @@ a,
   @apply mb-2;
 
   .s-input {
-    @apply mb-1 border border-red #{!important};
+    @apply border border-red;
+    @apply mb-1 #{!important};
   }
 
   .s-label {

--- a/src/views/Space/Settings.vue
+++ b/src/views/Space/Settings.vue
@@ -83,6 +83,12 @@ watchEffect(() => {
               type: 'integer',
               format: 'duration'
             }"
+            :custom-error-validation="
+              value =>
+                Number(value) > space.max_voting_period
+                  ? 'Must be equal to or lower than max. voting period'
+                  : undefined
+            "
             @save="value => handleSave('minVotingPeriod', value.toString())"
           >
             <h4 class="text-skin-link text-md" v-text="_d(space.min_voting_period) || 'No min.'" />
@@ -98,6 +104,12 @@ watchEffect(() => {
               type: 'integer',
               format: 'duration'
             }"
+            :custom-error-validation="
+              value =>
+                Number(value) < space.min_voting_period
+                  ? 'Must be equal to or higher than min. voting period'
+                  : undefined
+            "
             @save="value => handleSave('maxVotingPeriod', value.toString())"
           >
             <h4 class="text-skin-link text-md" v-text="_d(space.max_voting_period)" />


### PR DESCRIPTION
## Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/545

This PR adds validation for min/max voting duration.

- When creating space it validates max isn't lower than min.
- When editing space it validates each value separately (because they are updated independently).

## Test plan
- Try setting wrong values when deploying space.
- Try setting wrong values when editing space.

## Screenshots

<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/35117930-5edc-4f82-bc29-bf7e632e1fa8" width="500" />
<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/4e5dd134-d7cb-46ae-abd6-993fd568f0da" width="500" />
