### PR TITLE
fix: display tooltips at top of overview buttons

### DIFF
--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -62,9 +62,7 @@ watchEffect(() => {
 
 <template>
   <div>
-    <div
-      class="relative bg-skin-border h-[156px] md:h-[140px] -mb-[86px] md:-mb-[70px] top-[-1px] overflow-hidden"
-    >
+    <div class="relative bg-skin-border h-[156px] md:h-[140px] -mb-[86px] md:-mb-[70px] top-[-1px]">
       <div class="w-full h-full overflow-hidden">
         <SpaceCover
           v-if="props.space.cover"


### PR DESCRIPTION
## Summary

overflow-hidden was added before that caused it to move to bottom position (to prevent tooltips from being partially cut off). Removing it restores old placement, and it doesn't seem to cause any other issues.