### PR TITLE
chore: handle getNames failure

### DIFF
--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -18,13 +18,19 @@ export async function getNames(addresses: string[]) {
   if (addresses.length === 0) return {};
   const network = 1;
   const provider = getProvider(network);
-  const names = await call(
-    provider,
-    abi,
-    ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [addresses]],
-    { blockTag: 'latest' }
-  );
-  return Object.fromEntries(addresses.map((address, i) => [address, names[i]]));
+
+  try {
+    const names = await call(
+      provider,
+      abi,
+      ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [addresses]],
+      { blockTag: 'latest' }
+    );
+    return Object.fromEntries(addresses.map((address, i) => [address, names[i]]));
+  } catch (e) {
+    console.error('failed to reverse resolve names', e);
+    return {};
+  }
 }
 
 export async function resolveName(name: string, chainId: number) {


### PR DESCRIPTION
It seems that some addresses cause the call to revert, breaking logging in. For example calling get names with 0xaDa7E6d162C3Ff6f493Cc848f9FE1Bd74dD70A17 will throw.

This change will swallow errors and return empty object if this happens.