### PR TITLE
feat: add markdown toolbar to editor

### DIFF
--- a/src/composables/useMarkdownEditor.ts
+++ b/src/composables/useMarkdownEditor.ts
@@ -9,6 +9,23 @@ export function useMarkdownEditor(
   editorRef: Ref<HTMLTextAreaElement | null>,
   handler: ChangeHandler
 ) {
+  const shortcuts = {
+    b: bold,
+    i: italic,
+    k: link
+  };
+
+  watch(editorRef, el => {
+    if (!el) return;
+
+    el.addEventListener('keydown', (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && shortcuts[e.key]) {
+        e.preventDefault();
+        shortcuts[e.key]();
+      }
+    });
+  });
+
   function scheduleSelection(start: number, end: number) {
     requestAnimationFrame(() => {
       if (editorRef.value) editorRef.value.setSelectionRange(start, end);

--- a/src/composables/useMarkdownEditor.ts
+++ b/src/composables/useMarkdownEditor.ts
@@ -1,0 +1,126 @@
+type Formatting = {
+  prefix: string;
+  suffix: string;
+};
+
+type ChangeHandler = (value: string) => void;
+
+export function useMarkdownEditor(
+  editorRef: Ref<HTMLTextAreaElement | null>,
+  handler: ChangeHandler
+) {
+  function scheduleSelection(start: number, end: number) {
+    requestAnimationFrame(() => {
+      if (editorRef.value) editorRef.value.setSelectionRange(start, end);
+    });
+  }
+
+  function getEditorChange(formatting: Formatting) {
+    if (!editorRef.value) return;
+
+    const { selectionStart, selectionEnd, value } = editorRef.value;
+
+    const hasNoSelection = selectionStart === selectionEnd;
+    const selectionFormattedOutside =
+      value.substring(selectionStart - formatting.prefix.length, selectionStart) ===
+        formatting.prefix &&
+      value.substring(selectionEnd, selectionEnd + formatting.suffix.length) === formatting.suffix;
+    const selectionFormattedInside =
+      value.substring(selectionStart, selectionStart + formatting.prefix.length) ===
+        formatting.prefix &&
+      value.substring(selectionEnd - formatting.suffix.length, selectionEnd) === formatting.suffix;
+
+    if (hasNoSelection) {
+      const formattedValue =
+        value.substring(0, selectionStart) +
+        formatting.prefix +
+        formatting.suffix +
+        value.substring(selectionEnd);
+
+      return {
+        value: formattedValue,
+        selectionStart: selectionStart + formatting.prefix.length,
+        selectionEnd: selectionStart + formatting.prefix.length
+      };
+    }
+
+    if (selectionFormattedOutside) {
+      const formattedValue =
+        value.substring(0, selectionStart - formatting.prefix.length) +
+        value.substring(selectionStart, selectionEnd) +
+        value.substring(selectionEnd + formatting.suffix.length);
+
+      return {
+        value: formattedValue,
+        selectionStart: selectionStart - formatting.prefix.length,
+        selectionEnd: selectionEnd - formatting.prefix.length
+      };
+    }
+
+    if (selectionFormattedInside) {
+      const formattedValue =
+        value.substring(0, selectionStart) +
+        value.substring(
+          selectionStart + formatting.prefix.length,
+          selectionEnd - formatting.suffix.length
+        ) +
+        value.substring(selectionEnd);
+
+      return {
+        value: formattedValue,
+        selectionStart: selectionStart,
+        selectionEnd: selectionEnd - formatting.prefix.length - formatting.suffix.length
+      };
+    }
+
+    const formattedValue =
+      value.substring(0, selectionStart) +
+      formatting.prefix +
+      value.substring(selectionStart, selectionEnd) +
+      formatting.suffix +
+      value.substring(selectionEnd);
+
+    return {
+      value: formattedValue,
+      selectionStart: selectionStart + formatting.prefix.length,
+      selectionEnd: selectionEnd + formatting.prefix.length
+    };
+  }
+
+  function insertFormatting(formatting: Formatting) {
+    if (!editorRef.value) return;
+
+    const change = getEditorChange(formatting);
+    if (!change) return;
+
+    const { value, selectionStart, selectionEnd } = change;
+
+    handler(value);
+    scheduleSelection(selectionStart, selectionEnd);
+
+    editorRef.value.focus();
+  }
+
+  function heading() {
+    insertFormatting({ prefix: '# ', suffix: '' });
+  }
+
+  function bold() {
+    insertFormatting({ prefix: '**', suffix: '**' });
+  }
+
+  function italic() {
+    insertFormatting({ prefix: '*', suffix: '*' });
+  }
+
+  function link() {
+    insertFormatting({ prefix: '[', suffix: '](url)' });
+  }
+
+  return {
+    heading,
+    bold,
+    italic,
+    link
+  };
+}

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -20,6 +20,12 @@ const DISCUSSION_DEFINITION = {
 
 const { setTitle } = useTitle();
 const { proposals, createDraft } = useEditor();
+const editorRef = ref<HTMLTextAreaElement | null>(null);
+const editor = useMarkdownEditor(editorRef, value => {
+  if (!proposal.value) return;
+
+  proposal.value.body = value;
+});
 const { param } = useRouteParser('id');
 const { resolved, address, networkId } = useResolve(param);
 const route = useRoute();
@@ -290,17 +296,49 @@ export default defineComponent({
         class="px-3 py-2 border rounded-lg mb-5 min-h-[200px]"
         :body="proposal.body"
       />
-
-      <div v-else class="s-base mb-3">
-        <div class="s-label" v-text="'Description'" />
-        <textarea v-model="proposal.body" maxlength="9600" class="s-input mb-3 h-[200px]" />
-        <SIString
-          :key="proposalKey || ''"
-          v-model="proposal.discussion"
-          :definition="DISCUSSION_DEFINITION"
-          :error="formErrors.discussion"
-        />
-        <Preview :key="proposalKey || ''" :url="proposal.discussion" />
+      <div v-else>
+        <div class="flex gap-1 mb-2">
+          <button
+            class="p-1 w-[26px] h-[26px] leading-[18px] hover:text-skin-link rounded focus:ring-1"
+            @click="editor.heading"
+          >
+            H
+          </button>
+          <button
+            class="p-1 w-[26px] h-[26px] leading-[18px] font-bold hover:text-skin-link rounded focus:ring-1"
+            @click="editor.bold"
+          >
+            B
+          </button>
+          <button
+            class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus:ring-1"
+            @click="editor.italic"
+          >
+            I
+          </button>
+          <button
+            class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus:ring-1"
+            @click="editor.link"
+          >
+            <IH-link class="w-[18px] h-[18px]" />
+          </button>
+        </div>
+        <div class="s-base mb-3">
+          <div class="s-label" v-text="'Description'" />
+          <textarea
+            ref="editorRef"
+            v-model="proposal.body"
+            maxlength="9600"
+            class="s-input mb-3 h-[200px]"
+          />
+          <SIString
+            :key="proposalKey || ''"
+            v-model="proposal.discussion"
+            :definition="DISCUSSION_DEFINITION"
+            :error="formErrors.discussion"
+          />
+          <Preview :key="proposalKey || ''" :url="proposal.discussion" />
+        </div>
       </div>
       <div
         v-if="

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -297,7 +297,7 @@ export default defineComponent({
         :body="proposal.body"
       />
       <div v-else>
-        <div class="flex gap-1 mb-2">
+        <div class="flex justify-end gap-1 py-1 px-2 border rounded-t-lg">
           <button
             class="p-1 w-[26px] h-[26px] leading-[18px] hover:text-skin-link rounded focus:ring-1"
             @click="editor.heading"
@@ -329,7 +329,7 @@ export default defineComponent({
             ref="editorRef"
             v-model="proposal.body"
             maxlength="9600"
-            class="s-input mb-3 h-[200px]"
+            class="s-input mb-3 h-[200px] !rounded-t-none"
           />
           <SIString
             :key="proposalKey || ''"

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -297,31 +297,39 @@ export default defineComponent({
         :body="proposal.body"
       />
       <div v-else>
-        <div class="flex justify-end gap-1 py-1 px-2 border rounded-t-lg">
-          <button
-            class="p-1 w-[26px] h-[26px] leading-[18px] hover:text-skin-link rounded focus:ring-1"
-            @click="editor.heading"
-          >
-            H
-          </button>
-          <button
-            class="p-1 w-[26px] h-[26px] leading-[18px] font-bold hover:text-skin-link rounded focus:ring-1"
-            @click="editor.bold"
-          >
-            B
-          </button>
-          <button
-            class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus:ring-1"
-            @click="editor.italic"
-          >
-            I
-          </button>
-          <button
-            class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus:ring-1"
-            @click="editor.link"
-          >
-            <IH-link class="w-[18px] h-[18px]" />
-          </button>
+        <div class="flex justify-end gap-1 py-2 px-3 border rounded-t-lg">
+          <UiTooltip title="Add heading text">
+            <button
+              class="p-1 w-[26px] h-[26px] leading-[18px] hover:text-skin-link rounded focus-visible:ring-1"
+              @click="editor.heading"
+            >
+              H
+            </button>
+          </UiTooltip>
+          <UiTooltip title="Add bold text">
+            <button
+              class="p-1 w-[26px] h-[26px] leading-[18px] font-bold hover:text-skin-link rounded focus-visible:ring-1"
+              @click="editor.bold"
+            >
+              B
+            </button>
+          </UiTooltip>
+          <UiTooltip title="Add italic text">
+            <button
+              class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus-visible:ring-1"
+              @click="editor.italic"
+            >
+              I
+            </button>
+          </UiTooltip>
+          <UiTooltip title="Add a link">
+            <button
+              class="p-1 w-[26px] h-[26px] leading-[18px] italic hover:text-skin-link rounded focus-visible:ring-1"
+              @click="editor.link"
+            >
+              <IH-link class="w-[18px] h-[18px]" />
+            </button>
+          </UiTooltip>
         </div>
         <div class="s-base mb-3">
           <div class="s-label" v-text="'Description'" />


### PR DESCRIPTION
## Summary

This PR adds toolbar buttons for adding heading/bold/italic and links. Heading/bold/italic use text as icons as heroicons doesn't have anything matching.

Closes: https://github.com/snapshot-labs/sx-ui/issues/699

## Test plan
- Go to editor and try using it.

## Screenshots

<img src="https://github.com/snapshot-labs/sx-ui/assets/1968722/fdb489c7-8c9c-40ce-ae61-545de29f4a1e" width="600" />
