### PR TITLE
feat: add ENS support for execution forms

### DIFF
--- a/src/components/Modal/SendNft.vue
+++ b/src/components/Modal/SendNft.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { createSendNftTransaction } from '@/helpers/transactions';
 import { clone } from '@/helpers/utils';
-import { validateForm } from '@/helpers/validation';
+import { getValidator } from '@/helpers/validation';
 
 const DEFAULT_FORM_STATE = {
   to: '',
@@ -11,7 +11,7 @@ const DEFAULT_FORM_STATE = {
 
 const RECIPIENT_DEFINITION = {
   type: 'string',
-  format: 'address',
+  format: 'ens-or-address',
   title: 'Recipient',
   examples: ['Address']
 };
@@ -25,12 +25,25 @@ const props = defineProps({
   initialState: Object
 });
 
+const formValidator = getValidator({
+  $async: true,
+  type: 'object',
+  title: 'TokenTransfer',
+  additionalProperties: false,
+  required: ['to'],
+  properties: {
+    to: RECIPIENT_DEFINITION
+  }
+});
+
 const emit = defineEmits(['add', 'close']);
 
 const searchInput: Ref<HTMLElement | null> = ref(null);
 const showPicker = ref(false);
 const pickerType: Ref<'nft' | 'contact' | null> = ref(null);
 const searchValue = ref('');
+const formValidated = ref(false);
+const formErrors = ref({} as Record<string, any>);
 
 const form: { to: string; nft: string; amount: string | number } = reactive(
   clone(DEFAULT_FORM_STATE)
@@ -39,25 +52,11 @@ const form: { to: string; nft: string; amount: string | number } = reactive(
 const { loading, loaded, nfts, nftsMap, loadNfts } = useNfts();
 
 const currentNft = computed(() => nftsMap.value?.get(form.nft));
-const formErrors = computed(() =>
-  validateForm(
-    {
-      type: 'object',
-      title: 'TokenTransfer',
-      additionalProperties: false,
-      required: ['to'],
-      properties: {
-        to: RECIPIENT_DEFINITION
-      }
-    },
-    {
-      to: form.to
-    }
-  )
-);
+
 const formValid = computed(
   () =>
     currentNft.value &&
+    formValidated.value &&
     Object.keys(formErrors.value).length === 0 &&
     (currentNft.value.type !== 'erc1155' || form.amount !== '')
 );
@@ -77,8 +76,8 @@ function handlePickerClick(type: 'nft' | 'contact') {
   });
 }
 
-function handleSubmit() {
-  const tx = createSendNftTransaction({
+async function handleSubmit() {
+  const tx = await createSendNftTransaction({
     nft: currentNft.value,
     address: props.address,
     form: clone(form)
@@ -108,6 +107,15 @@ watch(
     }
   }
 );
+
+watchEffect(async () => {
+  formValidated.value = false;
+
+  formErrors.value = await formValidator.validateAsync({
+    to: form.to
+  });
+  formValidated.value = true;
+});
 </script>
 
 <template>

--- a/src/components/S/IObject.vue
+++ b/src/components/S/IObject.vue
@@ -57,6 +57,7 @@ const getComponent = (property: { type: string; format: string; enum?: string[] 
     case 'string':
       if (property.format === 'long') return IText;
       if (property.format === 'address') return IAddress;
+      if (property.format === 'ens-or-address') return IAddress;
       if (property.format === 'stamp') return IStamp;
       if (property.enum) return ISelect;
       return IString;

--- a/src/helpers/__tests__/__snapshots__/transactions.test.ts.snap
+++ b/src/helpers/__tests__/__snapshots__/transactions.test.ts.snap
@@ -21,6 +21,27 @@ exports[`transactions > createContractCallTransaction > should create contract c
 }
 `;
 
+exports[`transactions > createContractCallTransaction > should create contract call transaction with ENS domain 1`] = `
+{
+  "_form": {
+    "abi": [
+      "function deny(address guy)",
+    ],
+    "amount": undefined,
+    "args": {
+      "guy": "me.sekhmet.eth",
+    },
+    "method": "deny",
+    "recipient": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
+  },
+  "_type": "contractCall",
+  "data": "0x9c52a7f1000000000000000000000000556b14cbda79a36dc33fcd461a04a5bcb5dc2a70",
+  "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "to": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844",
+  "value": "0",
+}
+`;
+
 exports[`transactions > createContractCallTransaction > should create contract call transaction with payable 1`] = `
 {
   "_form": {

--- a/src/helpers/__tests__/transactions.test.ts
+++ b/src/helpers/__tests__/transactions.test.ts
@@ -48,14 +48,14 @@ describe('transactions', () => {
       value: 1076.29
     };
 
-    it('should create eth transaction', () => {
-      const tx = createSendTokenTransaction({ token: ethToken, form });
+    it('should create eth transaction', async () => {
+      const tx = await createSendTokenTransaction({ token: ethToken, form });
 
       expect(tx).toMatchSnapshot();
     });
 
-    it('should create erc20 transaction', () => {
-      const tx = createSendTokenTransaction({ token: balToken, form });
+    it('should create erc20 transaction', async () => {
+      const tx = await createSendTokenTransaction({ token: balToken, form });
 
       expect(tx).toMatchSnapshot();
     });
@@ -84,8 +84,8 @@ describe('transactions', () => {
       amount: '1'
     };
 
-    it('should create erc721 transaction', () => {
-      const tx = createSendNftTransaction({
+    it('should create erc721 transaction', async () => {
+      const tx = await createSendNftTransaction({
         nft: erc721Nft,
         form,
         address: '0x000000000000000000000000000000000000dead'
@@ -94,8 +94,8 @@ describe('transactions', () => {
       expect(tx).toMatchSnapshot();
     });
 
-    it('should create erc1155 transaction', () => {
-      const tx = createSendNftTransaction({
+    it('should create erc1155 transaction', async () => {
+      const tx = await createSendNftTransaction({
         nft: erc1155Nft,
         form,
         address: '0x000000000000000000000000000000000000dead'
@@ -106,8 +106,8 @@ describe('transactions', () => {
   });
 
   describe('createContractCallTransaction', () => {
-    it('should create contract call transaction', () => {
-      const tx = createContractCallTransaction({
+    it('should create contract call transaction', async () => {
+      const tx = await createContractCallTransaction({
         form: {
           to: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
           abi: ['function deny(address guy)'],
@@ -121,14 +121,29 @@ describe('transactions', () => {
       expect(tx).toMatchSnapshot();
     });
 
-    it('should create contract call transaction with payable', () => {
-      const tx = createContractCallTransaction({
+    it('should create contract call transaction with payable', async () => {
+      const tx = await createContractCallTransaction({
         form: {
           to: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
           abi: ['function deposit() payable'],
           method: 'deposit',
           args: {},
           amount: '20'
+        }
+      });
+
+      expect(tx).toMatchSnapshot();
+    });
+
+    it('should create contract call transaction with ENS domain', async () => {
+      const tx = await createContractCallTransaction({
+        form: {
+          to: '0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844',
+          abi: ['function deny(address guy)'],
+          method: 'deny',
+          args: {
+            guy: 'me.sekhmet.eth'
+          }
         }
       });
 

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -165,6 +165,7 @@ export function _rt(number) {
 
 export function abiToDefinition(abi) {
   const definition = {
+    $async: true,
     title: abi.name,
     type: 'object',
     required: [] as string[],
@@ -185,7 +186,7 @@ export function abiToDefinition(abi) {
       definition.properties[input.name].examples = ['0'];
     }
     if (input.type === 'address') {
-      definition.properties[input.name].format = 'address';
+      definition.properties[input.name].format = 'ens-or-address';
       definition.properties[input.name].examples = ['0x0000…'];
     }
     definition.properties[input.name].type = type;

--- a/src/helpers/validation.ts
+++ b/src/helpers/validation.ts
@@ -6,16 +6,143 @@ import { parseUnits } from '@ethersproject/units';
 import { Zero, MinInt256, MaxInt256, MaxUint256 } from '@ethersproject/constants';
 import { BigNumber } from '@ethersproject/bignumber';
 import { Interface } from '@ethersproject/abi';
+import { resolver } from '@/helpers/resolver';
 
-function getErrorMessage(errorObject: ErrorObject): string {
+type Opts = { skipEmptyOptionalFields: boolean };
+
+const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
+
+ajv.addFormat('address', {
+  validate: (value: string) => {
+    if (!value) return false;
+
+    try {
+      return !!validateAndParseAddress(value);
+    } catch (e) {
+      return isAddress(value);
+    }
+  }
+});
+
+ajv.addFormat('ens-or-address', {
+  async: true,
+  validate: async (value: string) => {
+    if (!value) return false;
+
+    try {
+      const resolved = await resolver.resolveName(value);
+      if (resolved?.address) return true;
+
+      return !!validateAndParseAddress(value);
+    } catch (e) {
+      return isAddress(value);
+    }
+  }
+});
+
+ajv.addFormat('abi', {
+  validate: (value: string) => {
+    if (!value) return false;
+
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed.length === 0) return false;
+
+      new Interface(parsed);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+});
+
+ajv.addFormat('stamp', {
+  validate: () => true
+});
+
+ajv.addFormat('twitter-handle', {
+  validate: (value: string) => {
+    if (!value) return false;
+
+    return !!value.match(/^[a-zA-Z0-9_]+$/);
+  }
+});
+
+ajv.addFormat('github-handle', {
+  validate: (value: string) => {
+    if (!value) return false;
+
+    return !!value.match(/^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/);
+  }
+});
+
+ajv.addFormat('discord-handle', {
+  validate: (value: string) => {
+    if (!value) return false;
+
+    return !!value.match(/^[a-zA-Z0-9-]+$/);
+  }
+});
+
+ajv.addFormat('long', {
+  validate: () => true
+});
+
+ajv.addFormat('uint256', {
+  validate: value => {
+    if (!value.match(/^([0-9]|[1-9][0-9]+)$/)) return false;
+
+    try {
+      const number = BigNumber.from(value);
+      return number.gte(Zero) && number.lte(MaxUint256);
+    } catch {
+      return false;
+    }
+  }
+});
+
+ajv.addFormat('ethValue', {
+  validate: value => {
+    if (!value.match(/^([0-9]|[1-9][0-9]+)(\.[0-9]+)?$/)) return false;
+
+    try {
+      parseUnits(value, 18);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+});
+
+ajv.addFormat('int256', {
+  validate: value => {
+    if (!value.match(/^-?([0-9]|[1-9][0-9]+)$/)) return false;
+
+    try {
+      const number = BigNumber.from(value);
+      return number.gte(MinInt256) && number.lte(MaxInt256);
+    } catch {
+      return false;
+    }
+  }
+});
+
+ajv.addKeyword('options');
+
+function getErrorMessage(errorObject: Partial<ErrorObject>): string {
   if (!errorObject.message) return 'Invalid field.';
 
   if (errorObject.keyword === 'format') {
+    if (!errorObject.params) return 'Invalid format.';
+
     switch (errorObject.params.format) {
       case 'uri':
         return 'Must be a valid URL.';
       case 'address':
         return 'Must be a valid address.';
+      case 'ens-or-address':
+        return 'Must be a valid ENS domain or address.';
       case 'abi':
         return 'Must be a valid ABI.';
       case 'twitter-handle':
@@ -40,134 +167,33 @@ function getErrorMessage(errorObject: ErrorObject): string {
     .toLocaleLowerCase()}.`;
 }
 
-export function validateForm(
-  schema,
-  form,
-  opts: { skipEmptyOptionalFields: boolean } = { skipEmptyOptionalFields: false }
-): Record<string, string> {
-  const ajv = new Ajv({ allErrors: true });
-  addFormats(ajv);
-
-  ajv.addFormat('address', {
-    validate: (value: string) => {
-      if (!value) return false;
-
-      try {
-        return !!validateAndParseAddress(value);
-      } catch (e) {
-        return isAddress(value);
-      }
-    }
-  });
-
-  ajv.addFormat('abi', {
-    validate: (value: string) => {
-      if (!value) return false;
-
-      try {
-        const parsed = JSON.parse(value);
-        if (parsed.length === 0) return false;
-
-        new Interface(parsed);
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  });
-
-  ajv.addFormat('stamp', {
-    validate: () => true
-  });
-
-  ajv.addFormat('twitter-handle', {
-    validate: (value: string) => {
-      if (!value) return false;
-
-      return !!value.match(/^[a-zA-Z0-9_]+$/);
-    }
-  });
-
-  ajv.addFormat('github-handle', {
-    validate: (value: string) => {
-      if (!value) return false;
-
-      return !!value.match(/^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/);
-    }
-  });
-
-  ajv.addFormat('discord-handle', {
-    validate: (value: string) => {
-      if (!value) return false;
-
-      return !!value.match(/^[a-zA-Z0-9-]+$/);
-    }
-  });
-
-  ajv.addFormat('long', {
-    validate: () => true
-  });
-
-  ajv.addFormat('uint256', {
-    validate: value => {
-      if (!value.match(/^([0-9]|[1-9][0-9]+)$/)) return false;
-
-      try {
-        const number = BigNumber.from(value);
-        return number.gte(Zero) && number.lte(MaxUint256);
-      } catch {
-        return false;
-      }
-    }
-  });
-
-  ajv.addFormat('ethValue', {
-    validate: value => {
-      if (!value.match(/^([0-9]|[1-9][0-9]+)(\.[0-9]+)?$/)) return false;
-
-      try {
-        parseUnits(value, 18);
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  });
-
-  ajv.addFormat('int256', {
-    validate: value => {
-      if (!value.match(/^-?([0-9]|[1-9][0-9]+)$/)) return false;
-
-      try {
-        const number = BigNumber.from(value);
-        return number.gte(MinInt256) && number.lte(MaxInt256);
-      } catch {
-        return false;
-      }
-    }
-  });
-
-  ajv.addKeyword('options');
+const getFormValues = (schema: any, form: any, opts: Opts) => {
+  if (!opts.skipEmptyOptionalFields) return form;
 
   const requiredKeys = schema.required || [];
-  const processedForm = !opts.skipEmptyOptionalFields
-    ? form
-    : Object.fromEntries(
-        Object.entries(form).filter(([key, value]) => {
-          if (requiredKeys.includes(key)) return true;
 
-          return value !== '';
-        })
-      );
+  return Object.fromEntries(
+    Object.entries(form).filter(([key, value]) => {
+      if (requiredKeys.includes(key)) return true;
 
-  ajv.validate(schema, processedForm);
+      return value !== '';
+    })
+  );
+};
 
-  const output = {};
-  if (!ajv.errors) {
-    return output;
-  }
+const getErrors = (errors: Partial<ErrorObject>[]) => {
+  const output: Record<string, any> = {};
 
-  for (const error of ajv.errors) {
+  if (!errors) return output;
+
+  for (const error of errors) {
+    if (error.keyword === 'required' && error.params?.missingProperty) {
+      output[error.params.missingProperty] = 'Required field.';
+      continue;
+    }
+
+    if (!error.instancePath) continue;
+
     const path = error.instancePath.split('/').slice(1);
 
     let current = output;
@@ -181,4 +207,46 @@ export function validateForm(
   }
 
   return output;
+};
+
+export const getValidator = (schema: any) => {
+  const validate = ajv.compile(schema);
+
+  return {
+    validate: (form: any, opts: Opts = { skipEmptyOptionalFields: false }) => {
+      validate(getFormValues(schema, form, opts));
+
+      if (!validate.errors) return {};
+
+      return getErrors(validate.errors);
+    },
+    validateAsync: async (form: any, opts: Opts = { skipEmptyOptionalFields: false }) => {
+      try {
+        await validate(getFormValues(schema, form, opts));
+
+        return {};
+      } catch (e) {
+        if (!(e instanceof Ajv.ValidationError)) throw e;
+
+        return getErrors(e.errors);
+      }
+    }
+  };
+};
+
+/**
+ * @deprecated Use getValidator instead.
+ */
+export function validateForm(
+  schema,
+  form,
+  opts: { skipEmptyOptionalFields: boolean } = { skipEmptyOptionalFields: false }
+): Record<string, string> {
+  const processedForm = getFormValues(schema, form, opts);
+
+  ajv.validate(schema, processedForm);
+
+  if (!ajv.errors) return {};
+
+  return getErrors(ajv.errors);
 }


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/693

This PR adds async form validation support, `ens-or-address` format and ability to create execution with ENS names.

## Test plan
- Create proposal with execution here: http://localhost:8080/#/gor:0x310d0c40c6d03e0d4189ceb733fc57efab803ea0
- Use ENS domains (created on Goerli) as recipient on Token/NFT execution or in arguments for Contract call.
- You can save/edit/simulate and create proposal with those.
- You can execute that transaction.

