### PR TITLE
fix: convert block to timestamp on timeline

### DIFF
--- a/src/components/Modal/Timeline.vue
+++ b/src/components/Modal/Timeline.vue
@@ -23,16 +23,16 @@ const labels = {
 
 const metaStore = useMetaStore();
 
-function getEstimatedTsFromBlock(network, blockNum) {
+function getTsFromBlock(network, blockNum) {
   const networkBlockNum = metaStore.currentBlocks.get(network) || 0;
   const blockDiff = networkBlockNum - blockNum;
 
-  if (blockDiff > 0) return metaStore.currentTs - METADATA[network].blockTime * blockDiff;
-  if (blockDiff < 0) return metaStore.currentTs + METADATA[network].blockTime * Math.abs(blockDiff);
-  return metaStore.currentTs;
+  return metaStore.currentTs.valueOf() - METADATA[network].blockTime * blockDiff;
 }
 
 const states = computed(() => {
+  const network = props.proposal.network;
+
   if (props.proposal.min_end === props.proposal.max_end) {
     return [
       {
@@ -42,12 +42,12 @@ const states = computed(() => {
       {
         id: 'start',
         block_number: props.proposal.start,
-        value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.start)
+        value: getTsFromBlock(network, props.proposal.start)
       },
       {
         id: 'end',
         block_number: props.proposal.min_end,
-        value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.min_end)
+        value: getTsFromBlock(network, props.proposal.min_end)
       }
     ];
   }
@@ -60,17 +60,17 @@ const states = computed(() => {
     {
       id: 'start',
       block_number: props.proposal.start,
-      value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.start)
+      value: getTsFromBlock(network, props.proposal.start)
     },
     {
       id: 'min_end',
       block_number: props.proposal.min_end,
-      value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.min_end)
+      value: getTsFromBlock(network, props.proposal.min_end)
     },
     {
       id: 'max_end',
       block_number: props.proposal.max_end,
-      value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.max_end)
+      value: getTsFromBlock(network, props.proposal.max_end)
     }
   ];
 });

--- a/src/components/Modal/Timeline.vue
+++ b/src/components/Modal/Timeline.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { _t } from '@/helpers/utils';
 import { Proposal } from '@/types';
+import { useMetaStore } from '@/stores/meta';
+import { METADATA } from '@/networks/evm';
 
 const props = defineProps<{
   open: boolean;
@@ -19,6 +21,17 @@ const labels = {
   max_end: 'Max. end'
 };
 
+const metaStore = useMetaStore();
+
+function getEstimatedTsFromBlock(network, blockNum) {
+  const networkBlockNum = metaStore.currentBlocks.get(network) || 0;
+  const blockDiff = networkBlockNum - blockNum;
+
+  if (blockDiff > 0) return metaStore.currentTs - METADATA[network].blockTime * blockDiff;
+  if (blockDiff < 0) return metaStore.currentTs + METADATA[network].blockTime * Math.abs(blockDiff);
+  return metaStore.currentTs;
+}
+
 const states = computed(() => {
   if (props.proposal.min_end === props.proposal.max_end) {
     return [
@@ -28,11 +41,13 @@ const states = computed(() => {
       },
       {
         id: 'start',
-        value: props.proposal.start
+        block_number: props.proposal.start,
+        value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.start)
       },
       {
         id: 'end',
-        value: props.proposal.min_end
+        block_number: props.proposal.min_end,
+        value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.min_end)
       }
     ];
   }
@@ -44,15 +59,18 @@ const states = computed(() => {
     },
     {
       id: 'start',
-      value: props.proposal.start
+      block_number: props.proposal.start,
+      value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.start)
     },
     {
       id: 'min_end',
-      value: props.proposal.min_end
+      block_number: props.proposal.min_end,
+      value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.min_end)
     },
     {
       id: 'max_end',
-      value: props.proposal.max_end
+      block_number: props.proposal.max_end,
+      value: getEstimatedTsFromBlock(props.proposal.network, props.proposal.max_end)
     }
   ];
 });

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -7,36 +7,41 @@ import networks from '@/helpers/networks.json';
 import { Network } from '@/networks/types';
 import { NetworkID, Space } from '@/types';
 
-const METADATA = {
+export const METADATA = {
   matic: {
     name: 'Polygon',
     chainId: 137,
     apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-polygon/version/latest',
-    avatar: 'ipfs://bafkreihcx4zkpfjfcs6fazjp6lcyes4pdhqx3uvnjuo5uj2dlsjopxv5am'
+    avatar: 'ipfs://bafkreihcx4zkpfjfcs6fazjp6lcyes4pdhqx3uvnjuo5uj2dlsjopxv5am',
+    blockTime: 2.15812
   },
   arb1: {
     name: 'Arbitrum One',
     chainId: 42161,
     apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-arbitrum/version/latest',
-    avatar: 'ipfs://bafkreic2p3zzafvz34y4tnx2kaoj6osqo66fpdo3xnagocil452y766gdq'
+    avatar: 'ipfs://bafkreic2p3zzafvz34y4tnx2kaoj6osqo66fpdo3xnagocil452y766gdq',
+    blockTime: 0.26082
   },
   gor: {
     name: 'Ethereum Goerli',
     chainId: 5,
     apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-goerli/version/latest',
-    avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4'
+    avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
+    blockTime: 15.52512
   },
   sep: {
     name: 'Ethereum Sepolia',
     chainId: 11155111,
     apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-sepolia/version/latest',
-    avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4'
+    avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
+    blockTime: 13.2816
   },
   'linea-testnet': {
     name: 'Linea testnet',
     chainId: 59140,
     apiUrl: 'https://thegraph.goerli.zkevm.consensys.net/subgraphs/name/snapshot-labs/sx-subgraph',
-    avatar: 'ipfs://bafkreibn4mjs54bnmvkrkiaiwp47gvcz6bervg2kr5ubknytfyz6l5wbs4'
+    avatar: 'ipfs://bafkreibn4mjs54bnmvkrkiaiwp47gvcz6bervg2kr5ubknytfyz6l5wbs4',
+    blockTime: 13.52926
   }
 };
 

--- a/src/stores/meta.ts
+++ b/src/stores/meta.ts
@@ -4,8 +4,8 @@ import { getProvider } from '@/helpers/provider';
 import { enabledNetworks, getNetwork } from '@/networks';
 
 export const useMetaStore = defineStore('meta', () => {
-  const loaded = ref(false);
-  const currentTs = ~~(Date.now() / 1e3);
+  const loaded = ref<boolean>(false);
+  const currentTs = ref<number>(Date.now() / 1e3);
   const currentBlocks = ref(new Map<NetworkID, number>());
 
   async function fetchBlocks() {
@@ -21,6 +21,8 @@ export const useMetaStore = defineStore('meta', () => {
     });
 
     await Promise.all(promises);
+
+    currentTs.value = Date.now() / 1e3;
     loaded.value = true;
   }
 

--- a/src/stores/meta.ts
+++ b/src/stores/meta.ts
@@ -5,6 +5,7 @@ import { enabledNetworks, getNetwork } from '@/networks';
 
 export const useMetaStore = defineStore('meta', () => {
   const loaded = ref(false);
+  const currentTs = ~~(Date.now() / 1e3);
   const currentBlocks = ref(new Map<NetworkID, number>());
 
   async function fetchBlocks() {
@@ -25,6 +26,7 @@ export const useMetaStore = defineStore('meta', () => {
 
   return {
     loaded,
+    currentTs,
     currentBlocks,
     fetchBlocks
   };


### PR DESCRIPTION
This PR fixes the time in timeline, it convert block number to timestamp using current block.

**Before**
<img width="476" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/16245250/977c2d37-9505-426b-b8db-0abfab0b5301">

**After**
<img width="476" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/16245250/13583332-9431-445f-b2c2-fb16b97bd119">
