### PR TITLE
feat: load current block at space level

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
-import { useMetaStore } from '@/stores/meta';
-
 const route = useRoute();
 const uiStore = useUiStore();
-const metaStore = useMetaStore();
 const { modalOpen } = useModal();
 const { userSkin } = useUserSkin();
 const { init, app } = useApp();
@@ -17,7 +13,6 @@ const skin = computed(() => userSkin.value);
 const scrollDisabled = computed(() => modalOpen.value || uiStore.sidebarOpen);
 
 onMounted(async () => {
-  metaStore.fetchBlocks();
   uiStore.restorePendingTransactions();
   await init();
 });
@@ -42,7 +37,7 @@ watch(route, () => {
     :class="{ [skin]: true, 'overflow-hidden': scrollDisabled }"
     class="font-serif text-base min-h-screen bg-skin-bg text-skin-text antialiased"
   >
-    <UiLoading v-if="app.loading || !app.init || !metaStore.loaded" class="overlay big" />
+    <UiLoading v-if="app.loading || !app.init" class="overlay big" />
     <div v-else class="pb-6 flex">
       <Sidebar class="lg:visible" :class="{ invisible: !uiStore.sidebarOpen }" />
       <Topnav @toggle="uiStore.toggleSidebar" />
@@ -68,15 +63,3 @@ watch(route, () => {
     <div id="modal" />
   </div>
 </template>
-
-<style>
-.backdrop {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 99;
-  background: rgba(0, 0, 0, 0.4);
-}
-</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,3 +63,15 @@ watch(route, () => {
     <div id="modal" />
   </div>
 </template>
+
+<style>
+.backdrop {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 99;
+  background: rgba(0, 0, 0, 0.4);
+}
+</style>

--- a/src/components/Block/ContactPicker.vue
+++ b/src/components/Block/ContactPicker.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { shorten, shortenAddress } from '@/helpers/utils';
-import { useContactsStore } from '@/stores/contacts';
 
 const props = defineProps<{
   searchValue: string;

--- a/src/components/Block/ExecutionEditable.vue
+++ b/src/components/Block/ExecutionEditable.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable';
 import { getNetwork } from '@/networks';
-import { useUiStore } from '@/stores/ui';
 import { simulate } from '@/helpers/tenderly';
 import { Transaction as TransactionType, Space, SelectedStrategy } from '@/types';
 

--- a/src/components/Modal/EditContact.vue
+++ b/src/components/Modal/EditContact.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { clone } from '@/helpers/utils';
-import { useContactsStore } from '@/stores/contacts';
 import { validateForm } from '@/helpers/validation';
 
 const DEFAULT_FORM_STATE = {

--- a/src/components/Modal/PendingTransactions.vue
+++ b/src/components/Modal/PendingTransactions.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
 import { getNetwork } from '@/networks';
 
 defineProps<{

--- a/src/components/Modal/Timeline.vue
+++ b/src/components/Modal/Timeline.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { _t } from '@/helpers/utils';
 import { Proposal } from '@/types';
-import { useMetaStore } from '@/stores/meta';
 import { METADATA } from '@/networks/evm';
 
 const props = defineProps<{
@@ -27,7 +26,7 @@ function getTsFromBlock(network, blockNum) {
   const networkBlockNum = metaStore.currentBlocks.get(network) || 0;
   const blockDiff = networkBlockNum - blockNum;
 
-  return metaStore.currentTs.valueOf() - METADATA[network].blockTime * blockDiff;
+  return (metaStore.currentTs.get(network) || 0) - METADATA[network].blockTime * blockDiff;
 }
 
 const states = computed(() => {

--- a/src/components/Modal/Timeline.vue
+++ b/src/components/Modal/Timeline.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { _t } from '@/helpers/utils';
 import { Proposal } from '@/types';
-import { METADATA } from '@/networks/evm';
 
 const props = defineProps<{
   open: boolean;
@@ -20,14 +19,7 @@ const labels = {
   max_end: 'Max. end'
 };
 
-const metaStore = useMetaStore();
-
-function getTsFromBlock(network, blockNum) {
-  const networkBlockNum = metaStore.currentBlocks.get(network) || 0;
-  const blockDiff = networkBlockNum - blockNum;
-
-  return (metaStore.currentTs.get(network) || 0) - METADATA[network].blockTime * blockDiff;
-}
+const { getTsFromBlock } = useMetaStore();
 
 const states = computed(() => {
   const network = props.proposal.network;

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -1,7 +1,4 @@
 <script lang="ts" setup>
-import { useUiStore } from '@/stores/ui';
-import { useSpacesStore } from '@/stores/spaces';
-
 // TODO: need to import all icons https://github.com/antfu/unplugin-icons/issues/5
 // move to this when stable to avoid imports https://www.npmjs.com/package/@iconify/tailwind
 import IHGlobeAlt from '~icons/heroicons-outline/globe-alt';

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { useUiStore } from '@/stores/ui';
-
 const uiStore = useUiStore();
 </script>
 

--- a/src/components/PendingTransactionsIndicator.vue
+++ b/src/components/PendingTransactionsIndicator.vue
@@ -5,8 +5,6 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
-
 const uiStore = useUiStore();
 const pendingTransactionsModalOpen = ref(false);
 </script>

--- a/src/components/S/IStamp.vue
+++ b/src/components/S/IStamp.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
 import { getUrl, imageUpload } from '@/helpers/utils';
 
 const props = defineProps<{

--- a/src/components/S/IStampCover.vue
+++ b/src/components/S/IStampCover.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
 import { getUrl, imageUpload } from '@/helpers/utils';
 
 const props = defineProps<{

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
-import { useSpacesStore } from '@/stores/spaces';
 import draggable from 'vuedraggable';
 
 const uiStore = useUiStore();

--- a/src/components/SpaceItem.vue
+++ b/src/components/SpaceItem.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { useSpacesStore } from '@/stores/spaces';
 import { _n } from '@/helpers/utils';
 import { Space } from '@/types';
 

--- a/src/components/Topnav.vue
+++ b/src/components/Topnav.vue
@@ -2,7 +2,6 @@
 import { useFocus } from '@vueuse/core';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { shorten } from '@/helpers/utils';
-import { useUiStore } from '@/stores/ui';
 
 const emit = defineEmits(['toggle']);
 

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { _t } from '@/helpers/utils';
-import { useUiStore } from '@/stores/ui';
 import { getNetwork } from '@/networks';
 import { Proposal as ProposalType } from '@/types';
 

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -7,6 +7,9 @@ const props = defineProps<{ proposal: ProposalType }>();
 
 const uiStore = useUiStore();
 const { votes } = useAccount();
+const { getTsFromBlock } = useMetaStore();
+
+const start = getTsFromBlock(props.proposal.network, props.proposal.start);
 
 const isSupported = computed(() => {
   const network = getNetwork(props.proposal.network);
@@ -35,7 +38,7 @@ const isSupported = computed(() => {
     You have already voted for this proposal
   </slot>
   <slot v-else-if="!proposal.has_started" name="waiting">
-    Voting for this proposal hasn't started yet. Voting will start {{ _t(proposal.start) }}.
+    Voting for this proposal hasn't started yet. Voting will start {{ _t(start) }}.
   </slot>
 
   <slot v-else-if="proposal.has_ended || proposal.executed" name="ended">

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -1,6 +1,5 @@
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { getNetwork, evmNetworks } from '@/networks';
-import { useUiStore } from '@/stores/ui';
 
 import { convertToMetaTransactions } from '@/helpers/transactions';
 import type {

--- a/src/composables/useMarkdownEditor.ts
+++ b/src/composables/useMarkdownEditor.ts
@@ -1,4 +1,3 @@
-import { useUiStore } from '@/stores/ui';
 import { imageUpload } from '@/helpers/utils';
 
 type Formatting = {

--- a/src/stores/meta.ts
+++ b/src/stores/meta.ts
@@ -1,35 +1,29 @@
 import { defineStore } from 'pinia';
 import { NetworkID } from '@/types';
 import { getProvider } from '@/helpers/provider';
-import { enabledNetworks, getNetwork } from '@/networks';
+import { getNetwork } from '@/networks';
 
 export const useMetaStore = defineStore('meta', () => {
-  const loaded = ref<boolean>(false);
-  const currentTs = ref<number>(Date.now() / 1e3);
+  const currentTs = ref(new Map<NetworkID, number>());
   const currentBlocks = ref(new Map<NetworkID, number>());
 
-  async function fetchBlocks() {
-    const promises = enabledNetworks.map(async network => {
-      const provider = getProvider(getNetwork(network).baseChainId);
+  async function fetchBlock(network) {
+    if (currentBlocks.value.get(network)) return;
 
-      try {
-        const blockNumber = await provider.getBlockNumber();
-        currentBlocks.value.set(network, blockNumber);
-      } catch (e) {
-        console.error(e);
-      }
-    });
+    const provider = getProvider(getNetwork(network).baseChainId);
 
-    await Promise.all(promises);
-
-    currentTs.value = Date.now() / 1e3;
-    loaded.value = true;
+    try {
+      const blockNumber = await provider.getBlockNumber();
+      currentBlocks.value.set(network, blockNumber);
+      currentTs.value.set(network, Date.now() / 1e3);
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   return {
-    loaded,
     currentTs,
     currentBlocks,
-    fetchBlocks
+    fetchBlock
   };
 });

--- a/src/stores/meta.ts
+++ b/src/stores/meta.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { NetworkID } from '@/types';
 import { getProvider } from '@/helpers/provider';
 import { getNetwork } from '@/networks';
+import { METADATA } from '@/networks/evm';
 
 export const useMetaStore = defineStore('meta', () => {
   const currentTs = ref(new Map<NetworkID, number>());
@@ -21,9 +22,17 @@ export const useMetaStore = defineStore('meta', () => {
     }
   }
 
+  function getTsFromBlock(network, blockNum) {
+    const networkBlockNum = currentBlocks.value.get(network) || 0;
+    const blockDiff = networkBlockNum - blockNum;
+
+    return (currentTs.value.get(network) || 0) - METADATA[network].blockTime * blockDiff;
+  }
+
   return {
     currentTs,
     currentBlocks,
-    fetchBlock
+    fetchBlock,
+    getTsFromBlock
   };
 });

--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia';
 import { getNetwork } from '@/networks';
-import { useMetaStore } from '@/stores/meta';
 import type { NetworkID, Proposal } from '@/types';
 
 type SpaceRecord = {

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useSpacesStore } from '@/stores/spaces';
 import { getNetwork } from '@/networks';
 import { getProvider } from '@/helpers/provider';
 import { omit, shortenAddress } from '@/helpers/utils';

--- a/src/views/Explore.vue
+++ b/src/views/Explore.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useSpacesStore } from '@/stores/spaces';
-
 const { setTitle } = useTitle();
 const spacesStore = useSpacesStore();
 

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useProposalsStore } from '@/stores/proposals';
 import { getNetwork } from '@/networks';
 import {
   _rt,
@@ -21,6 +20,7 @@ const { param } = useRouteParser('space');
 const { resolved, address: spaceAddress, networkId } = useResolve(param);
 const { setTitle } = useTitle();
 const proposalsStore = useProposalsStore();
+const metaStore = useMetaStore();
 const { web3 } = useWeb3();
 const { vote, cancelProposal } = useActions();
 const { createDraft } = useEditor();
@@ -166,9 +166,10 @@ async function handleVoteClick(choice: Choice) {
 watch([() => web3.value.account, proposal], () => getVotingPower());
 watch(
   [networkId, spaceAddress, id],
-  ([networkId, spaceAddress, id]) => {
+  async ([networkId, spaceAddress, id]) => {
     if (!networkId || !spaceAddress) return;
 
+    await metaStore.fetchBlock(networkId);
     proposalsStore.fetchProposal(spaceAddress, id, networkId);
   },
   { immediate: true }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
-
 const uiStore = useUiStore();
 const { web3Account } = useWeb3();
 </script>

--- a/src/views/Settings/Contacts.vue
+++ b/src/views/Settings/Contacts.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useContactsStore } from '@/stores/contacts';
 import { shorten, shortenAddress } from '@/helpers/utils';
 
 useTitle('Contacts');

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useUiStore } from '@/stores/ui';
-import { useSpacesStore } from '@/stores/spaces';
 import { getCacheHash, getStampUrl } from '@/helpers/utils';
 
 const { setFavicon } = useFavicon();
@@ -8,6 +6,7 @@ const { param } = useRouteParser('id');
 const { resolved, address, networkId } = useResolve(param);
 const uiStore = useUiStore();
 const spacesStore = useSpacesStore();
+const metaStore = useMetaStore();
 
 const space = computed(() => {
   if (!resolved.value) return null;
@@ -17,9 +16,10 @@ const space = computed(() => {
 
 watch(
   [resolved, networkId, address],
-  ([resolved, networkId, address]) => {
+  async ([resolved, networkId, address]) => {
     if (!resolved || !networkId || !address) return;
 
+    await metaStore.fetchBlock(networkId);
     spacesStore.fetchSpace(address, networkId);
   },
   {

--- a/src/views/Space/Overview.vue
+++ b/src/views/Space/Overview.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useSpacesStore } from '@/stores/spaces';
-import { useProposalsStore } from '@/stores/proposals';
 import { _n, compareAddresses, sanitizeUrl } from '@/helpers/utils';
 import { Space, Proposal as ProposalType } from '@/types';
 

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useProposalsStore } from '@/stores/proposals';
 import { getNetwork } from '@/networks';
 import { getProvider } from '@/helpers/provider';
 import { Space } from '@/types';

--- a/src/views/Space/SearchProposals.vue
+++ b/src/views/Space/SearchProposals.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getNetwork } from '@/networks';
-import { useMetaStore } from '@/stores/meta';
 import { Space, Proposal as ProposalType } from '@/types';
 
 const PROPOSALS_LIMIT = 20;

--- a/src/views/User.vue
+++ b/src/views/User.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useUsersStore } from '@/stores/users';
 import { shortenAddress, _n } from '@/helpers/utils';
 
 const { setTitle } = useTitle();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     vue({ reactivityTransform: true }),
     AutoImport({
       imports: ['vue', 'vue-router'],
-      dirs: ['./src/composables'],
+      dirs: ['./src/composables', './src/stores'],
       eslintrc: {
         enabled: true
       }


### PR DESCRIPTION
Closes #729 

This PR remove the global loading to get all networks current blocks and instead load current block for a single network when a space or a proposal is loaded. Also this add auto-import for the stores.