### PR TITLE
feat: replace currentBlock with generic current

### DIFF
--- a/src/components/Modal/Timeline.vue
+++ b/src/components/Modal/Timeline.vue
@@ -19,7 +19,7 @@ const labels = {
   max_end: 'Max. end'
 };
 
-const { getTsFromBlock } = useMetaStore();
+const { getTsFromCurrent } = useMetaStore();
 
 const states = computed(() => {
   const network = props.proposal.network;
@@ -33,12 +33,12 @@ const states = computed(() => {
       {
         id: 'start',
         block_number: props.proposal.start,
-        value: getTsFromBlock(network, props.proposal.start)
+        value: getTsFromCurrent(network, props.proposal.start)
       },
       {
         id: 'end',
         block_number: props.proposal.min_end,
-        value: getTsFromBlock(network, props.proposal.min_end)
+        value: getTsFromCurrent(network, props.proposal.min_end)
       }
     ];
   }
@@ -51,17 +51,17 @@ const states = computed(() => {
     {
       id: 'start',
       block_number: props.proposal.start,
-      value: getTsFromBlock(network, props.proposal.start)
+      value: getTsFromCurrent(network, props.proposal.start)
     },
     {
       id: 'min_end',
       block_number: props.proposal.min_end,
-      value: getTsFromBlock(network, props.proposal.min_end)
+      value: getTsFromCurrent(network, props.proposal.min_end)
     },
     {
       id: 'max_end',
       block_number: props.proposal.max_end,
-      value: getTsFromBlock(network, props.proposal.max_end)
+      value: getTsFromCurrent(network, props.proposal.max_end)
     }
   ];
 });

--- a/src/components/Vote.vue
+++ b/src/components/Vote.vue
@@ -7,9 +7,9 @@ const props = defineProps<{ proposal: ProposalType }>();
 
 const uiStore = useUiStore();
 const { votes } = useAccount();
-const { getTsFromBlock } = useMetaStore();
+const { getTsFromCurrent } = useMetaStore();
 
-const start = getTsFromBlock(props.proposal.network, props.proposal.start);
+const start = getTsFromCurrent(props.proposal.network, props.proposal.start);
 
 const isSupported = computed(() => {
   const network = getNetwork(props.proposal.network);

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -133,12 +133,12 @@ export type NetworkApi = {
   loadProposals(
     spaceId: string,
     paginationOpts: PaginationOpts,
-    currentBlock: number,
+    current: number,
     filter?: 'any' | 'active' | 'pending' | 'closed',
     searchQuery?: string
   ): Promise<Proposal[]>;
-  loadProposalsSummary(spaceId: string, currentBlock: number, limit: number): Promise<Proposal[]>;
-  loadProposal(spaceId: string, proposalId: number, currentBlock: number): Promise<Proposal | null>;
+  loadProposalsSummary(spaceId: string, current: number, limit: number): Promise<Proposal[]>;
+  loadProposal(spaceId: string, proposalId: number, current: number): Promise<Proposal | null>;
   loadSpaces(paginationOpts: PaginationOpts, filter?: SpacesFilter): Promise<Space[]>;
   loadSpace(spaceId: string): Promise<Space | null>;
   loadUser(userId: string): Promise<User>;

--- a/src/stores/meta.ts
+++ b/src/stores/meta.ts
@@ -1,38 +1,44 @@
 import { defineStore } from 'pinia';
 import { NetworkID } from '@/types';
 import { getProvider } from '@/helpers/provider';
-import { getNetwork } from '@/networks';
+import { evmNetworks, getNetwork } from '@/networks';
 import { METADATA } from '@/networks/evm';
 
 export const useMetaStore = defineStore('meta', () => {
   const currentTs = ref(new Map<NetworkID, number>());
   const currentBlocks = ref(new Map<NetworkID, number>());
 
-  async function fetchBlock(network) {
-    if (currentBlocks.value.get(network)) return;
+  function getCurrent(networkId: NetworkID): number | undefined {
+    if (evmNetworks.includes(networkId)) return currentBlocks.value.get(networkId);
+    return currentTs.value.get(networkId);
+  }
 
-    const provider = getProvider(getNetwork(network).baseChainId);
+  async function fetchBlock(networkId: NetworkID) {
+    if (currentBlocks.value.get(networkId)) return;
+
+    const provider = getProvider(getNetwork(networkId).baseChainId);
 
     try {
       const blockNumber = await provider.getBlockNumber();
-      currentBlocks.value.set(network, blockNumber);
-      currentTs.value.set(network, Date.now() / 1e3);
+      currentBlocks.value.set(networkId, blockNumber);
+      currentTs.value.set(networkId, Math.floor(Date.now() / 1e3));
     } catch (e) {
       console.error(e);
     }
   }
 
-  function getTsFromBlock(network, blockNum) {
-    const networkBlockNum = currentBlocks.value.get(network) || 0;
-    const blockDiff = networkBlockNum - blockNum;
+  function getTsFromCurrent(networkId: NetworkID, current: number) {
+    if (!evmNetworks.includes(networkId)) return current;
 
-    return (currentTs.value.get(network) || 0) - METADATA[network].blockTime * blockDiff;
+    const networkBlockNum = currentBlocks.value.get(networkId) || 0;
+    const blockDiff = networkBlockNum - current;
+
+    return (currentTs.value.get(networkId) || 0) - METADATA[networkId].blockTime * blockDiff;
   }
 
   return {
-    currentTs,
-    currentBlocks,
+    getCurrent,
     fetchBlock,
-    getTsFromBlock
+    getTsFromCurrent
   };
 });

--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -73,7 +73,7 @@ export const useProposalsStore = defineStore('proposals', () => {
       {
         limit: PROPOSALS_LIMIT
       },
-      metaStore.currentBlocks.get(networkId) || 0,
+      metaStore.getCurrent(networkId) || 0,
       filter
     );
 
@@ -115,7 +115,7 @@ export const useProposalsStore = defineStore('proposals', () => {
         limit: PROPOSALS_LIMIT,
         skip: record.value.proposalsIdsList.length
       },
-      metaStore.currentBlocks.get(networkId) || 0
+      metaStore.getCurrent(networkId) || 0
     );
 
     record.value.proposalsIdsList = [
@@ -156,7 +156,7 @@ export const useProposalsStore = defineStore('proposals', () => {
     record.value.summaryLoading = true;
     record.value.summaryProposals = await getNetwork(networkId).api.loadProposalsSummary(
       spaceId,
-      metaStore.currentBlocks.get(networkId) || 0,
+      metaStore.getCurrent(networkId) || 0,
       limit
     );
     record.value.summaryLoaded = true;
@@ -185,7 +185,7 @@ export const useProposalsStore = defineStore('proposals', () => {
     const proposal = await getNetwork(networkId).api.loadProposal(
       spaceId,
       proposalId,
-      metaStore.currentBlocks.get(networkId) || 0
+      metaStore.getCurrent(networkId) || 0
     );
     if (!proposal) return;
 

--- a/src/views/Space/SearchProposals.vue
+++ b/src/views/Space/SearchProposals.vue
@@ -26,7 +26,7 @@ async function fetch() {
     {
       limit: PROPOSALS_LIMIT
     },
-    metaStore.currentBlocks.get(props.space.network) || 0,
+    metaStore.getCurrent(props.space.network) || 0,
     'any',
     query.value
   );
@@ -44,7 +44,7 @@ async function fetchMore() {
       limit: PROPOSALS_LIMIT,
       skip: proposals.value.length
     },
-    metaStore.currentBlocks.get(props.space.network) || 0,
+    metaStore.getCurrent(props.space.network) || 0,
     'any',
     query.value
   );


### PR DESCRIPTION
`current` now represents generic current point that can be either block (EVM) or timestamp (starknet) or something else in the future.

By making it generic we can support both types at the same time.