### PR TITLE
feat: hide results if voting hasn't started yet

### DIFF
--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -361,7 +361,7 @@ watchEffect(() => {
             </UiTooltip>
           </div>
         </Vote>
-        <template v-if="!proposal.cancelled">
+        <template v-if="!proposal.cancelled && proposal.has_started">
           <h4 class="block eyebrow mb-2 mt-4">Results</h4>
           <Results with-details :proposal="proposal" :decimals="votingPowerDecimals" />
         </template>


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/720

## Test plan

- Create proposal with voting delay. (http://localhost:8080/#/sep:0xea4322cc9be9ae0c9400984209c858031b1c4438/proposal/3)
- Before voting starts no results are shown.

## Screenshots

<img width="565" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/e49e923f-35e4-46cd-8efc-a379c9614d10">
