### PR TITLE
feat: use IDuration input for sx-evm with block estimations

### DIFF
--- a/src/components/Block/SpaceFormVoting.vue
+++ b/src/components/Block/SpaceFormVoting.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { validateForm } from '@/helpers/validation';
-import { getCurrentName } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
 import type { NetworkID } from '@/types';
 
 const props = defineProps<{
@@ -14,9 +12,6 @@ const emit = defineEmits<{
 }>();
 
 const definition = computed(() => {
-  const network = getNetwork(props.selectedNetworkId);
-  const useDuration = network.currentUnit === 'second';
-
   return {
     type: 'object',
     title: 'SpaceSettings',
@@ -25,24 +20,18 @@ const definition = computed(() => {
     properties: {
       votingDelay: {
         type: 'number',
-        format: useDuration ? 'duration' : undefined,
-        title: useDuration
-          ? 'Voting delay'
-          : `Voting delay in ${getCurrentName(network.currentUnit)}`
+        format: 'duration',
+        title: 'Voting delay'
       },
       minVotingDuration: {
         type: 'number',
-        format: useDuration ? 'duration' : undefined,
-        title: useDuration
-          ? 'Min. voting duration'
-          : `Min. voting duration in ${getCurrentName(network.currentUnit)}`
+        format: 'duration',
+        title: 'Min. voting duration'
       },
       maxVotingDuration: {
         type: 'number',
-        format: useDuration ? 'duration' : undefined,
-        title: useDuration
-          ? 'Max. voting duration'
-          : `Max. voting duration in ${getCurrentName(network.currentUnit)}`
+        format: 'duration',
+        title: 'Max. voting duration'
       }
     }
   };

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -16,6 +16,7 @@ import type { Connector, StrategyConfig } from '@/networks/types';
 export function useActions() {
   const uiStore = useUiStore();
   const { web3 } = useWeb3();
+  const { getCurrentFromDuration } = useMetaStore();
   const { modalAccountOpen } = useModal();
   const auth = getInstance();
 
@@ -146,9 +147,9 @@ export function useActions() {
 
     const receipt = await network.actions.createSpace(auth.web3, salt, {
       controller,
-      votingDelay: settings.votingDelay,
-      minVotingDuration: settings.minVotingDuration,
-      maxVotingDuration: settings.maxVotingDuration,
+      votingDelay: getCurrentFromDuration(networkId, settings.votingDelay),
+      minVotingDuration: getCurrentFromDuration(networkId, settings.minVotingDuration),
+      maxVotingDuration: getCurrentFromDuration(networkId, settings.maxVotingDuration),
       authenticators,
       validationStrategy,
       votingStrategies,
@@ -374,7 +375,11 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.setVotingDelay(auth.web3, space, votingDelay);
+    const receipt = await network.actions.setVotingDelay(
+      auth.web3,
+      space,
+      getCurrentFromDuration(space.network, votingDelay)
+    );
     console.log('Receipt', receipt);
 
     if (handleSafeEnvelope(receipt)) return;
@@ -390,7 +395,11 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.setMinVotingDuration(auth.web3, space, minVotingDuration);
+    const receipt = await network.actions.setMinVotingDuration(
+      auth.web3,
+      space,
+      getCurrentFromDuration(space.network, minVotingDuration)
+    );
     console.log('Receipt', receipt);
 
     if (handleSafeEnvelope(receipt)) return;
@@ -406,7 +415,11 @@ export function useActions() {
       throw new Error(`${web3.value.type} is not supported for this actions`);
     }
 
-    const receipt = await network.actions.setMaxVotingDuration(auth.web3, space, maxVotingDuration);
+    const receipt = await network.actions.setMaxVotingDuration(
+      auth.web3,
+      space,
+      getCurrentFromDuration(space.network, maxVotingDuration)
+    );
     console.log('Receipt', receipt);
 
     if (handleSafeEnvelope(receipt)) return;

--- a/src/stores/meta.ts
+++ b/src/stores/meta.ts
@@ -27,6 +27,22 @@ export const useMetaStore = defineStore('meta', () => {
     }
   }
 
+  function getCurrentFromDuration(networkId: NetworkID, duration: number) {
+    const network = getNetwork(networkId);
+
+    if (network.currentUnit === 'second') return duration;
+
+    return Math.round(duration / METADATA[networkId].blockTime);
+  }
+
+  function getDurationFromCurrent(networkId: NetworkID, current: number) {
+    const network = getNetwork(networkId);
+
+    if (network.currentUnit === 'second') return current;
+
+    return Math.round(current * METADATA[networkId].blockTime);
+  }
+
   function getTsFromCurrent(networkId: NetworkID, current: number) {
     if (!evmNetworks.includes(networkId)) return current;
 
@@ -39,6 +55,8 @@ export const useMetaStore = defineStore('meta', () => {
   return {
     getCurrent,
     fetchBlock,
+    getCurrentFromDuration,
+    getDurationFromCurrent,
     getTsFromCurrent
   };
 });


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/750

This PR adds IDuration input for sx-evm voting delay and voting periods with blocks being estimated from duration.

## Test plan
- Deploy new EVM space.
- Go to deployed space settings, values are formatted as durations there.
- Try editing one of the settings, everything works as expected.