### PR TITLE
feat: add whitelist support with simplified UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
-    "@snapshot-labs/sx": "^0.1.0-beta.39",
+    "@snapshot-labs/sx": "^0.1.0-beta.40",
     "@vueuse/core": "^10.4.1",
     "@walletconnect/client": "^1.8.0",
     "ajv": "^8.12.0",

--- a/src/components/Block/CreationConfirmation.vue
+++ b/src/components/Block/CreationConfirmation.vue
@@ -116,6 +116,7 @@ async function deploy() {
     currentStep.value = currentStep.value + 1;
   } catch {
     failed.value = true;
+    return;
   }
 
   try {

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -47,10 +47,11 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     executors: space.metadata.executors,
     executors_types: space.metadata.executors_types,
     strategies_parsed_metadata: space.strategies_parsed_metadata.map(
-      ({ data: { decimals, symbol, token } }) => ({
+      ({ data: { decimals, symbol, token, payload } }) => ({
         decimals,
         symbol,
-        token
+        token,
+        payload
       })
     )
   };
@@ -68,10 +69,11 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID, current: nu
       executors: proposal.space.metadata.executors,
       executors_types: proposal.space.metadata.executors_types,
       strategies_parsed_metadata: proposal.space.strategies_parsed_metadata.map(
-        ({ data: { decimals, symbol, token } }) => ({
+        ({ data: { decimals, symbol, token, payload } }) => ({
           decimals,
           symbol,
-          token
+          token,
+          payload
         })
       )
     },

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -46,6 +46,15 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     delegation_contract: space.metadata.delegation_contract,
     executors: space.metadata.executors,
     executors_types: space.metadata.executors_types,
+    voting_power_validation_strategies_parsed_metadata:
+      space.voting_power_validation_strategies_parsed_metadata.map(
+        ({ data: { decimals, symbol, token, payload } }) => ({
+          decimals,
+          symbol,
+          token,
+          payload
+        })
+      ),
     strategies_parsed_metadata: space.strategies_parsed_metadata.map(
       ({ data: { decimals, symbol, token, payload } }) => ({
         decimals,
@@ -68,6 +77,15 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID, current: nu
       voting_power_symbol: proposal.space.metadata.voting_power_symbol,
       executors: proposal.space.metadata.executors,
       executors_types: proposal.space.metadata.executors_types,
+      voting_power_validation_strategies_parsed_metadata:
+        proposal.space.voting_power_validation_strategies_parsed_metadata.map(
+          ({ data: { decimals, symbol, token, payload } }) => ({
+            decimals,
+            symbol,
+            token,
+            payload
+          })
+        ),
       strategies_parsed_metadata: proposal.space.strategies_parsed_metadata.map(
         ({ data: { decimals, symbol, token, payload } }) => ({
           decimals,

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -38,6 +38,14 @@ const SPACE_FRAGMENT = gql`
         payload
       }
     }
+    voting_power_validation_strategies_parsed_metadata {
+      data {
+        decimals
+        symbol
+        token
+        payload
+      }
+    }
     authenticators
     proposal_count
     vote_count
@@ -61,6 +69,14 @@ const PROPOSAL_FRAGMENT = gql`
         executors_types
       }
       strategies_parsed_metadata {
+        data {
+          decimals
+          symbol
+          token
+          payload
+        }
+      }
+      voting_power_validation_strategies_parsed_metadata {
         data {
           decimals
           symbol

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -35,6 +35,7 @@ const SPACE_FRAGMENT = gql`
         decimals
         symbol
         token
+        payload
       }
     }
     authenticators
@@ -64,6 +65,7 @@ const PROPOSAL_FRAGMENT = gql`
           decimals
           symbol
           token
+          payload
         }
       }
     }

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -34,6 +34,7 @@ export type ApiSpace = {
   validation_strategy: string;
   voting_power_validation_strategy_strategies: string[];
   voting_power_validation_strategy_strategies_params: string[];
+  voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
   strategies: string[];
   strategies_params: any[];
   strategies_parsed_metadata: StrategyParsedMetadata[];
@@ -63,6 +64,7 @@ export type ApiProposal = {
       executors_types: string[];
     };
     authenticators: string[];
+    voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
     strategies_parsed_metadata: StrategyParsedMetadata[];
   };
   author: {

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -3,6 +3,7 @@ type StrategyParsedMetadata = {
     decimals: number;
     symbol: string;
     token: string | null;
+    payload: string | null;
   };
 };
 

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -125,7 +125,7 @@ export function createActions(
         params.votingStrategies.map(async config => {
           if (!config.generateMetadata) return '';
 
-          const metadata = config.generateMetadata(config.params);
+          const metadata = await config.generateMetadata(config.params);
           const pinned = await helpers.pin(metadata);
 
           return `ipfs://${pinned.cid}`;

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -150,6 +150,53 @@ export const EDITOR_VOTING_STRATEGIES = [
     }
   },
   {
+    address: '0x3cee21a33751a2722413ff62dec3dec48e7748a4',
+    name: 'Whitelist',
+    generateSummary: (params: Record<string, any>) => {
+      const length = params.whitelist.split('\n').length;
+
+      return `(${length} ${length === 1 ? 'address' : 'addresses'})`;
+    },
+    generateParams: (params: Record<string, any>) => {
+      const whitelist = params.whitelist.split('\n').map((item: string) => {
+        const [addr, vp] = item.split(':');
+        return { addr, vp: BigInt(vp) };
+      });
+
+      const abiCoder = new AbiCoder();
+      return [abiCoder.encode(['tuple(address addr, uint256 vp)[]'], [whitelist])];
+    },
+    generateMetadata: (params: Record<string, any>) => {
+      return {
+        name: 'Whitelist',
+        properties: {
+          symbol: params.symbol,
+          decimals: 0
+        }
+      };
+    },
+    paramsDefinition: {
+      type: 'object',
+      title: 'Params',
+      additionalProperties: false,
+      required: [],
+      properties: {
+        symbol: {
+          type: 'string',
+          maxLength: 6,
+          title: 'Symbol',
+          examples: ['e.g. VP']
+        },
+        whitelist: {
+          type: 'string',
+          format: 'long',
+          title: 'Whitelist',
+          examples: ['0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70:40']
+        }
+      }
+    }
+  },
+  {
     address: '0x2c8631584474e750cedf2fb6a904f2e84777aefe',
     name: 'ERC-20 Votes (EIP-5805)',
     about:

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -150,54 +150,6 @@ export const EDITOR_VOTING_STRATEGIES = [
     }
   },
   {
-    address: '0x3cee21a33751a2722413ff62dec3dec48e7748a4',
-    name: 'Whitelist',
-    about: 'A strategy that defines a list of addresses each with designated voting power.',
-    generateSummary: (params: Record<string, any>) => {
-      const length = params.whitelist.split('\n').length;
-
-      return `(${length} ${length === 1 ? 'address' : 'addresses'})`;
-    },
-    generateParams: (params: Record<string, any>) => {
-      const whitelist = params.whitelist.split('\n').map((item: string) => {
-        const [addr, vp] = item.split(':');
-        return { addr, vp: BigInt(vp) };
-      });
-
-      const abiCoder = new AbiCoder();
-      return [abiCoder.encode(['tuple(address addr, uint256 vp)[]'], [whitelist])];
-    },
-    generateMetadata: (params: Record<string, any>) => {
-      return {
-        name: 'Whitelist',
-        properties: {
-          symbol: params.symbol,
-          decimals: 0
-        }
-      };
-    },
-    paramsDefinition: {
-      type: 'object',
-      title: 'Params',
-      additionalProperties: false,
-      required: [],
-      properties: {
-        symbol: {
-          type: 'string',
-          maxLength: 6,
-          title: 'Symbol',
-          examples: ['e.g. VP']
-        },
-        whitelist: {
-          type: 'string',
-          format: 'long',
-          title: 'Whitelist',
-          examples: ['0x556B14CbdA79A36dC33FcD461a04A5BCb5dC2A70:40']
-        }
-      }
-    }
-  },
-  {
     address: '0x2c8631584474e750cedf2fb6a904f2e84777aefe',
     name: 'ERC-20 Votes (EIP-5805)',
     about:

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -152,6 +152,7 @@ export const EDITOR_VOTING_STRATEGIES = [
   {
     address: '0x3cee21a33751a2722413ff62dec3dec48e7748a4',
     name: 'Whitelist',
+    about: 'A strategy that defines a list of addresses each with designated voting power.',
     generateSummary: (params: Record<string, any>) => {
       const length = params.whitelist.split('\n').length;
 

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -171,7 +171,14 @@ export function createActions(
       const data = {
         space: space.id,
         authenticator,
-        strategies,
+        strategies: strategies.map((strategy, i) => {
+          const strategyMetadataPayload = space.strategies_parsed_metadata[i].payload;
+
+          return {
+            ...strategy,
+            metadata: strategyMetadataPayload ? JSON.parse(strategyMetadataPayload) : null
+          };
+        }),
         executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${cid}`
       };
@@ -286,7 +293,14 @@ export function createActions(
       const data = {
         space: proposal.space.id,
         authenticator,
-        strategies,
+        strategies: strategies.map((strategy, i) => {
+          const strategyMetadataPayload = proposal.space.strategies_parsed_metadata[i].payload;
+
+          return {
+            ...strategy,
+            metadata: strategyMetadataPayload ? JSON.parse(strategyMetadataPayload) : null
+          };
+        }),
         proposal: proposal.proposal_id,
         choice
       };
@@ -357,10 +371,12 @@ export function createActions(
           const strategy = getStarknetStrategy(address, defaultNetwork);
           if (!strategy) return { address, value: 0n, decimals: 0, token: null, symbol: '' };
 
+          const strategyMetadataPayload = strategiesMetadata[i].payload;
+
           const value = await strategy.getVotingPower(
             address,
             voterAddress,
-            null,
+            strategyMetadataPayload ? JSON.parse(strategyMetadataPayload) : null,
             timestamp,
             strategiesParams[i].split(','),
             {

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -1,6 +1,6 @@
 import { defaultNetwork, clients, getStarknetStrategy } from '@snapshot-labs/sx';
 import { MANA_URL } from '@/helpers/mana';
-import { createErc1155Metadata, verifyNetwork } from '@/helpers/utils';
+import { createErc1155Metadata, getUrl, verifyNetwork } from '@/helpers/utils';
 import { getExecutionData, createStrategyPicker } from '@/networks/common/helpers';
 import { EVM_CONNECTORS, STARKNET_CONNECTORS } from '@/networks/common/constants';
 import {
@@ -52,6 +52,17 @@ export function createActions(
     return code !== '0x';
   };
 
+  const parseStrategyMetadata = async (metadata: string | null) => {
+    if (metadata === null) return null;
+    if (!metadata.startsWith('ipfs://')) return JSON.parse(metadata);
+
+    const strategyUrl = getUrl(metadata);
+    if (!strategyUrl) return null;
+
+    const res = await fetch(strategyUrl);
+    return res.json();
+  };
+
   const client = new clients.StarkNetTx(clientConfig);
   const starkSigClient = new clients.StarkNetSig(clientConfig);
   const ethSigClient = new clients.EthereumSig(clientConfig);
@@ -86,16 +97,20 @@ export function createActions(
         })
       );
 
+      const buildMetadata = async (config: StrategyConfig) => {
+        if (!config.generateMetadata) return '';
+
+        const metadata = await config.generateMetadata(config.params);
+        const pinned = await helpers.pin(metadata);
+
+        return `ipfs://${pinned.cid}`;
+      };
+
       const metadataUris = await Promise.all(
-        params.votingStrategies.map(async config => {
-          if (!config.generateMetadata) return '';
-
-          const metadata = config.generateMetadata(config.params);
-          const pinned = await helpers.pin(metadata);
-
-          return `ipfs://${pinned.cid}`;
-        })
+        params.votingStrategies.map(config => buildMetadata(config))
       );
+
+      const proposalValidationStrategyMetadataUri = await buildMetadata(params.validationStrategy);
 
       return client.deploySpace({
         account: web3.provider.account,
@@ -107,6 +122,7 @@ export function createActions(
               ? params.validationStrategy.generateParams(params.validationStrategy.params)
               : []
           },
+          proposalValidationStrategyMetadataUri,
           metadataUri: `ipfs://${pinned.cid}`,
           daoUri: '',
           authenticators: params.authenticators.map(config => config.address),
@@ -168,17 +184,23 @@ export function createActions(
         };
       }
 
-      const data = {
-        space: space.id,
-        authenticator,
-        strategies: strategies.map((strategy, i) => {
-          const strategyMetadataPayload = space.strategies_parsed_metadata[i].payload;
+      const strategiesWithMetadata = await Promise.all(
+        strategies.map(async strategy => {
+          const metadata = await parseStrategyMetadata(
+            space.strategies_parsed_metadata[strategy.index].payload
+          );
 
           return {
             ...strategy,
-            metadata: strategyMetadataPayload ? JSON.parse(strategyMetadataPayload) : null
+            metadata
           };
-        }),
+        })
+      );
+
+      const data = {
+        space: space.id,
+        authenticator,
+        strategies: strategiesWithMetadata,
         executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${cid}`
       };
@@ -290,17 +312,23 @@ export function createActions(
         await verifyNetwork(web3, l1ChainId);
       }
 
-      const data = {
-        space: proposal.space.id,
-        authenticator,
-        strategies: strategies.map((strategy, i) => {
-          const strategyMetadataPayload = proposal.space.strategies_parsed_metadata[i].payload;
+      const strategiesWithMetadata = await Promise.all(
+        strategies.map(async strategy => {
+          const metadata = await parseStrategyMetadata(
+            proposal.space.strategies_parsed_metadata[strategy.index].payload
+          );
 
           return {
             ...strategy,
-            metadata: strategyMetadataPayload ? JSON.parse(strategyMetadataPayload) : null
+            metadata
           };
-        }),
+        })
+      );
+
+      const data = {
+        space: proposal.space.id,
+        authenticator,
+        strategies: strategiesWithMetadata,
         proposal: proposal.proposal_id,
         choice
       };
@@ -371,12 +399,12 @@ export function createActions(
           const strategy = getStarknetStrategy(address, defaultNetwork);
           if (!strategy) return { address, value: 0n, decimals: 0, token: null, symbol: '' };
 
-          const strategyMetadataPayload = strategiesMetadata[i].payload;
+          const strategyMetadata = await parseStrategyMetadata(strategiesMetadata[i].payload);
 
           const value = await strategy.getVotingPower(
             address,
             voterAddress,
-            strategyMetadataPayload ? JSON.parse(strategyMetadataPayload) : null,
+            strategyMetadata,
             timestamp,
             strategiesParams[i].split(','),
             {

--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -178,6 +178,8 @@ export const EDITOR_VOTING_STRATEGIES = [
   {
     address: '0x297fb0104d8be6c86f168bf1dcdc28b0625d2b06108c3c46194aa4415f2e2ec',
     name: 'Whitelist',
+    about:
+      'A strategy that defines a list of addresses each with designated voting power, using a Merkle tree for verification.',
     generateSummary: (params: Record<string, any>) => {
       const length = params.whitelist.split('\n').length;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type StrategyParsedMetadata = {
   decimals: number;
   symbol: string;
   token: string | null;
+  payload: string | null;
 };
 
 export type Space = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export type Space = {
   validation_strategy: string;
   voting_power_validation_strategy_strategies: string[];
   voting_power_validation_strategy_strategies_params: string[];
+  voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
   strategies: string[];
   strategies_params: any[];
   strategies_parsed_metadata: StrategyParsedMetadata[];
@@ -88,6 +89,7 @@ export type Proposal = {
     authenticators: string[];
     executors: string[];
     executors_types: string[];
+    voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
     strategies_parsed_metadata: StrategyParsedMetadata[];
   };
   author: {

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -171,7 +171,7 @@ async function getVotingPower() {
     const votingPowers = await network.actions.getVotingPower(
       space.value.voting_power_validation_strategy_strategies,
       space.value.voting_power_validation_strategy_strategies_params,
-      [],
+      space.value.voting_power_validation_strategies_parsed_metadata,
       web3.value.account,
       supportsNullCurrent(space.value.network) ? null : getCurrent(space.value.network) || 0
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,10 +1514,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/sx@^0.1.0-beta.39":
-  version "0.1.0-beta.39"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.39.tgz#04495cadae063030b985b3aa4426ff0be8ff6e76"
-  integrity sha512-4NamhFX/zU3V6kJNLd2YmlM3guWjMYuByTwF5CQTMKXpS9c4/th8KE0AJQw8Ewmq970kYh9/7aMS/UVPYEE4DQ==
+"@snapshot-labs/sx@^0.1.0-beta.40":
+  version "0.1.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.40.tgz#3a9befebeb22369157db170a2f1f2f98e895d60b"
+  integrity sha512-27nEyJTuEeLafOZf2UFOOHcIunIbXRWiCYecUHqsyQmLIDKe1StnNGQSkI4puwZ+yvnC0PXJ0Js/AmvWkfLWeg==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/622

This PR adds support for whitelist strategies with simplified UI (textarea where you put addresses in specified format), no custom UI as of now.

## Test plan

- Add Starknet/EVM whitelist strategy to space.
- Try propose/vote.