### PR TITLE
feat: add strategies editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "js-sha3": "^0.9.2",
     "lodash.set": "^4.3.2",
     "mixpanel-browser": "^2.47.0",
+    "object-hash": "^3.0.0",
     "pinia": "^2.1.6",
     "remarkable": "^2.0.1",
     "scrollmonitor": "^1.2.11",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@ethersproject/units": "^5.7.0",
     "@floating-ui/vue": "^1.0.2",
     "@headlessui/vue": "^1.7.16",
+    "@openzeppelin/merkle-tree": "^1.0.5",
     "@snapshot-labs/eslint-config-vue": "^0.1.0-beta.13",
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -60,10 +60,6 @@ const navigationConfig = computed(() => ({
           settings: {
             name: 'Settings',
             icon: IHCog
-          },
-          'edit-settings': {
-            name: 'Edit settings',
-            icon: IHCog
           }
         }
       : undefined)

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -60,6 +60,10 @@ const navigationConfig = computed(() => ({
           settings: {
             name: 'Settings',
             icon: IHCog
+          },
+          'edit-settings': {
+            name: 'Edit settings',
+            icon: IHCog
           }
         }
       : undefined)

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -458,6 +458,37 @@ export function useActions() {
     uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
   }
 
+  async function updateStrategies(
+    space: Space,
+    authenticatorsToAdd: StrategyConfig[],
+    authenticatorsToRemove: number[],
+    votingStrategiesToAdd: StrategyConfig[],
+    votingStrategiesToRemove: number[],
+    validationStrategy: StrategyConfig
+  ) {
+    if (!web3.value.account) return await forceLogin();
+
+    const network = getReadWriteNetwork(space.network);
+    if (!network.managerConnectors.includes(web3.value.type as Connector)) {
+      throw new Error(`${web3.value.type} is not supported for this actions`);
+    }
+
+    const receipt = await network.actions.updateStrategies(
+      auth.web3,
+      space,
+      authenticatorsToAdd,
+      authenticatorsToRemove,
+      votingStrategiesToAdd,
+      votingStrategiesToRemove,
+      validationStrategy
+    );
+    console.log('Receipt', receipt);
+
+    if (handleSafeEnvelope(receipt)) return;
+
+    uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
+  }
+
   async function delegate(space: Space, networkId: NetworkID, delegatee: string) {
     if (!web3.value.account) return await forceLogin();
 
@@ -493,6 +524,7 @@ export function useActions() {
     setMinVotingDuration: wrapWithErrors(setMinVotingDuration),
     setMaxVotingDuration: wrapWithErrors(setMaxVotingDuration),
     transferOwnership: wrapWithErrors(transferOwnership),
+    updateStrategies: wrapWithErrors(updateStrategies),
     delegate: wrapWithErrors(delegate)
   };
 }

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -58,6 +58,8 @@ function processStrategiesMetadata(
   parsedMetadata: ApiStrategyParsedMetadata[],
   strategiesIndicies?: number[]
 ) {
+  if (parsedMetadata.length === 0) return [];
+
   const maxIndex = Math.max(...parsedMetadata.map(metadata => metadata.index));
 
   const metadataMap = Object.fromEntries(

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -24,7 +24,7 @@ import { PaginationOpts, SpacesFilter, NetworkApi } from '@/networks/types';
 import { getNames } from '@/helpers/stamp';
 import { CHOICES } from '@/helpers/constants';
 import { Space, Proposal, Vote, User, Transaction, NetworkID, ProposalState } from '@/types';
-import { ApiSpace, ApiProposal } from './types';
+import { ApiSpace, ApiProposal, ApiStrategyParsedMetadata } from './types';
 
 type ApiOptions = {
   highlightApiUrl?: string;
@@ -54,6 +54,22 @@ function formatExecution(execution: string): Transaction[] {
   }
 }
 
+function processStrategiesMetadata(
+  parsedMetadata: ApiStrategyParsedMetadata[],
+  strategiesIndicies?: number[]
+) {
+  return parsedMetadata
+    .filter((_, i) => (strategiesIndicies ? strategiesIndicies.includes(i) : true))
+    .map(({ data: { name, description, decimals, symbol, token, payload } }) => ({
+      name,
+      description,
+      decimals,
+      symbol,
+      token,
+      payload
+    }));
+}
+
 function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
   return {
     ...space,
@@ -73,22 +89,12 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     delegation_contract: space.metadata.delegation_contract,
     executors: space.metadata.executors,
     executors_types: space.metadata.executors_types,
-    voting_power_validation_strategies_parsed_metadata:
-      space.voting_power_validation_strategies_parsed_metadata.map(
-        ({ data: { decimals, symbol, token, payload } }) => ({
-          decimals,
-          symbol,
-          token,
-          payload
-        })
-      ),
-    strategies_parsed_metadata: space.strategies_parsed_metadata.map(
-      ({ data: { decimals, symbol, token, payload } }) => ({
-        decimals,
-        symbol,
-        token,
-        payload
-      })
+    voting_power_validation_strategies_parsed_metadata: processStrategiesMetadata(
+      space.voting_power_validation_strategies_parsed_metadata
+    ),
+    strategies_parsed_metadata: processStrategiesMetadata(
+      space.strategies_parsed_metadata,
+      space.strategies_indicies
     )
   };
 }
@@ -105,22 +111,9 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID, current: nu
       voting_power_symbol: proposal.space.metadata.voting_power_symbol,
       executors: proposal.space.metadata.executors,
       executors_types: proposal.space.metadata.executors_types,
-      voting_power_validation_strategies_parsed_metadata:
-        proposal.space.voting_power_validation_strategies_parsed_metadata.map(
-          ({ data: { decimals, symbol, token, payload } }) => ({
-            decimals,
-            symbol,
-            token,
-            payload
-          })
-        ),
-      strategies_parsed_metadata: proposal.space.strategies_parsed_metadata.map(
-        ({ data: { decimals, symbol, token, payload } }) => ({
-          decimals,
-          symbol,
-          token,
-          payload
-        })
+      strategies_parsed_metadata: processStrategiesMetadata(
+        proposal.space.strategies_parsed_metadata,
+        proposal.strategies_indicies
       )
     },
     metadata_uri: proposal.metadata.id,

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -58,16 +58,24 @@ function processStrategiesMetadata(
   parsedMetadata: ApiStrategyParsedMetadata[],
   strategiesIndicies?: number[]
 ) {
-  return parsedMetadata
-    .filter((_, i) => (strategiesIndicies ? strategiesIndicies.includes(i) : true))
-    .map(({ data: { name, description, decimals, symbol, token, payload } }) => ({
-      name,
-      description,
-      decimals,
-      symbol,
-      token,
-      payload
-    }));
+  const maxIndex = Math.max(...parsedMetadata.map(metadata => metadata.index));
+
+  const metadataMap = Object.fromEntries(
+    parsedMetadata.map(metadata => [
+      metadata.index,
+      {
+        name: metadata.data.name,
+        description: metadata.data.description,
+        decimals: metadata.data.decimals,
+        symbol: metadata.data.symbol,
+        token: metadata.data.token,
+        payload: metadata.data.payload
+      }
+    ])
+  );
+
+  strategiesIndicies = strategiesIndicies || Array.from(Array(maxIndex + 1).keys());
+  return strategiesIndicies.map(index => metadataMap[index]) || [];
 }
 
 function formatSpace(space: ApiSpace, networkId: NetworkID): Space {

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -31,23 +31,21 @@ const SPACE_FRAGMENT = gql`
     voting_power_validation_strategy_strategies_params
     voting_power_validation_strategies_parsed_metadata {
       data {
-        decimals
-        symbol
-        token
-      }
-    }
-    strategies
-    strategies_params
-    strategies_parsed_metadata {
-      data {
+        name
+        description
         decimals
         symbol
         token
         payload
       }
     }
-    voting_power_validation_strategies_parsed_metadata {
+    strategies_indicies
+    strategies
+    strategies_params
+    strategies_parsed_metadata {
       data {
+        name
+        description
         decimals
         symbol
         token
@@ -79,14 +77,8 @@ const PROPOSAL_FRAGMENT = gql`
       }
       strategies_parsed_metadata {
         data {
-          decimals
-          symbol
-          token
-          payload
-        }
-      }
-      voting_power_validation_strategies_parsed_metadata {
-        data {
+          name
+          description
           decimals
           symbol
           token
@@ -118,6 +110,7 @@ const PROPOSAL_FRAGMENT = gql`
     execution_strategy
     execution_strategy_type
     timelock_veto_guardian
+    strategies_indicies
     strategies
     strategies_params
     created

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -30,6 +30,7 @@ const SPACE_FRAGMENT = gql`
     voting_power_validation_strategy_strategies
     voting_power_validation_strategy_strategies_params
     voting_power_validation_strategies_parsed_metadata {
+      index
       data {
         name
         description
@@ -43,6 +44,7 @@ const SPACE_FRAGMENT = gql`
     strategies
     strategies_params
     strategies_parsed_metadata {
+      index
       data {
         name
         description
@@ -76,6 +78,7 @@ const PROPOSAL_FRAGMENT = gql`
         executors_types
       }
       strategies_parsed_metadata {
+        index
         data {
           name
           description

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -26,8 +26,16 @@ const SPACE_FRAGMENT = gql`
     max_voting_period
     proposal_threshold
     validation_strategy
+    validation_strategy_params
     voting_power_validation_strategy_strategies
     voting_power_validation_strategy_strategies_params
+    voting_power_validation_strategies_parsed_metadata {
+      data {
+        decimals
+        symbol
+        token
+      }
+    }
     strategies
     strategies_params
     strategies_parsed_metadata {

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -32,6 +32,7 @@ export type ApiSpace = {
   max_voting_period: number;
   proposal_threshold: string;
   validation_strategy: string;
+  validation_strategy_params: string;
   voting_power_validation_strategy_strategies: string[];
   voting_power_validation_strategy_strategies_params: string[];
   voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -1,5 +1,7 @@
-type StrategyParsedMetadata = {
+export type ApiStrategyParsedMetadata = {
   data: {
+    name: string;
+    description: string;
     decimals: number;
     symbol: string;
     token: string | null;
@@ -35,10 +37,11 @@ export type ApiSpace = {
   validation_strategy_params: string;
   voting_power_validation_strategy_strategies: string[];
   voting_power_validation_strategy_strategies_params: string[];
-  voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
+  voting_power_validation_strategies_parsed_metadata: ApiStrategyParsedMetadata[];
+  strategies_indicies: number[];
   strategies: string[];
   strategies_params: any[];
-  strategies_parsed_metadata: StrategyParsedMetadata[];
+  strategies_parsed_metadata: ApiStrategyParsedMetadata[];
   authenticators: string[];
   proposal_count: number;
   vote_count: number;
@@ -66,8 +69,7 @@ export type ApiProposal = {
       executors_types: string[];
     };
     authenticators: string[];
-    voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
-    strategies_parsed_metadata: StrategyParsedMetadata[];
+    strategies_parsed_metadata: ApiStrategyParsedMetadata[];
   };
   author: {
     id: string;
@@ -87,6 +89,7 @@ export type ApiProposal = {
   execution_strategy: string;
   execution_strategy_type: string;
   timelock_veto_guardian: string | null;
+  strategies_indicies: number[];
   strategies: string[];
   strategies_params: any[];
   created: number;

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -1,4 +1,5 @@
 export type ApiStrategyParsedMetadata = {
+  index: number;
   data: {
     name: string;
     description: string;

--- a/src/networks/common/helpers.ts
+++ b/src/networks/common/helpers.ts
@@ -44,12 +44,14 @@ export function createStrategyPicker({
   return function pick({
     authenticators,
     strategies,
-    isContract = false,
+    strategiesIndicies,
+    isContract,
     connectorType
   }: {
     authenticators: string[];
     strategies: string[];
-    isContract?: boolean;
+    strategiesIndicies: number[];
+    isContract: boolean;
     connectorType: Connector;
   }) {
     const authenticatorsInfo = [...authenticators]
@@ -106,7 +108,7 @@ export function createStrategyPicker({
     );
 
     const selectedStrategies = strategies
-      .map((strategy, index) => ({ address: strategy, index }) as const)
+      .map((strategy, index) => ({ address: strategy, index: strategiesIndicies[index] }) as const)
       .filter(({ address }) => supportedStrategies[address]);
 
     if (!authenticatorInfo || (strategies.length !== 0 && selectedStrategies.length === 0)) {

--- a/src/networks/common/helpers.ts
+++ b/src/networks/common/helpers.ts
@@ -1,8 +1,9 @@
 import { getExecutionData as _getExecutionData } from '@snapshot-labs/sx';
 import { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
-import { Connector } from '@/networks/types';
-import { Space } from '@/types';
 import { EVM_CONNECTORS, STARKNET_CONNECTORS } from './constants';
+import { getUrl } from '@/helpers/utils';
+import { Connector, NetworkHelpers, StrategyConfig } from '@/networks/types';
+import { Space } from '@/types';
 
 type SpaceExecutionData = Pick<Space, 'executors' | 'executors_types'>;
 type ExecutorType = Parameters<typeof _getExecutionData>[0];
@@ -24,6 +25,26 @@ export function getExecutionData(
   return _getExecutionData(executorType, executionStrategy, {
     transactions
   });
+}
+
+export async function parseStrategyMetadata(metadata: string | null) {
+  if (metadata === null) return null;
+  if (!metadata.startsWith('ipfs://')) return JSON.parse(metadata);
+
+  const strategyUrl = getUrl(metadata);
+  if (!strategyUrl) return null;
+
+  const res = await fetch(strategyUrl);
+  return res.json();
+}
+
+export async function buildMetadata(helpers: NetworkHelpers, config: StrategyConfig) {
+  if (!config.generateMetadata) return '';
+
+  const metadata = await config.generateMetadata(config.params);
+  const pinned = await helpers.pin(metadata);
+
+  return `ipfs://${pinned.cid}`;
 }
 
 export function createStrategyPicker({

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -519,6 +519,8 @@ export function createActions(
       votingStrategiesToRemove: number[],
       validationStrategy: StrategyConfig
     ) => {
+      await verifyNetwork(web3, chainId);
+
       const metadataUris = await Promise.all(
         votingStrategiesToAdd.map(config => buildMetadata(helpers, config))
       );

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -212,10 +212,23 @@ export function createActions(
         };
       }
 
+      const strategiesWithMetadata = await Promise.all(
+        strategies.map(async strategy => {
+          const metadata = await parseStrategyMetadata(
+            space.voting_power_validation_strategies_parsed_metadata[strategy.index].payload
+          );
+
+          return {
+            ...strategy,
+            metadata
+          };
+        })
+      );
+
       const data = {
         space: space.id,
         authenticator,
-        strategies,
+        strategies: strategiesWithMetadata,
         executionStrategy: selectedExecutionStrategy,
         metadataUri: `ipfs://${cid}`
       };
@@ -340,10 +353,25 @@ export function createActions(
       if (choice === 2) convertedChoice = 0;
       if (choice === 3) convertedChoice = 2;
 
+      const strategiesWithMetadata = await Promise.all(
+        strategies.map(async strategy => {
+          const metadataIndex = proposal.strategies_indicies.indexOf(strategy.index);
+
+          const metadata = await parseStrategyMetadata(
+            proposal.space.strategies_parsed_metadata[metadataIndex].payload
+          );
+
+          return {
+            ...strategy,
+            metadata
+          };
+        })
+      );
+
       const data = {
         space: proposal.space.id,
         authenticator,
-        strategies,
+        strategies: strategiesWithMetadata,
         proposal: proposal.proposal_id as number,
         choice: convertedChoice,
         metadataUri: ''

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -191,6 +191,7 @@ export function createActions(
       const { relayerType, authenticator, strategies } = pickAuthenticatorAndStrategies({
         authenticators: space.authenticators,
         strategies: space.voting_power_validation_strategy_strategies,
+        strategiesIndicies: space.voting_power_validation_strategy_strategies.map((_, i) => i),
         connectorType,
         isContract
       });
@@ -252,6 +253,7 @@ export function createActions(
       const { relayerType, authenticator } = pickAuthenticatorAndStrategies({
         authenticators: space.authenticators,
         strategies: space.voting_power_validation_strategy_strategies,
+        strategiesIndicies: space.voting_power_validation_strategy_strategies.map((_, i) => i),
         connectorType,
         isContract
       });
@@ -325,6 +327,7 @@ export function createActions(
       const { relayerType, authenticator, strategies } = pickAuthenticatorAndStrategies({
         authenticators: proposal.space.authenticators,
         strategies: proposal.strategies,
+        strategiesIndicies: proposal.strategies_indicies,
         connectorType,
         isContract
       });
@@ -475,6 +478,9 @@ export function createActions(
       );
 
       return votesContract.delegate(delegatee);
+    },
+    updateStrategies: () => {
+      throw new Error('Not implemented');
     },
     send: (envelope: any) => ethSigClient.send(envelope),
     getVotingPower: async (

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -128,7 +128,7 @@ export const EDITOR_VOTING_STRATEGIES = [
     about:
       'A strategy that gives one voting power to anyone. It should only be used for testing purposes and not in production.',
     icon: IHBeaker,
-    generateMetadata: (params: Record<string, any>) => ({
+    generateMetadata: async (params: Record<string, any>) => ({
       name: 'Vanilla',
       properties: {
         symbol: params.symbol,
@@ -159,7 +159,7 @@ export const EDITOR_VOTING_STRATEGIES = [
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
-    generateMetadata: (params: Record<string, any>) => ({
+    generateMetadata: async (params: Record<string, any>) => ({
       name: 'ERC-20 Votes (EIP-5805)',
       properties: {
         symbol: params.symbol,
@@ -202,7 +202,7 @@ export const EDITOR_VOTING_STRATEGIES = [
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
-    generateMetadata: (params: Record<string, any>) => ({
+    generateMetadata: async (params: Record<string, any>) => ({
       name: 'ERC-20 Votes Comp (EIP-5805)',
       properties: {
         symbol: params.symbol,

--- a/src/networks/offchain/api/index.ts
+++ b/src/networks/offchain/api/index.ts
@@ -56,9 +56,11 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     executors: [],
     executors_types: [],
     strategies: [],
+    strategies_indicies: [],
     strategies_params: [],
     strategies_parsed_metadata: [],
     validation_strategy: '',
+    validation_strategy_params: '',
     voting_power_validation_strategy_strategies: [],
     voting_power_validation_strategy_strategies_params: [],
     voting_power_validation_strategies_parsed_metadata: []
@@ -102,7 +104,6 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
       authenticators: [],
       executors: [],
       executors_types: [],
-      voting_power_validation_strategies_parsed_metadata: [],
       strategies_parsed_metadata: []
     },
     // NOTE: ignored
@@ -113,6 +114,7 @@ function formatProposal(proposal: ApiProposal, networkId: NetworkID): Proposal {
     execution_strategy_type: '',
     timelock_veto_guardian: null,
     strategies: [],
+    strategies_indicies: [],
     strategies_params: [],
     tx: '',
     execution_tx: null,

--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -325,7 +325,7 @@ export function createConstants(networkId: NetworkID) {
       }
     },
     {
-      address: '0x619040eb54857252396d0bf337dc7a7f98182fa015c11578201105038106cb7',
+      address: config.Strategies.ERC20Votes,
       name: 'ERC-20 Votes (EIP-5805)',
       about:
         'A strategy that allows delegated balances of OpenZeppelin style checkpoint tokens to be used as voting power.',

--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -247,6 +247,24 @@ export function createConstants(networkId: NetworkID) {
           }
         };
       },
+      parseParams: async (params: string, metadata: StrategyParsedMetadata | null) => {
+        if (!metadata) throw new Error('Missing metadata');
+
+        const getWhitelist = async (payload: string) => {
+          const metadataUrl = getUrl(payload);
+
+          if (!metadataUrl) return '';
+
+          const res = await fetch(metadataUrl);
+          const { tree } = await res.json();
+          return tree.map((item: any) => `${item.address}:${item.votingPower}`).join('\n');
+        };
+
+        return {
+          symbol: metadata.symbol,
+          whitelist: metadata.payload ? await getWhitelist(metadata.payload) : ''
+        };
+      },
       paramsDefinition: {
         type: 'object',
         title: 'Params',
@@ -277,7 +295,7 @@ export function createConstants(networkId: NetworkID) {
       generateSummary: (params: Record<string, any>) =>
         `(${shorten(params.contractAddress)}, ${params.decimals})`,
       generateParams: (params: Record<string, any>) => [params.contractAddress],
-      generateMetadata: (params: Record<string, any>) => ({
+      generateMetadata: async (params: Record<string, any>) => ({
         name: 'ERC-20 Votes (EIP-5805)',
         properties: {
           symbol: params.symbol,
@@ -333,7 +351,7 @@ export function createConstants(networkId: NetworkID) {
       generateSummary: (params: Record<string, any>) =>
         `(${shorten(params.contractAddress)}, ${params.decimals})`,
       generateParams: (params: Record<string, any>) => [params.contractAddress],
-      generateMetadata: (params: Record<string, any>) => ({
+      generateMetadata: async (params: Record<string, any>) => ({
         name: 'ERC-20 Votes (EIP-5805)',
         properties: {
           symbol: params.symbol,

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -31,6 +31,10 @@ export type StrategyTemplate = {
   generateSummary?: (params: Record<string, any>) => string;
   generateParams?: (params: Record<string, any>) => any[];
   generateMetadata?: (params: Record<string, any>) => any;
+  parseParams?: (
+    params: string,
+    metadata: StrategyParsedMetadata | null
+  ) => Promise<Record<string, any>>;
   deploy?: (
     client: any,
     signer: Signer,

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -19,6 +19,20 @@ export type SpacesFilter = {
   id_in?: string[];
 };
 export type Connector = 'argentx' | 'injected' | 'walletconnect' | 'walletlink' | 'gnosis';
+export type GeneratedMetadata =
+  | {
+      name: string;
+      description?: string;
+      properties: {
+        symbol?: string;
+        decimals: number;
+        token?: string;
+        payload?: string;
+      };
+    }
+  | {
+      strategies_metadata: string[];
+    };
 
 export type StrategyTemplate = {
   address: string;
@@ -30,7 +44,7 @@ export type StrategyTemplate = {
   validate?: (params: Record<string, any>) => boolean;
   generateSummary?: (params: Record<string, any>) => string;
   generateParams?: (params: Record<string, any>) => any[];
-  generateMetadata?: (params: Record<string, any>) => any;
+  generateMetadata?: (params: Record<string, any>) => Promise<GeneratedMetadata>;
   parseParams?: (
     params: string,
     metadata: StrategyParsedMetadata | null
@@ -131,6 +145,15 @@ export type NetworkActions = ReadOnlyNetworkActions & {
   setMinVotingDuration(web3: Web3Provider, space: Space, minVotingDuration: number);
   setMaxVotingDuration(web3: Web3Provider, space: Space, maxVotingDuration: number);
   transferOwnership(web3: Web3Provider, space: Space, owner: string);
+  updateStrategies(
+    web3: Web3Provider,
+    space: Space,
+    authenticatorsToAdd: StrategyConfig[],
+    authenticatorsToRemove: number[],
+    votingStrategiesToAdd: StrategyConfig[],
+    votingStrategiesToRemove: number[],
+    validationStrategy: StrategyConfig
+  );
   delegate(web3: Web3Provider, space: Space, networkId: NetworkID, delegatee: string);
   send(envelope: any): Promise<any>;
 };

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,6 +5,7 @@ import SpaceOverview from '@/views/Space/Overview.vue';
 import SpaceProposals from '@/views/Space/Proposals.vue';
 import SpaceSearch from '@/views/Space/Search.vue';
 import SpaceSettings from '@/views/Space/Settings.vue';
+import SpaceEditSettings from '@/views/Space/EditSettings.vue';
 import SpaceTreasury from '@/views/Space/Treasury.vue';
 import SpaceDelegates from '@/views/Space/Delegates.vue';
 import Editor from '@/views/Editor.vue';
@@ -31,6 +32,7 @@ const routes: any[] = [
       { path: 'proposals', name: 'space-proposals', component: SpaceProposals },
       { path: 'search', name: 'space-search', component: SpaceSearch },
       { path: 'settings', name: 'space-settings', component: SpaceSettings },
+      { path: 'edit-settings', name: 'space-edit-settings', component: SpaceEditSettings },
       { path: 'treasury', name: 'space-treasury', component: SpaceTreasury },
       { path: 'delegates', name: 'space-delegates', component: SpaceDelegates }
     ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export type Space = {
   max_voting_period: number;
   proposal_threshold: string;
   validation_strategy: string;
+  validation_strategy_params: string;
   voting_power_validation_strategy_strategies: string[];
   voting_power_validation_strategy_strategies_params: string[];
   voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,8 @@ export type SpaceSettings = {
 };
 
 export type StrategyParsedMetadata = {
+  name: string;
+  description: string;
   decimals: number;
   symbol: string;
   token: string | null;
@@ -78,6 +80,7 @@ export type Space = {
   voting_power_validation_strategy_strategies: string[];
   voting_power_validation_strategy_strategies_params: string[];
   voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
+  strategies_indicies: number[];
   strategies: string[];
   strategies_params: any[];
   strategies_parsed_metadata: StrategyParsedMetadata[];
@@ -104,7 +107,6 @@ export type Proposal = {
     authenticators: string[];
     executors: string[];
     executors_types: string[];
-    voting_power_validation_strategies_parsed_metadata: StrategyParsedMetadata[];
     strategies_parsed_metadata: StrategyParsedMetadata[];
   };
   author: {
@@ -127,6 +129,7 @@ export type Proposal = {
   execution_strategy: string;
   execution_strategy_type: string;
   timelock_veto_guardian: string | null;
+  strategies_indicies: number[];
   strategies: string[];
   strategies_params: any[];
   created: number;

--- a/src/views/Space/EditSettings.vue
+++ b/src/views/Space/EditSettings.vue
@@ -1,17 +1,44 @@
 <script setup lang="ts">
+import objectHash from 'object-hash';
 import { compareAddresses } from '@/helpers/utils';
 import { getNetwork } from '@/networks';
-import { StrategyConfig, StrategyTemplate } from '@/networks/types';
+import { StrategyConfig, StrategyTemplate, GeneratedMetadata } from '@/networks/types';
 import { Space, StrategyParsedMetadata } from '@/types';
 
 const props = defineProps<{ space: Space }>();
 
+const { updateStrategies } = useActions();
+
 const network = computed(() => getNetwork(props.space.network));
 
 const loading = ref(true);
+const saving = ref(false);
 const authenticators = ref([] as StrategyConfig[]);
 const validationStrategy = ref(null as StrategyConfig | null);
 const votingStrategies = ref([] as StrategyConfig[]);
+
+function processParams(paramsArray: string[]) {
+  return paramsArray.map(params => (params === '' ? [] : params.split(',')));
+}
+
+function processMetadata(metadataArray: StrategyParsedMetadata[]): GeneratedMetadata[] {
+  return metadataArray.map(metadata => {
+    const result: GeneratedMetadata = {
+      name: metadata.name,
+      properties: {
+        decimals: metadata.decimals,
+        symbol: metadata.symbol
+      }
+    };
+
+    if (metadata.name) result.name = metadata.name;
+    if (metadata.description) result.description = metadata.description;
+    if (metadata.payload !== null) result.properties.payload = metadata.payload;
+    if (metadata.token !== null) result.properties.token = metadata.token;
+
+    return result;
+  });
+}
 
 async function getInitialStrategiesConfig(
   configured: string[],
@@ -73,6 +100,119 @@ async function getInitialValidationStrategy(
   };
 }
 
+async function hasStrategyChanged(
+  strategy: StrategyConfig,
+  previousParams: any = [],
+  previousMetadata: any = {}
+) {
+  const params = strategy.generateParams ? strategy.generateParams(strategy.params) : [];
+  const metadata = strategy.generateMetadata
+    ? await strategy.generateMetadata(strategy.params)
+    : {};
+
+  return (
+    objectHash(params) !== objectHash(previousParams) ||
+    objectHash(metadata) !== objectHash(previousMetadata)
+  );
+}
+
+async function processChanges(
+  editorStrategies: StrategyConfig[],
+  currentAddresses: string[],
+  params: any[],
+  metadata: StrategyParsedMetadata[]
+): Promise<[StrategyConfig[], number[]]> {
+  const processedParams = processParams(params);
+  const processedMetadata = processMetadata(metadata);
+
+  const current = [...currentAddresses];
+  const currentStrategiesParams = [...processedParams];
+  const currentStrategiesMetadata = [...processedMetadata];
+  const toAdd = [] as StrategyConfig[];
+  for (const target of editorStrategies) {
+    let isInCurrent = false;
+
+    for (const [currentIndex, address] of current.entries()) {
+      const matchingStrategy =
+        compareAddresses(address, target.address) &&
+        !(await hasStrategyChanged(
+          target,
+          currentStrategiesParams[currentIndex],
+          currentStrategiesMetadata[currentIndex]
+        ));
+
+      if (matchingStrategy) {
+        isInCurrent = true;
+        current.splice(currentIndex, 1);
+        currentStrategiesParams.splice(currentIndex, 1);
+        currentStrategiesMetadata.splice(currentIndex, 1);
+        break;
+      }
+    }
+
+    if (!isInCurrent) toAdd.push(target);
+  }
+
+  const target = [...editorStrategies];
+  const toRemove = [] as number[];
+  for (const [currentIndex, address] of currentAddresses.entries()) {
+    let isInTarget = false;
+
+    for (const [targetIndex, strategy] of target.entries()) {
+      const matchingStrategy =
+        compareAddresses(address, strategy.address) &&
+        !(await hasStrategyChanged(
+          strategy,
+          processedParams[currentIndex],
+          processedMetadata[currentIndex]
+        ));
+
+      if (matchingStrategy) {
+        isInTarget = true;
+        target.splice(targetIndex, 1);
+        break;
+      }
+    }
+
+    if (!isInTarget) toRemove.push(currentIndex);
+  }
+
+  return [toAdd, toRemove];
+}
+
+async function save() {
+  if (!validationStrategy.value) return;
+
+  saving.value = true;
+
+  try {
+    const [authenticatorsToAdd, authenticatorsToRemove] = await processChanges(
+      authenticators.value,
+      props.space.authenticators,
+      [],
+      []
+    );
+
+    const [strategiesToAdd, strategiesToRemove] = await processChanges(
+      votingStrategies.value,
+      props.space.strategies,
+      props.space.strategies_params,
+      props.space.strategies_parsed_metadata
+    );
+
+    await updateStrategies(
+      props.space,
+      authenticatorsToAdd,
+      authenticatorsToRemove,
+      strategiesToAdd,
+      strategiesToRemove,
+      validationStrategy.value
+    );
+  } finally {
+    saving.value = false;
+  }
+}
+
 watchEffect(async () => {
   loading.value = true;
 
@@ -125,7 +265,7 @@ watchEffect(async () => {
         title="Voting strategies"
         description="Voting strategies are customizable contracts used to define how much voting power each user has when casting a vote."
       />
-      <UiButton class="w-full">Save</UiButton>
+      <UiButton :loading="saving" class="w-full" @click="save">Save</UiButton>
     </template>
   </div>
 </template>

--- a/src/views/Space/EditSettings.vue
+++ b/src/views/Space/EditSettings.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import objectHash from 'object-hash';
 import { compareAddresses } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
+import { evmNetworks, getNetwork } from '@/networks';
 import { StrategyConfig, StrategyTemplate, GeneratedMetadata } from '@/networks/types';
 import { Space, StrategyParsedMetadata } from '@/types';
 
@@ -102,10 +102,18 @@ async function getInitialValidationStrategy(
 
 async function hasStrategyChanged(
   strategy: StrategyConfig,
-  previousParams: any = [],
+  previousParams: any,
   previousMetadata: any = {}
 ) {
-  const params = strategy.generateParams ? strategy.generateParams(strategy.params) : [];
+  let params;
+  if (evmNetworks.includes(props.space.network)) {
+    params = strategy.generateParams ? strategy.generateParams(strategy.params) : ['0x'];
+    previousParams = previousParams ?? ['0x'];
+  } else {
+    params = strategy.generateParams ? strategy.generateParams(strategy.params) : [];
+    previousParams = previousParams ?? [];
+  }
+
   const metadata = strategy.generateMetadata
     ? await strategy.generateMetadata(strategy.params)
     : {};

--- a/src/views/Space/EditSettings.vue
+++ b/src/views/Space/EditSettings.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { compareAddresses } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
+import { StrategyConfig, StrategyTemplate } from '@/networks/types';
+import { Space, StrategyParsedMetadata } from '@/types';
+
+const props = defineProps<{ space: Space }>();
+
+const network = computed(() => getNetwork(props.space.network));
+
+const loading = ref(true);
+const authenticators = ref([] as StrategyConfig[]);
+const validationStrategy = ref(null as StrategyConfig | null);
+const votingStrategies = ref([] as StrategyConfig[]);
+
+async function getInitialStrategiesConfig(
+  configured: string[],
+  editorStrategies: StrategyTemplate[],
+  params?: string[],
+  metadata?: StrategyParsedMetadata[]
+) {
+  const promises = configured.map(async (configuredAddress, i) => {
+    const strategy = editorStrategies.find(({ address }) =>
+      compareAddresses(address, configuredAddress)
+    );
+
+    if (!strategy) return null;
+
+    const resolvedParams =
+      strategy.parseParams && params && metadata
+        ? await strategy.parseParams(params[i], metadata[i])
+        : {};
+
+    return {
+      id: crypto.randomUUID(),
+      params: resolvedParams,
+      ...strategy
+    };
+  });
+
+  return (await Promise.all(promises)).filter(strategy => strategy !== null) as StrategyConfig[];
+}
+
+async function getInitialValidationStrategy(
+  configuredAddress: string,
+  editorStrategies: StrategyTemplate[],
+  params: string,
+  nestedStrategies: string[],
+  nestedStrategiesParams: string[],
+  nestedStrategiesMetadata: StrategyParsedMetadata[]
+) {
+  const strategy = editorStrategies.find(({ address }) =>
+    compareAddresses(address, configuredAddress)
+  );
+
+  if (!strategy) return null;
+
+  const resolvedParams = strategy.parseParams ? await strategy.parseParams(params, null) : {};
+  const strategies = await getInitialStrategiesConfig(
+    nestedStrategies,
+    network.value.constants.EDITOR_VOTING_STRATEGIES,
+    nestedStrategiesParams,
+    nestedStrategiesMetadata
+  );
+
+  return {
+    id: crypto.randomUUID(),
+    params: {
+      ...resolvedParams,
+      strategies
+    },
+    ...strategy
+  };
+}
+
+watchEffect(async () => {
+  loading.value = true;
+
+  authenticators.value = await getInitialStrategiesConfig(
+    props.space.authenticators,
+    network.value.constants.EDITOR_AUTHENTICATORS
+  );
+
+  votingStrategies.value = await getInitialStrategiesConfig(
+    props.space.strategies,
+    network.value.constants.EDITOR_VOTING_STRATEGIES,
+    props.space.strategies_params,
+    props.space.strategies_parsed_metadata
+  );
+
+  validationStrategy.value = await getInitialValidationStrategy(
+    props.space.validation_strategy,
+    network.value.constants.EDITOR_PROPOSAL_VALIDATIONS,
+    props.space.validation_strategy_params,
+    props.space.voting_power_validation_strategy_strategies,
+    props.space.voting_power_validation_strategy_strategies_params,
+    props.space.voting_power_validation_strategies_parsed_metadata
+  );
+
+  loading.value = false;
+});
+</script>
+
+<template>
+  <div class="space-y-4 mx-4 pt-4">
+    <UiLoading v-if="loading" />
+    <template v-else>
+      <BlockSpaceFormStrategies
+        v-model="authenticators"
+        unique
+        :available-strategies="network.constants.EDITOR_AUTHENTICATORS"
+        title="Authenticators"
+        description="Authenticators are customizable contracts that verify user identity for proposing and voting using different methods."
+      />
+      <BlockSpaceFormValidation
+        v-model="validationStrategy"
+        :available-strategies="network.constants.EDITOR_PROPOSAL_VALIDATIONS"
+        :available-voting-strategies="network.constants.EDITOR_VOTING_STRATEGIES"
+        title="Proposal validation"
+        description="Proposal validation strategies are used to determine if a user is allowed to create a proposal."
+      />
+      <BlockSpaceFormStrategies
+        v-model="votingStrategies"
+        :available-strategies="network.constants.EDITOR_VOTING_STRATEGIES"
+        title="Voting strategies"
+        description="Voting strategies are customizable contracts used to define how much voting power each user has when casting a vote."
+      />
+      <UiButton class="w-full">Save</UiButton>
+    </template>
+  </div>
+</template>


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-ui/issues/659

This PR adds ability to edit authenticators/votingStrategies/proposalValidationStrategy on spaces (EVM and Starknet).

## Test plan
- Deploy new space (to make sure it has all metadata created properly, old spaces didn't have proposal validation strategies metadata).
- Try editing it.

## Screenshots

Temporary UI, but functional.

<img width="1028" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/6b866ba1-6d57-47d0-993f-e9fd842ec4fb">
