### PR TITLE
fix: Use auto-imports to resolve Icons outside of template

### DIFF
--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -1,16 +1,6 @@
 <script lang="ts" setup>
 import { compareAddresses } from '@/helpers/utils';
 
-// TODO: need to import all icons https://github.com/antfu/unplugin-icons/issues/5
-// move to this when stable to avoid imports https://www.npmjs.com/package/@iconify/tailwind
-import IHGlobeAlt from '~icons/heroicons-outline/globe-alt';
-import IHNewspaper from '~icons/heroicons-outline/newspaper';
-import IHCash from '~icons/heroicons-outline/cash';
-import IHLightningBolt from '~icons/heroicons-outline/lightning-bolt';
-import IHCog from '~icons/heroicons-outline/cog';
-import IHUsers from '~icons/heroicons-outline/users';
-import IHStop from '~icons/heroicons-outline/stop';
-
 const route = useRoute();
 const uiStore = useUiStore();
 const spacesStore = useSpacesStore();
@@ -35,17 +25,17 @@ const navigationConfig = computed(() => ({
   space: {
     overview: {
       name: 'Overview',
-      icon: IHGlobeAlt
+      icon: IconHeroiconsOutlineGlobeAlt
     },
     proposals: {
       name: 'Proposals',
-      icon: IHNewspaper
+      icon: IconHeroiconsOutlineNewspaper
     },
     ...(space.value?.delegation_api_url
       ? {
           delegates: {
             name: 'Delegates',
-            icon: IHLightningBolt
+            icon: IconHeroiconsOutlineLightningBolt
           }
         }
       : undefined),
@@ -53,7 +43,7 @@ const navigationConfig = computed(() => ({
       ? {
           treasury: {
             name: 'Treasury',
-            icon: IHCash
+            icon: IconHeroiconsOutlineCash
           }
         }
       : undefined),
@@ -61,7 +51,7 @@ const navigationConfig = computed(() => ({
       ? {
           settings: {
             name: 'Settings',
-            icon: IHCog
+            icon: IconHeroiconsOutlineCog
           }
         }
       : undefined)
@@ -69,11 +59,11 @@ const navigationConfig = computed(() => ({
   settings: {
     spaces: {
       name: 'My spaces',
-      icon: IHStop
+      icon: IconHeroiconsOutlineStop
     },
     contacts: {
       name: 'Contacts',
-      icon: IHUsers
+      icon: IconHeroiconsOutlineUsers
     }
   }
 }));

--- a/src/components/StrategyButton.vue
+++ b/src/components/StrategyButton.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import IHCode from '~icons/heroicons-outline/code';
 import { StrategyTemplate } from '@/networks/types';
 
 defineProps<{
@@ -18,9 +17,11 @@ defineProps<{
   >
     <div class="flex items-center justify-center min-h-[40px] bg-skin-border">
       <component
-        :is="strategy.icon ? strategy.icon : IHCode"
+        :is="strategy.icon"
+        v-if="strategy.icon"
         class="inline-block mx-3 text-skin-link"
       />
+      <IHCode v-else />
     </div>
     <div class="py-3 px-4">
       <h4 class="text-skin-link" v-text="strategy.name" />

--- a/src/networks/evm/constants.ts
+++ b/src/networks/evm/constants.ts
@@ -4,14 +4,6 @@ import { shorten } from '@/helpers/utils';
 import type { Signer } from '@ethersproject/abstract-signer';
 import type { StrategyConfig } from '../types';
 
-import IHCode from '~icons/heroicons-outline/code';
-import IHBeaker from '~icons/heroicons-outline/beaker';
-import IHCube from '~icons/heroicons-outline/cube';
-import IHPencil from '~icons/heroicons-outline/pencil';
-import IHClock from '~icons/heroicons-outline/clock';
-import IHUserCircle from '~icons/heroicons-outline/user-circle';
-import IHLightningBolt from '~icons/heroicons-outline/lightning-bolt';
-
 export const SUPPORTED_AUTHENTICATORS = {
   '0xba06e6ccb877c332181a6867c05c8b746a21aed1': true,
   '0x5f9b7d78c9a37a439d78f801e0e339c6e711e260': true
@@ -64,7 +56,7 @@ export const EDITOR_AUTHENTICATORS = [
     name: 'Ethereum transaction',
     about:
       'Will authenticate a user by checking if the caller address corresponds to the author or voter address.',
-    icon: IHCube,
+    icon: IconHeroiconsOutlineCube,
     paramsDefinition: null
   },
   {
@@ -72,7 +64,7 @@ export const EDITOR_AUTHENTICATORS = [
     name: 'Ethereum signature',
     about:
       'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',
-    icon: IHPencil,
+    icon: IconHeroiconsOutlinePencil,
     paramsDefinition: null
   }
 ];
@@ -82,7 +74,7 @@ export const EDITOR_PROPOSAL_VALIDATIONS = [
     address: '0x6d9d6d08ef6b26348bd18f1fc8d953696b7cf311',
     type: 'VotingPower',
     name: 'Voting power',
-    icon: IHLightningBolt,
+    icon: IconHeroiconsOutlineLightningBolt,
     validate: (params: Record<string, any>) => {
       return params?.strategies?.length > 0;
     },
@@ -126,7 +118,7 @@ export const EDITOR_VOTING_STRATEGIES = [
     name: 'Vanilla',
     about:
       'A strategy that gives one voting power to anyone. It should only be used for testing purposes and not in production.',
-    icon: IHBeaker,
+    icon: IconHeroiconsOutlineBeaker,
     generateMetadata: (params: Record<string, any>) => ({
       name: 'Vanilla',
       properties: {
@@ -154,7 +146,7 @@ export const EDITOR_VOTING_STRATEGIES = [
     name: 'ERC-20 Votes (EIP-5805)',
     about:
       'A strategy that allows delegated balances of OpenZeppelin style checkpoint tokens to be used as voting power.',
-    icon: IHCode,
+    icon: IconHeroiconsOutlineCode,
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
@@ -197,7 +189,7 @@ export const EDITOR_VOTING_STRATEGIES = [
     name: 'ERC-20 Votes Comp (EIP-5805)',
     about:
       'A strategy that allows delegated balances of Compound style checkpoint tokens to be used as voting power.',
-    icon: IHCode,
+    icon: IconHeroiconsOutlineCode,
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],
@@ -244,7 +236,7 @@ export const EDITOR_EXECUTION_STRATEGIES = [
     name: EXECUTORS.SimpleQuorumAvatar,
     about:
       'An execution strategy that allows proposals to execute transactions from a specified target Avatar contract, the most popular one being a Safe.',
-    icon: IHUserCircle,
+    icon: IconHeroiconsOutlineUserCircle,
     generateSummary: (params: Record<string, any>) =>
       `(${params.quorum}, ${shorten(params.contractAddress)})`,
     deploy: async (
@@ -290,7 +282,7 @@ export const EDITOR_EXECUTION_STRATEGIES = [
     name: EXECUTORS.SimpleQuorumTimelock,
     about:
       'Timelock implementation with a specified delay that queues proposal transactions for execution and includes an optional role to veto queued proposals.',
-    icon: IHClock,
+    icon: IconHeroiconsOutlineClock,
     generateSummary: (params: Record<string, any>) => `(${params.quorum}, ${params.timelockDelay})`,
     deploy: async (
       client: clients.EvmEthereumTx,

--- a/src/networks/starknet/constants.ts
+++ b/src/networks/starknet/constants.ts
@@ -4,11 +4,6 @@ import { shorten } from '@/helpers/utils';
 import { pinPineapple } from '@/helpers/pin';
 import { StrategyConfig } from '../types';
 
-import IHCode from '~icons/heroicons-outline/code';
-import IHCube from '~icons/heroicons-outline/cube';
-import IHPencil from '~icons/heroicons-outline/pencil';
-import IHLightningBolt from '~icons/heroicons-outline/lightning-bolt';
-
 export const API_URL = 'https://api-1.snapshotx.xyz';
 
 export const SUPPORTED_AUTHENTICATORS = {
@@ -64,14 +59,14 @@ export const EDITOR_AUTHENTICATORS = [
     name: 'Starknet transaction',
     about:
       'Will authenticate a user by checking if the caller address corresponds to the author or voter address.',
-    icon: IHCube,
+    icon: IconHeroiconsOutlineCube,
     paramsDefinition: null
   },
   {
     address: '0xb321c09ee9851c125bd4213de71ebd03c07813556bae5d4700968df42ee476',
     name: 'Starknet signature',
     about: 'Will authenticate a user based on an EIP-712 message signed by a Starknet private key.',
-    icon: IHPencil,
+    icon: IconHeroiconsOutlinePencil,
     paramsDefinition: null
   },
   {
@@ -79,7 +74,7 @@ export const EDITOR_AUTHENTICATORS = [
     name: 'Ethereum transaction',
     about:
       'Will authenticate a user by checking if the caller address of Ethereum transaction corresponds to the author or voter address.',
-    icon: IHCube,
+    icon: IconHeroiconsOutlineCube,
     paramsDefinition: null
   },
   {
@@ -87,7 +82,7 @@ export const EDITOR_AUTHENTICATORS = [
     name: 'Ethereum signature',
     about:
       'Will authenticate a user based on an EIP-712 message signed by an Ethereum private key.',
-    icon: IHPencil,
+    icon: IconHeroiconsOutlinePencil,
     paramsDefinition: null
   }
 ];
@@ -97,7 +92,7 @@ export const EDITOR_PROPOSAL_VALIDATIONS = [
     address: '0x38f034f17941669555fca61c43c67a517263aaaab833b26a1ab877a21c0bb6d',
     type: 'VotingPower',
     name: 'Voting power',
-    icon: IHLightningBolt,
+    icon: IconHeroiconsOutlineLightningBolt,
     validate: (params: Record<string, any>) => {
       return params?.strategies?.length > 0;
     },
@@ -247,7 +242,7 @@ export const EDITOR_VOTING_STRATEGIES = [
     name: 'ERC-20 Votes (EIP-5805)',
     about:
       'A strategy that allows delegated balances of OpenZeppelin style checkpoint tokens to be used as voting power.',
-    icon: IHCode,
+    icon: IconHeroiconsOutlineCode,
     generateSummary: (params: Record<string, any>) =>
       `(${shorten(params.contractAddress)}, ${params.decimals})`,
     generateParams: (params: Record<string, any>) => [params.contractAddress],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,13 @@ export default defineConfig({
       dirs: ['./src/composables', './src/stores'],
       eslintrc: {
         enabled: true
-      }
+      },
+      resolvers: [
+        IconsResolver({
+          componentPrefix: 'icon',
+          enabledCollections: ['heroicons-outline', 'heroicons-solid']
+        })
+      ]
     }),
     Components({
       directoryAsNamespace: true,


### PR DESCRIPTION
This isn't as elegant as I initially hoped, and we might want to consider this instead https://www.npmjs.com/package/@iconify/tailwind?activeTab=readme

Do you think it is stable enough for us to use it @Sekhmet?