### PR TITLE
fix: Notification width

### DIFF
--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -9,7 +9,7 @@ const uiStore = useUiStore();
       :key="notification.id"
       dismissable
       :type="notification.type"
-      class="w-fit max-w-[90%] mx-auto mb-2 last:mb-0"
+      class="!w-fit max-w-[90%] mx-auto mb-2 last:mb-0"
       @close="uiStore.dismissNotification(notification.id)"
     >
       {{ notification.message }}

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -7,7 +7,7 @@ const uiStore = useUiStore();
     <UiAlert
       v-for="notification in uiStore.notifications"
       :key="notification.id"
-      dismissable
+      dismissible
       :type="notification.type"
       class="!w-fit max-w-[90%] mx-auto mb-2 last:mb-0"
       @close="uiStore.dismissNotification(notification.id)"

--- a/src/components/Ui/Alert.vue
+++ b/src/components/Ui/Alert.vue
@@ -3,7 +3,7 @@ import { NotificationType } from '@/types';
 
 defineProps<{
   type: NotificationType;
-  dismissable?: boolean;
+  dismissible?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -25,7 +25,7 @@ const emit = defineEmits<{
   >
     <slot />
     <a
-      v-if="dismissable"
+      v-if="dismissible"
       class="text-skin-link opacity-50 hover:opacity-100"
       @click="emit('close')"
     >

--- a/src/components/Ui/Alert.vue
+++ b/src/components/Ui/Alert.vue
@@ -13,7 +13,7 @@ const emit = defineEmits<{
 
 <template>
   <div
-    class="flex gap-2 justify-between items-center w-full py-2 px-3 rounded border text-sm"
+    class="flex gap-3 justify-between items-center w-full py-2 px-3 rounded border text-sm"
     :class="{
       'bg-rose-100 border-rose-300 text-rose-500 dark:bg-rose-700 dark:border-rose-700 dark:text-neutral-100':
         type === 'error',


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Closes: #771


The issues was that somehow `w-fit` wasn't taking effect. Fixes it buy adding `!` and I also increased the gap to 16px. And fixed a typo

Preview:
<img width="1379" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/51686767/906b86f0-6289-4a34-87b0-f5e876e702de">




### How to test

1. Make action that triggers Notification 


<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
