### PR TITLE
fix: fetchBlock on loading proposals/spaces

### DIFF
--- a/src/stores/proposals.ts
+++ b/src/stores/proposals.ts
@@ -47,6 +47,8 @@ export const useProposalsStore = defineStore('proposals', () => {
     networkId: NetworkID,
     filter?: 'any' | 'active' | 'pending' | 'closed'
   ) {
+    await metaStore.fetchBlock(networkId);
+
     const uniqueSpaceId = getUniqueSpaceId(spaceId, networkId);
 
     if (!proposals.value[uniqueSpaceId]) {
@@ -88,6 +90,8 @@ export const useProposalsStore = defineStore('proposals', () => {
   }
 
   async function fetchMore(spaceId: string, networkId: NetworkID) {
+    await metaStore.fetchBlock(networkId);
+
     const uniqueSpaceId = getUniqueSpaceId(spaceId, networkId);
 
     if (!proposals.value[uniqueSpaceId]) {
@@ -132,6 +136,8 @@ export const useProposalsStore = defineStore('proposals', () => {
   }
 
   async function fetchSummary(spaceId: string, networkId: NetworkID, limit = 3) {
+    await metaStore.fetchBlock(networkId);
+
     const uniqueSpaceId = getUniqueSpaceId(spaceId, networkId);
 
     if (!proposals.value[uniqueSpaceId]) {
@@ -164,6 +170,8 @@ export const useProposalsStore = defineStore('proposals', () => {
   }
 
   async function fetchProposal(spaceId: string, proposalId: number, networkId: NetworkID) {
+    await metaStore.fetchBlock(networkId);
+
     const uniqueSpaceId = getUniqueSpaceId(spaceId, networkId);
 
     if (!proposals.value[uniqueSpaceId]) {

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -4,6 +4,7 @@ import { NetworkID, Space } from '@/types';
 import pkg from '../../package.json';
 
 export const useSpacesStore = defineStore('spaces', () => {
+  const metaStore = useMetaStore();
   const starredSpacesIds = useStorage(`${pkg.name}.spaces-starred`, [] as string[]);
   const starredSpacesData = ref([] as Space[]);
 
@@ -35,6 +36,8 @@ export const useSpacesStore = defineStore('spaces', () => {
   });
 
   async function fetchSpace(spaceId: string, networkId: NetworkID) {
+    await metaStore.fetchBlock(networkId);
+
     const network = getNetwork(networkId);
 
     const space = await network.api.loadSpace(spaceId);

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -170,7 +170,6 @@ watch(
   async ([networkId, spaceAddress, id]) => {
     if (!networkId || !spaceAddress) return;
 
-    await metaStore.fetchBlock(networkId);
     proposalsStore.fetchProposal(spaceAddress, id, networkId);
   },
   { immediate: true }

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -6,7 +6,6 @@ const { param } = useRouteParser('id');
 const { resolved, address, networkId } = useResolve(param);
 const uiStore = useUiStore();
 const spacesStore = useSpacesStore();
-const metaStore = useMetaStore();
 
 const space = computed(() => {
   if (!resolved.value) return null;
@@ -19,7 +18,6 @@ watch(
   async ([resolved, networkId, address]) => {
     if (!resolved || !networkId || !address) return;
 
-    await metaStore.fetchBlock(networkId);
     spacesStore.fetchSpace(address, networkId);
   },
   {


### PR DESCRIPTION
### Summary

Because we made calling fetchBlock from global to on-demand there is risk that UI doesn't call it when it's needed (it happened in case of visiting space from explore page where it has space right away.

We avoid this problem by making requesting latest block responsibility of store actions (it won't fetch new block if it's already fetched).

Regression from: https://github.com/snapshot-labs/sx-ui/pull/730

Closes: https://github.com/snapshot-labs/sx-ui/issues/780

### How to test

1. Go to http://localhost:8080/#/explore
2. Click on Shadow DAO
3. Proposals in overview page show as closed proposals.
