### PR TITLE
feat: allow to enable networks via env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+VITE_ENABLED_NETWORKS=
 VITE_ETH_RPC_URL=https://rpc.snapshotx.xyz
 VITE_MANA_URL=https://mana.pizza
 VITE_IPFS_GATEWAY=snapshot.4everland.link

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
-    "@snapshot-labs/sx": "^0.1.0-beta.40",
+    "@snapshot-labs/sx": "^0.1.0-beta.42",
     "@vueuse/core": "^10.4.1",
     "@walletconnect/client": "^1.8.0",
     "ajv": "^8.12.0",

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -5,6 +5,7 @@ import {
   getEvmStrategy,
   evmArbitrum,
   evmPolygon,
+  evmMainnet,
   evmGoerli,
   evmSepolia,
   evmLineaGoerli,
@@ -38,6 +39,7 @@ type Choice = 0 | 1 | 2;
 const CONFIGS: Record<number, EvmNetworkConfig> = {
   137: evmPolygon,
   42161: evmArbitrum,
+  1: evmMainnet,
   5: evmGoerli,
   11155111: evmSepolia,
   59140: evmLineaGoerli
@@ -492,6 +494,7 @@ export function createActions(
           const value = await strategy.getVotingPower(
             address,
             voterAddress,
+            null,
             block,
             strategiesParams[i],
             provider

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -33,6 +33,13 @@ export const METADATA: Record<string, Metadata> = {
     avatar: 'ipfs://bafkreic2p3zzafvz34y4tnx2kaoj6osqo66fpdo3xnagocil452y766gdq',
     blockTime: 0.26082
   },
+  eth: {
+    name: 'Ethereum',
+    chainId: 1,
+    apiUrl: 'https://api.studio.thegraph.com/query/23545/sx/version/latest',
+    avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
+    blockTime: 12.09
+  },
   gor: {
     name: 'Ethereum Goerli',
     chainId: 5,
@@ -91,7 +98,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
     chainId,
     baseChainId: chainId,
     hasReceive: false,
-    supportsSimulation: ['gor', 'sep', 'matic', 'arb1'].includes(networkId),
+    supportsSimulation: ['eth', 'gor', 'sep', 'matic', 'arb1'].includes(networkId),
     managerConnectors: EVM_CONNECTORS,
     actions: createActions(provider, helpers, chainId),
     api,

--- a/src/networks/index.ts
+++ b/src/networks/index.ts
@@ -5,19 +5,21 @@ import { NetworkID } from '@/types';
 const starknetNetwork = createStarknetNetwork('sn-tn');
 const polygonNetwork = createEvmNetwork('matic');
 const arbitrumNetwork = createEvmNetwork('arb1');
+const ethereumNetwork = createEvmNetwork('eth');
 const goerliNetwork = createEvmNetwork('gor');
 const sepoliaNetwork = createEvmNetwork('sep');
 const lineaTestnetNetwork = createEvmNetwork('linea-testnet');
 
 export const enabledNetworks: NetworkID[] = process.env.VITE_ENABLED_NETWORKS
   ? (process.env.VITE_ENABLED_NETWORKS.split(',') as NetworkID[])
-  : ['matic', 'arb1', 'gor', 'sep', 'sn-tn'];
+  : ['matic', 'arb1', 'eth', 'gor', 'sep', 'sn-tn'];
 
-export const evmNetworks: NetworkID[] = ['matic', 'arb1', 'gor', 'sep', 'linea-testnet'];
+export const evmNetworks: NetworkID[] = ['matic', 'arb1', 'eth', 'gor', 'sep', 'linea-testnet'];
 
 export const getNetwork = (id: NetworkID) => {
   if (id === 'matic') return polygonNetwork;
   if (id === 'arb1') return arbitrumNetwork;
+  if (id === 'eth') return ethereumNetwork;
   if (id === 'gor') return goerliNetwork;
   if (id === 'sep') return sepoliaNetwork;
   if (id === 'linea-testnet') return lineaTestnetNetwork;

--- a/src/networks/index.ts
+++ b/src/networks/index.ts
@@ -9,7 +9,9 @@ const goerliNetwork = createEvmNetwork('gor');
 const sepoliaNetwork = createEvmNetwork('sep');
 const lineaTestnetNetwork = createEvmNetwork('linea-testnet');
 
-export const enabledNetworks: NetworkID[] = ['matic', 'arb1', 'gor', 'sep', 'sn-tn'];
+export const enabledNetworks: NetworkID[] = process.env.VITE_ENABLED_NETWORKS
+  ? (process.env.VITE_ENABLED_NETWORKS.split(',') as NetworkID[])
+  : ['matic', 'arb1', 'gor', 'sep', 'sn-tn'];
 
 export const evmNetworks: NetworkID[] = ['matic', 'arb1', 'gor', 'sep', 'linea-testnet'];
 

--- a/src/networks/index.ts
+++ b/src/networks/index.ts
@@ -12,9 +12,9 @@ const lineaTestnetNetwork = createEvmNetwork('linea-testnet');
 
 export const enabledNetworks: NetworkID[] = process.env.VITE_ENABLED_NETWORKS
   ? (process.env.VITE_ENABLED_NETWORKS.split(',') as NetworkID[])
-  : ['matic', 'arb1', 'eth', 'gor', 'sep', 'sn-tn'];
+  : ['eth', 'matic', 'arb1', 'gor', 'sep', 'sn-tn'];
 
-export const evmNetworks: NetworkID[] = ['matic', 'arb1', 'eth', 'gor', 'sep', 'linea-testnet'];
+export const evmNetworks: NetworkID[] = ['eth', 'matic', 'arb1', 'gor', 'sep', 'linea-testnet'];
 
 export const getNetwork = (id: NetworkID) => {
   if (id === 'matic') return polygonNetwork;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,15 @@
 // UI
 export type NotificationType = 'error' | 'warning' | 'success';
 
-export type NetworkID = 'gor' | 'sep' | 'linea-testnet' | 'sn-tn' | 'sn-tn2' | 'matic' | 'arb1';
+export type NetworkID =
+  | 'eth'
+  | 'gor'
+  | 'sep'
+  | 'linea-testnet'
+  | 'sn-tn'
+  | 'sn-tn2'
+  | 'matic'
+  | 'arb1';
 export type Choice = 1 | 2 | 3;
 
 export type SelectedStrategy = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,6 +1235,11 @@
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.1.tgz#6899660f6fbb97798a6fbd227227c4589a454724"
   integrity sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==
 
+"@noble/hashes@1.2.0", "@noble/hashes@^1.1.2", "@noble/hashes@~1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
+  integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
+
 "@noble/hashes@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
@@ -1245,12 +1250,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
   integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
-"@noble/hashes@^1.1.2":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
-  integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
-
-"@noble/secp256k1@^1.6.3":
+"@noble/secp256k1@1.7.1", "@noble/secp256k1@^1.6.3", "@noble/secp256k1@~1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
   integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
@@ -1275,6 +1275,14 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@openzeppelin/merkle-tree@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/merkle-tree/-/merkle-tree-1.0.5.tgz#4836d377777a7e39f31674f06ec3d6909def7913"
+  integrity sha512-JkwG2ysdHeIphrScNxYagPy6jZeNONgDRyqU6lbFgE8HKCZFSkcP8r6AjZs+3HZk4uRNV0kNBBzuWhKQ3YV7Kw==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    ethereum-cryptography "^1.1.2"
 
 "@pkgr/utils@^2.3.1":
   version "2.4.2"
@@ -1442,6 +1450,15 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.3.tgz#8584115565228290a6c6c4961973e0903bb3df2f"
   integrity sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==
 
+"@scure/bip32@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.1.5.tgz#d2ccae16dcc2e75bc1d75f5ef3c66a338d1ba300"
+  integrity sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==
+  dependencies:
+    "@noble/hashes" "~1.2.0"
+    "@noble/secp256k1" "~1.7.0"
+    "@scure/base" "~1.1.0"
+
 "@scure/bip32@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.2.tgz#90e78c027d5e30f0b22c1f8d50ff12f3fb7559f8"
@@ -1450,6 +1467,14 @@
     "@noble/curves" "~1.2.0"
     "@noble/hashes" "~1.3.2"
     "@scure/base" "~1.1.2"
+
+"@scure/bip39@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.1.tgz#b54557b2e86214319405db819c4b6a370cf340c5"
+  integrity sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==
+  dependencies:
+    "@noble/hashes" "~1.2.0"
+    "@scure/base" "~1.1.0"
 
 "@scure/bip39@1.2.1":
   version "1.2.1"
@@ -1514,10 +1539,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/sx@^0.1.0-beta.40":
-  version "0.1.0-beta.40"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.40.tgz#3a9befebeb22369157db170a2f1f2f98e895d60b"
-  integrity sha512-27nEyJTuEeLafOZf2UFOOHcIunIbXRWiCYecUHqsyQmLIDKe1StnNGQSkI4puwZ+yvnC0PXJ0Js/AmvWkfLWeg==
+"@snapshot-labs/sx@^0.1.0-beta.42":
+  version "0.1.0-beta.42"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.42.tgz#49d4abc3cdcd23104fa80a20df228e300a48a06d"
+  integrity sha512-NuYdzkpr7Ew304HVnzAY3/8yMxsMx+68OhluW4GCEu12HAX10UgTuDthUGugDBvgYiFFyqtPRztaMm3xI/Ad8Q==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"
@@ -1531,6 +1556,7 @@
     "@ethersproject/providers" "^5.7.0"
     "@ethersproject/solidity" "^5.7.0"
     "@ethersproject/wallet" "^5.7.0"
+    "@openzeppelin/merkle-tree" "^1.0.5"
     cross-fetch "^3.1.5"
     micro-starknet "^0.2.3"
     randombytes "^2.1.0"
@@ -4524,6 +4550,16 @@ ethereum-cryptography@^0.1.3:
     scrypt-js "^3.0.0"
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
+
+ethereum-cryptography@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz#5ccfa183e85fdaf9f9b299a79430c044268c9b3a"
+  integrity sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==
+  dependencies:
+    "@noble/hashes" "1.2.0"
+    "@noble/secp256k1" "1.7.1"
+    "@scure/bip32" "1.1.5"
+    "@scure/bip39" "1.1.1"
 
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/770

This PR also enabled Ethereum mainnet as valid network so we can have proper "live" deployment.

### How to test

1. Run `VITE_ENABLED_NETWORKS=eth yarn dev`
2. Only Mainnet spaces are available.
