### PR TITLE
feat: add basic Mixpanel events

### DIFF
--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -14,6 +14,7 @@ import type {
 import type { Connector, StrategyConfig } from '@/networks/types';
 
 export function useActions() {
+  const { mixpanel } = useMixpanel();
   const uiStore = useUiStore();
   const { web3 } = useWeb3();
   const { getCurrentFromDuration } = useMetaStore();
@@ -159,6 +160,11 @@ export function useActions() {
 
     console.log('Receipt', receipt);
 
+    mixpanel.track('Create space', {
+      network: networkId,
+      predictedSpaceAddress: predictSpaceAddress(networkId, salt)
+    });
+
     return receipt.txId;
   }
 
@@ -193,6 +199,13 @@ export function useActions() {
     );
 
     uiStore.addPendingVote(proposal.id);
+
+    mixpanel.track('Vote', {
+      network: proposal.network,
+      space: proposal.space,
+      proposalId: proposal.id,
+      choice
+    });
   }
 
   async function propose(
@@ -236,6 +249,11 @@ export function useActions() {
         convertToMetaTransactions(transactions)
       )
     );
+
+    mixpanel.track('Propose', {
+      network: space.network,
+      space: space.id
+    });
 
     return true;
   }
@@ -452,6 +470,12 @@ export function useActions() {
     console.log('Receipt', receipt);
 
     uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, networkId);
+
+    mixpanel.track('Delegate', {
+      network: networkId,
+      space: space.id,
+      delegatee
+    });
   }
 
   return {

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -23,11 +23,15 @@ const state = reactive({
 });
 
 export function useWeb3() {
+  const { mixpanel } = useMixpanel();
+
   async function login(connector = 'injected') {
     auth = getInstance();
     state.authLoading = true;
     await auth.login(connector);
     if (auth.provider.value) {
+      mixpanel.track('Connect', { connector });
+
       auth.web3 = new Web3Provider(auth.provider.value, 'any');
       await loadProvider();
     }

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -5,6 +5,7 @@ import pkg from '../../package.json';
 
 export const useSpacesStore = defineStore('spaces', () => {
   const metaStore = useMetaStore();
+  const { mixpanel } = useMixpanel();
   const starredSpacesIds = useStorage(`${pkg.name}.spaces-starred`, [] as string[]);
   const starredSpacesData = ref([] as Space[]);
 
@@ -50,11 +51,18 @@ export const useSpacesStore = defineStore('spaces', () => {
   }
 
   function toggleSpaceStar(id: string) {
-    if (starredSpacesIds.value.includes(id)) {
+    const alreadyStarred = starredSpacesIds.value.includes(id);
+
+    if (alreadyStarred) {
       starredSpacesIds.value = starredSpacesIds.value.filter((spaceId: string) => spaceId !== id);
     } else {
       starredSpacesIds.value = [id, ...starredSpacesIds.value];
     }
+
+    mixpanel.track('Set space favorite', {
+      space: id,
+      favorite: !alreadyStarred
+    });
   }
 
   watch(


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/pitches/issues/50

Tracks following events in Mixpanel:
- Connect wallet
- Create space
- Propose
- Vote
- Delegate
-  Favorite space

**Vercel fails because it tries to build stories that are worked on in other PR.**

### How to test

1. Do any of the actions listed.
2. Events should be stored in Mixpanel (make sure adblocker doesn't block it for you).

