### PR TITLE
fix: make Starknet whitelist work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
-    "@snapshot-labs/sx": "^0.1.0-beta.43",
+    "@snapshot-labs/sx": "^0.1.0-beta.44",
     "@vueuse/core": "^10.4.1",
     "@walletconnect/client": "^1.8.0",
     "ajv": "^8.12.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
-    "@snapshot-labs/sx": "^0.1.0-beta.42",
+    "@snapshot-labs/sx": "^0.1.0-beta.43",
     "@vueuse/core": "^10.4.1",
     "@walletconnect/client": "^1.8.0",
     "ajv": "^8.12.0",

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -187,7 +187,7 @@ export function createActions(
       const strategiesWithMetadata = await Promise.all(
         strategies.map(async strategy => {
           const metadata = await parseStrategyMetadata(
-            space.strategies_parsed_metadata[strategy.index].payload
+            space.voting_power_validation_strategies_parsed_metadata[strategy.index].payload
           );
 
           return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,10 +1539,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/sx@^0.1.0-beta.42":
-  version "0.1.0-beta.42"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.42.tgz#49d4abc3cdcd23104fa80a20df228e300a48a06d"
-  integrity sha512-NuYdzkpr7Ew304HVnzAY3/8yMxsMx+68OhluW4GCEu12HAX10UgTuDthUGugDBvgYiFFyqtPRztaMm3xI/Ad8Q==
+"@snapshot-labs/sx@^0.1.0-beta.43":
+  version "0.1.0-beta.43"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.43.tgz#b04203ed093c25ce54e0b6646cd3c929234a9089"
+  integrity sha512-kDkpvJPJo50Mwj7PADGPu8XlrNchmlTYVIaEnqCV7Ujtp1+rX2ex1LFt7PNPuMUMXUQgXNNz7rlHqBY9P5SvwQ==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,10 +1539,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/sx@^0.1.0-beta.43":
-  version "0.1.0-beta.43"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.43.tgz#b04203ed093c25ce54e0b6646cd3c929234a9089"
-  integrity sha512-kDkpvJPJo50Mwj7PADGPu8XlrNchmlTYVIaEnqCV7Ujtp1+rX2ex1LFt7PNPuMUMXUQgXNNz7rlHqBY9P5SvwQ==
+"@snapshot-labs/sx@^0.1.0-beta.44":
+  version "0.1.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.44.tgz#ddc26d4987cf56382770ba8d02f438c5da6e5e69"
+  integrity sha512-RI5fcyUHk4QcmEaK4GDIkwQcCh+c7JihhVQ/U6wFqfEcrIP93/4uSZfipKJIKHYSo9sGfHPFQmdJhwPicbVebg==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
### Summary

Fixes two issues:
- Make merkle tree address lookup independent of paddings.
- Use validation strategy strategies metadata when proposing (it was fixed in PR that adds support for editing strategies, but never ported back to master).

### Test plan

- Create space with merkle whitelist strategy as validation strategy but not as voting strategy.
- Try proposing.