### PR TITLE
fix: do not reset networksMap when fetching explore page

### DIFF
--- a/src/composables/useSpaces.ts
+++ b/src/composables/useSpaces.ts
@@ -108,25 +108,28 @@ export function useSpaces() {
       })
     );
 
-    networksMap.value = Object.fromEntries(
-      results.map(result => {
-        const spacesIds = result.spaces.map(space => space.id);
+    networksMap.value = {
+      ...networksMap.value,
+      ...(Object.fromEntries(
+        results.map(result => {
+          const spacesIds = result.spaces.map(space => space.id);
 
-        return [
-          result.id,
-          {
-            spacesIdsList: overwrite
-              ? spacesIds
-              : [...networksMap.value[result.id].spacesIdsList, ...spacesIds],
-            spaces: {
-              ...networksMap.value[result.id].spaces,
-              ...Object.fromEntries(result.spaces.map(space => [space.id, space]))
-            },
-            hasMoreSpaces: result.hasMoreSpaces
-          }
-        ];
-      })
-    ) as Record<NetworkID, NetworkRecord>;
+          return [
+            result.id,
+            {
+              spacesIdsList: overwrite
+                ? spacesIds
+                : [...networksMap.value[result.id].spacesIdsList, ...spacesIds],
+              spaces: {
+                ...networksMap.value[result.id].spaces,
+                ...Object.fromEntries(result.spaces.map(space => [space.id, space]))
+              },
+              hasMoreSpaces: result.hasMoreSpaces
+            }
+          ];
+        })
+      ) as Record<NetworkID, NetworkRecord>)
+    };
   }
 
   async function fetch(filter?: SpacesFilter) {


### PR DESCRIPTION
### Summary

We don't fetch all networks for explore page (snapshot.org spaces are not fetched, but we have to keep previous networksMap entries so it doesn't get lost).

### How to test

1. Go to http://localhost:8080/#/s:arbitrumfoundation.eth and favorite this space.
2. Go to http://localhost:8080/#/explore
3. Click on Arbitrum space from favorites list.
4. It loads.

