### PR TITLE
chore: split test and test:watch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
       - run: yarn build
       - run: yarn typecheck
       - run: yarn lint:nofix
-      - run: yarn test:unit
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn lint
 ### Runs tests
 
 ```
-yarn test:unit
+yarn test
 ```
 
 ### Verifies TypeScript code

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint:nofix": "eslint \"./src/**/*.{ts,vue,json}\"",
     "lint": "yarn lint:nofix --fix",
     "typecheck": "vue-tsc --noEmit",
-    "test:unit": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "electron:start": "electron .",
     "electron:build": "ELECTRON=true yarn build"
   },


### PR DESCRIPTION
### Summary

Non-watch should be default variant. We want to run all test under same name under mono repo.

### How to test

1. CI should pass.
