### PR TITLE
fix: remove subtree option for BlockInfiniteScroller

### DIFF
--- a/src/components/Block/InfiniteScroller.vue
+++ b/src/components/Block/InfiniteScroller.vue
@@ -2,7 +2,6 @@
 const props = withDefaults(
   defineProps<{
     enabled?: boolean;
-    subtree?: boolean;
     loadingMore?: boolean;
   }>(),
   { enabled: true, loadingMore: false }
@@ -51,7 +50,7 @@ watch([container, () => props.enabled], ([ref, enabled]) => {
 
   if (!ref) return;
 
-  mutationObserver.observe(ref, { childList: true, subtree: props.subtree });
+  mutationObserver.observe(ref, { childList: true });
   updateIntersectionObserver();
 });
 

--- a/src/views/Proposal/Votes.vue
+++ b/src/views/Proposal/Votes.vue
@@ -90,84 +90,85 @@ watch([sortBy, choiceFilter], () => {
 </script>
 
 <template>
-  <BlockInfiniteScroller
-    :subtree="true"
-    :loading-more="loadingMore"
-    @end-reached="handleEndReached"
-  >
-    <table class="text-left w-full table-fixed">
-      <colgroup>
-        <col class="w-[50%] lg:w-[40%]" />
-        <col class="w-[25%] lg:w-[20%]" />
-        <col class="w-[25%] lg:w-[20%]" />
-        <col class="w-[60px] lg:w-[20%]" />
-        <col class="w-[0px] lg:w-[60px]" />
-      </colgroup>
-      <thead
-        class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 after:border-b after:absolute after:w-full"
-      >
-        <tr class="bg-skin-border/10">
-          <th class="pl-4 font-medium">
-            <span class="relative bottom-[1px]">Voter</span>
-          </th>
-          <th class="hidden lg:table-cell">
+  <table class="text-left w-full table-fixed">
+    <colgroup>
+      <col class="w-[50%] lg:w-[40%]" />
+      <col class="w-[25%] lg:w-[20%]" />
+      <col class="w-[25%] lg:w-[20%]" />
+      <col class="w-[60px] lg:w-[20%]" />
+      <col class="w-[0px] lg:w-[60px]" />
+    </colgroup>
+    <thead
+      class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 after:border-b after:absolute after:w-full"
+    >
+      <tr class="bg-skin-border/10">
+        <th class="pl-4 font-medium">
+          <span class="relative bottom-[1px]">Voter</span>
+        </th>
+        <th class="hidden lg:table-cell">
+          <button
+            class="relative bottom-[1px] flex items-center min-w-0 w-full font-medium hover:text-skin-link"
+            @click="handleSortChange('created')"
+          >
+            <span>Date</span>
+            <IH-arrow-sm-down v-if="sortBy === 'created-desc'" class="ml-1" />
+            <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="ml-1" />
+          </button>
+        </th>
+        <th class="font-medium">
+          <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
+          <UiSelect
+            v-else
+            v-model="choiceFilter"
+            class="font-normal"
+            title="Choice"
+            gap="12px"
+            placement="left"
+            :items="[
+              { key: 'any', label: 'Any' },
+              { key: 'for', label: 'For', indicator: 'bg-choice-for' },
+              { key: 'against', label: 'Against', indicator: 'bg-choice-against' },
+              { key: 'abstain', label: 'Abstain', indicator: 'bg-choice-abstain' }
+            ]"
+          >
+            <template #button>
+              <div class="relative bottom-[1px] flex items-center min-w-0 hover:text-skin-link">
+                <span class="truncate">Choice</span>
+                <IH-adjustments-vertical class="ml-2" />
+              </div>
+            </template>
+          </UiSelect>
+        </th>
+        <th>
+          <div class="relative bottom-[1px] flex justify-end">
             <button
-              class="relative bottom-[1px] flex items-center min-w-0 w-full font-medium hover:text-skin-link"
-              @click="handleSortChange('created')"
+              class="flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link"
+              @click="handleSortChange('vp')"
             >
-              <span>Date</span>
-              <IH-arrow-sm-down v-if="sortBy === 'created-desc'" class="ml-1" />
-              <IH-arrow-sm-up v-else-if="sortBy === 'created-asc'" class="ml-1" />
+              <span class="truncate">Voting power</span>
+              <IH-arrow-sm-down v-if="sortBy === 'vp-desc'" class="ml-1" />
+              <IH-arrow-sm-up v-else-if="sortBy === 'vp-asc'" class="ml-1" />
             </button>
-          </th>
-          <th class="font-medium">
-            <template v-if="offchainNetworks.includes(proposal.network)">Choice</template>
-            <UiSelect
-              v-else
-              v-model="choiceFilter"
-              class="font-normal"
-              title="Choice"
-              gap="12px"
-              placement="left"
-              :items="[
-                { key: 'any', label: 'Any' },
-                { key: 'for', label: 'For', indicator: 'bg-choice-for' },
-                { key: 'against', label: 'Against', indicator: 'bg-choice-against' },
-                { key: 'abstain', label: 'Abstain', indicator: 'bg-choice-abstain' }
-              ]"
-            >
-              <template #button>
-                <div class="relative bottom-[1px] flex items-center min-w-0 hover:text-skin-link">
-                  <span class="truncate">Choice</span>
-                  <IH-adjustments-vertical class="ml-2" />
-                </div>
-              </template>
-            </UiSelect>
-          </th>
-          <th>
-            <div class="relative bottom-[1px] flex justify-end">
-              <button
-                class="flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link"
-                @click="handleSortChange('vp')"
-              >
-                <span class="truncate">Voting power</span>
-                <IH-arrow-sm-down v-if="sortBy === 'vp-desc'" class="ml-1" />
-                <IH-arrow-sm-up v-else-if="sortBy === 'vp-asc'" class="ml-1" />
-              </button>
-            </div>
-          </th>
-          <th />
-        </tr>
-      </thead>
-      <td v-if="!loaded" colspan="5">
-        <UiLoading class="p-4 block text-center" />
-      </td>
-      <template v-else>
-        <tbody>
-          <td v-if="votes.length === 0" class="p-4 text-center" colspan="5">
-            There isn't any votes yet!
-          </td>
-          <tr v-for="(vote, i) in votes" :key="i" class="border-b relative">
+          </div>
+        </th>
+        <th />
+      </tr>
+    </thead>
+    <td v-if="!loaded" colspan="5">
+      <UiLoading class="p-4 block text-center" />
+    </td>
+    <template v-else>
+      <tbody>
+        <td v-if="votes.length === 0" class="p-4 text-center" colspan="5">
+          There isn't any votes yet!
+        </td>
+        <BlockInfiniteScroller :loading-more="loadingMore" @end-reached="handleEndReached">
+          <template #loading>
+            <td colspan="5">
+              <UiLoading class="p-4 block text-center" />
+            </td>
+          </template>
+          <tr v-for="(vote, i) in votes" :key="i" class="border-b relative align-middle">
             <div
               class="absolute top-0 bottom-0 right-0 pointer-events-none"
               :style="{
@@ -273,8 +274,8 @@ watch([sortBy, choiceFilter], () => {
               </div>
             </td>
           </tr>
-        </tbody>
-      </template>
-    </table>
-  </BlockInfiniteScroller>
+        </BlockInfiniteScroller>
+      </tbody>
+    </template>
+  </table>
 </template>


### PR DESCRIPTION
### Summary

BlockInfiniteScroller used to wrap entire table but it wouldn't trigger endReached event because table itself didn't have any direct children added to it, so subtree property was added, but it caused different issue as now table's last element is always visible on screen (tbody) so it triggers endReached event all the time.

subtree property is not good solution and we should always wrap just the elements we want to load.

### How to test

1. Go to http://localhost:8080/#/s:arbitrumfoundation.eth/proposal/0xc040de9c6a85dee5ca15de10691165bf5595245ffac922cbef61e45199522345/votes
2. Check for network requests - no requests being fired all the time.
3. Scroll down, it will fetch new votes as needed.

