### PR TITLE
fix: do not show read only networks on space creation form

### DIFF
--- a/src/components/Block/SpaceFormNetwork.vue
+++ b/src/components/Block/SpaceFormNetwork.vue
@@ -11,10 +11,12 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: NetworkID);
 }>();
 
-const availableNetworks = enabledNetworks.map(id => {
-  const { name, avatar } = getNetwork(id);
-  return { id, name, avatar };
-});
+const availableNetworks = enabledNetworks
+  .map(id => {
+    const { name, avatar, readOnly } = getNetwork(id);
+    return { id, name, avatar, readOnly };
+  })
+  .filter(network => !network.readOnly);
 </script>
 
 <template>

--- a/src/networks/offchain/constants.ts
+++ b/src/networks/offchain/constants.ts
@@ -1,0 +1,13 @@
+export const SUPPORTED_AUTHENTICATORS = {};
+export const CONTRACT_SUPPORTED_AUTHENTICATORS = {};
+export const SUPPORTED_STRATEGIES = {};
+export const SUPPORTED_EXECUTORS = {};
+export const RELAYER_AUTHENTICATORS = {};
+export const AUTHS = {};
+export const PROPOSAL_VALIDATIONS = {};
+export const STRATEGIES = {};
+export const EXECUTORS = {};
+export const EDITOR_AUTHENTICATORS = [];
+export const EDITOR_PROPOSAL_VALIDATIONS = [];
+export const EDITOR_VOTING_STRATEGIES = [];
+export const EDITOR_EXECUTION_STRATEGIES = [];

--- a/src/networks/offchain/index.ts
+++ b/src/networks/offchain/index.ts
@@ -1,5 +1,5 @@
 import { createApi } from './api';
-import * as constants from '../starknet/constants';
+import * as constants from './constants';
 import { pinPineapple } from '@/helpers/pin';
 import { Network } from '@/networks/types';
 import { NetworkID } from '@/types';
@@ -36,8 +36,8 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
 
   return {
     readOnly: true,
-    name: 'Starknet (testnet)',
-    avatar: 'ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m',
+    name: networkId === 's-tn' ? 'Snapshot (testnet)' : 'Snapshot',
+    avatar: '',
     currentUnit: 'second',
     chainId: l1ChainId,
     baseChainId: l1ChainId,


### PR DESCRIPTION
### Summary

Filter out read only networks from create space form.

Also created constans for Snapshot network. 

### How to test

1. Go to http://localhost:8080/#/create
2. Name space, go next.
3. Snapshot network is not visible.

