### PR TITLE
style: enhance proposal view and tabs

### DIFF
--- a/src/components/Link.vue
+++ b/src/components/Link.vue
@@ -1,14 +1,24 @@
 <script setup lang="ts">
+import { _n } from '@/helpers/utils';
+
 defineProps<{
   text: string;
   isActive: boolean;
+  count?: number;
 }>();
 </script>
 
 <template>
-  <h4
-    class="eyebrow py-2 cursor-pointer"
-    :class="[isActive ? 'text-skin-link' : 'text-skin-text']"
-    v-text="text"
-  />
+  <div class="flex items-center" :class="[isActive && 'border-b border-skin-link -mb-[1px]']">
+    <h4
+      class="eyebrow py-2 cursor-pointer inline-block hover:text-skin-link"
+      :class="[isActive ? 'text-skin-link' : 'text-skin-text']"
+      v-text="text"
+    />
+    <span
+      v-if="count"
+      class="inline-block bg-skin-border text-skin-link text-xs rounded-full px-[6px] ml-2"
+      v-text="_n(count, 'compact')"
+    />
+  </div>
 </template>

--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -18,7 +18,6 @@ remarkable.core.ruler.disable(['abbr', 'abbr2', 'footnote_tail', 'replacements',
 remarkable.block.ruler.disable(['code', 'deflist', 'fences', 'footnote', 'htmlblock', 'lheading']);
 remarkable.inline.ruler.disable([
   'autolink',
-  'backticks',
   'del',
   'entity',
   'escape',
@@ -164,6 +163,10 @@ const parsed = computed(() => {
   ol ul {
     margin-top: 0;
     margin-bottom: 0;
+  }
+
+  code {
+    @apply bg-skin-border text-[16px] rounded-md px-[6px] py-[2px];
   }
 
   li {

--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { Remarkable } from 'remarkable';
+import { linkify } from 'remarkable/linkify';
 import { getUrl } from '@/helpers/utils';
 
 const props = defineProps<{
@@ -12,7 +13,7 @@ const remarkable = new Remarkable({
   breaks: true,
   typographer: false,
   linkTarget: '_blank'
-});
+}).use(linkify);
 remarkable.core.ruler.disable(['abbr', 'abbr2', 'footnote_tail', 'replacements', 'smartquotes']);
 remarkable.block.ruler.disable(['code', 'deflist', 'fences', 'footnote', 'htmlblock', 'lheading']);
 remarkable.inline.ruler.disable([

--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -18,12 +18,12 @@ const editor = useMarkdownEditor(editorRef, editorFileInputRef, editorContainerR
 <template>
   <div
     ref="editorContainerRef"
-    class="rounded-lg mb-3"
+    class="rounded-lg mb-3 border"
     :class="{
       'ring-2': editor.hovered.value
     }"
   >
-    <div class="flex justify-end gap-1 py-2 px-3 border rounded-t-lg">
+    <div class="flex justify-end gap-1 py-2 px-3">
       <UiTooltip title="Add heading text">
         <button
           class="p-1 w-[26px] h-[26px] leading-[18px] hover:text-skin-link rounded focus-visible:ring-1"

--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -32,7 +32,7 @@ async function handleVoteClick(choice: Choice) {
               space: `${route.params.id}`
             }
           }"
-          class="space-x-2 flex max-w-[700px]"
+          class="space-x-2 flex"
         >
           <ProposalStatusIcon width="17" height="17" :state="proposal.state" class="top-[7.5px]" />
           <h3

--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -23,7 +23,7 @@ async function handleVoteClick(choice: Choice) {
 <template>
   <div>
     <div class="border-b mx-4 py-2.5 flex">
-      <div class="flex-auto mr-4">
+      <div class="flex-auto mr-4 w-0">
         <router-link
           :to="{
             name: 'proposal-overview',
@@ -32,11 +32,11 @@ async function handleVoteClick(choice: Choice) {
               space: `${route.params.id}`
             }
           }"
-          class="max-w-fit flex space-x-2"
+          class="space-x-2 flex max-w-[700px]"
         >
           <ProposalStatusIcon width="17" height="17" :state="proposal.state" class="top-[7.5px]" />
           <h3
-            class="leading-6 my-1"
+            class="leading-6 my-1 text-[21px] md:truncate md:text-ellipsis"
             v-text="proposal.title || `Proposal #${proposal.proposal_id}`"
           />
         </router-link>

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -111,7 +111,7 @@ export function _n(
   { maximumFractionDigits }: { maximumFractionDigits?: number } = {}
 ) {
   const formatter = new Intl.NumberFormat('en', { notation, maximumFractionDigits });
-  return formatter.format(value);
+  return formatter.format(value).toLowerCase();
 }
 
 export function getCurrentName(currentUnit: 'block' | 'second') {

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -248,7 +248,10 @@ export default defineComponent({
         <PendingTransactionsIndicator class="mr-2" />
         <UiLoading v-if="!space" class="block p-4" />
         <div v-else class="space-x-2">
-          <UiButton class="float-left leading-3 !px-3 rounded-r-none" @click="modalOpen = true">
+          <UiButton
+            class="float-left leading-3 !pl-3 !pr-[12px] rounded-r-none"
+            @click="modalOpen = true"
+          >
             <IH-collection class="inline-block" />
           </UiButton>
           <UiButton
@@ -266,7 +269,7 @@ export default defineComponent({
         </div>
       </div>
     </nav>
-    <Container v-if="proposal" class="pt-5 !max-w-[630px] mx-0 md:mx-auto s-box">
+    <Container v-if="proposal" class="pt-5 !max-w-[660px] mx-0 md:mx-auto s-box">
       <UiAlert v-if="!fetchingVotingPower && !votingPowerValid" type="error" class="mb-4">
         You do not have enough voting power to create proposal in this space.
       </UiAlert>
@@ -276,21 +279,26 @@ export default defineComponent({
         :definition="TITLE_DEFINITION"
         :error="formErrors.title"
       />
-      <div class="flex">
+      <div class="flex space-x-3">
         <Link
           :is-active="!previewEnabled"
           text="Write"
-          class="pr-3"
+          class="border-transparent"
           @click="previewEnabled = false"
         />
-        <Link :is-active="previewEnabled" text="Preview" @click="previewEnabled = true" />
+        <Link
+          :is-active="previewEnabled"
+          text="Preview"
+          class="border-transparent"
+          @click="previewEnabled = true"
+        />
       </div>
       <Markdown
         v-if="previewEnabled"
         class="px-3 py-2 border rounded-lg mb-5 min-h-[200px]"
         :body="proposal.body"
       />
-      <MarkdownEditor v-else v-model="proposal.body" />
+      <MarkdownEditor v-else v-model="proposal.body" class="" />
       <div class="s-base mb-4">
         <SIString
           :key="proposalKey || ''"

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getNetwork, offchainNetworks } from '@/networks';
-import { getStampUrl, getCacheHash } from '@/helpers/utils';
+import { getStampUrl, getCacheHash, _n, sanitizeUrl } from '@/helpers/utils';
 import { Choice } from '@/types';
 import { VotingPower } from '@/networks/types';
 
@@ -26,6 +26,11 @@ const proposal = computed(() => {
 
   return proposalsStore.getProposal(spaceAddress.value, id.value, networkId.value);
 });
+
+const discussion = computed(() => {
+  return sanitizeUrl(proposal.value.discussion);
+});
+
 const votingPowerDecimals = computed(() => {
   if (!proposal.value) return 0;
   return Math.max(
@@ -103,23 +108,34 @@ watchEffect(() => {
     <UiLoading v-if="!proposal" class="ml-4 mt-3" />
     <template v-else>
       <div class="flex-1 md:mr-[340px]">
-        <div class="flex px-4 bg-skin-bg border-b sticky top-[72px] z-40">
+        <div class="flex px-4 bg-skin-bg border-b sticky top-[72px] z-40 space-x-3">
           <router-link
             :to="{
               name: 'proposal-overview',
               params: { id: proposal.proposal_id }
             }"
           >
-            <Link :is-active="route.name === 'proposal-overview'" text="Overview" class="pr-3" />
+            <Link :is-active="route.name === 'proposal-overview'" text="Overview" />
           </router-link>
           <router-link
             :to="{
               name: 'proposal-votes',
               params: { id: proposal.proposal_id }
             }"
+            class="flex items-center"
           >
-            <Link :is-active="route.name === 'proposal-votes'" text="Votes" />
+            <Link :is-active="route.name === 'proposal-votes'" text="Votes" class="inline-block" />
+            <span
+              v-if="proposal.vote_count"
+              class="inline-block bg-skin-border text-skin-link text-xs rounded-full px-[6px] ml-2"
+            >
+              {{ _n(proposal.vote_count, 'compact') }}
+            </span>
           </router-link>
+          <a v-if="discussion" :href="discussion" target="_blank" class="flex items-center">
+            <h4 class="eyebrow text-skin-text" v-text="'Discussion'" />
+            <IH-arrow-sm-right class="-rotate-45 text-skin-text" />
+          </a>
         </div>
         <router-view :proposal="proposal" />
       </div>

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getNetwork, offchainNetworks } from '@/networks';
-import { getStampUrl, getCacheHash, _n, sanitizeUrl } from '@/helpers/utils';
+import { getStampUrl, getCacheHash, sanitizeUrl } from '@/helpers/utils';
 import { Choice } from '@/types';
 import { VotingPower } from '@/networks/types';
 
@@ -124,13 +124,12 @@ watchEffect(() => {
             }"
             class="flex items-center"
           >
-            <Link :is-active="route.name === 'proposal-votes'" text="Votes" class="inline-block" />
-            <span
-              v-if="proposal.vote_count"
-              class="inline-block bg-skin-border text-skin-link text-xs rounded-full px-[6px] ml-2"
-            >
-              {{ _n(proposal.vote_count, 'compact') }}
-            </span>
+            <Link
+              :is-active="route.name === 'proposal-votes'"
+              :count="proposal.vote_count"
+              text="Votes"
+              class="inline-block"
+            />
           </router-link>
           <a v-if="discussion" :href="discussion" target="_blank" class="flex items-center">
             <h4 class="eyebrow text-skin-text" v-text="'Discussion'" />

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -199,7 +199,7 @@ watchEffect(() => {
           </Vote>
         </template>
 
-        <template v-if="!proposal.cancelled && proposal.state !== 'pending'">
+        <template v-if="!proposal.cancelled && proposal.state !== 'pending' && proposal.vote_count">
           <h4 class="block eyebrow mb-2 mt-4 first:mt-1">Results</h4>
           <Results with-details :proposal="proposal" :decimals="votingPowerDecimals" />
         </template>

--- a/src/views/Proposal/Overview.vue
+++ b/src/views/Proposal/Overview.vue
@@ -91,7 +91,7 @@ async function handleCancelClick() {
 </script>
 
 <template>
-  <Container class="pt-5 !max-w-[630px] mx-0 md:mx-auto">
+  <Container class="pt-5 !max-w-[660px] mx-0 md:mx-auto">
     <div>
       <h1 class="mb-3 text-[36px]">
         {{ proposal.title || `Proposal #${proposal.proposal_id}` }}

--- a/src/views/Proposal/Overview.vue
+++ b/src/views/Proposal/Overview.vue
@@ -93,7 +93,7 @@ async function handleCancelClick() {
 <template>
   <Container class="pt-5 !max-w-[660px] mx-0 md:mx-auto">
     <div>
-      <h1 class="mb-3 text-[36px]">
+      <h1 class="mb-3 text-[36px] leading-10">
         {{ proposal.title || `Proposal #${proposal.proposal_id}` }}
         <span class="text-skin-text">{{ getProposalId(proposal) }}</span>
       </h1>

--- a/src/views/Proposal/Votes.vue
+++ b/src/views/Proposal/Votes.vue
@@ -155,17 +155,18 @@ watch([sortBy, choiceFilter], () => {
       </tr>
     </thead>
     <td v-if="!loaded" colspan="5">
-      <UiLoading class="p-4 block text-center" />
+      <UiLoading class="px-4 py-3 block" />
     </td>
     <template v-else>
       <tbody>
-        <td v-if="votes.length === 0" class="p-4 text-center" colspan="5">
-          There isn't any votes yet!
+        <td v-if="votes.length === 0" class="px-4 py-3" colspan="5">
+          <IH-exclamation-circle class="inline-block mr-2" />
+          <span v-text="'There are no votes here.'" />
         </td>
         <BlockInfiniteScroller :loading-more="loadingMore" @end-reached="handleEndReached">
           <template #loading>
             <td colspan="5">
-              <UiLoading class="p-4 block text-center" />
+              <UiLoading class="px-4 py-3 block" />
             </td>
           </template>
           <tr v-for="(vote, i) in votes" :key="i" class="border-b relative align-middle">

--- a/src/views/Space/Treasury.vue
+++ b/src/views/Space/Treasury.vue
@@ -142,13 +142,8 @@ watchEffect(() => {
         </a>
       </div>
       <div>
-        <div class="flex pl-4 border-b">
-          <Link
-            :is-active="page === 'tokens'"
-            text="Tokens"
-            class="pr-3"
-            @click="page = 'tokens'"
-          />
+        <div class="flex pl-4 border-b space-x-3">
+          <Link :is-active="page === 'tokens'" text="Tokens" @click="page = 'tokens'" />
           <Link :is-active="page === 'nfts'" text="NFTs" @click="page = 'nfts'" />
         </div>
         <div v-if="page === 'tokens'">


### PR DESCRIPTION
Closes #814 
Closes #818 

- Also this PR add markdown support for `backticks` you can try here: http://localhost:8080/#/s:balancer.eth/proposal/0x141051b2fe6f18e322539c0e54b2fb0d9872b6096f2c3fd71fa3bf27e5c7b8f8
- Increase width for proposal overview and editor to 660px
- Update loading layout on proposal votes page to be consistent with others loading
- Add border bottom on active tabs
- Truncate proposal preview title