### PR TITLE
feat: use Stamp API to resolve names

### DIFF
--- a/src/composables/useDelegates.ts
+++ b/src/composables/useDelegates.ts
@@ -1,6 +1,6 @@
 import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client/core';
 import gql from 'graphql-tag';
-import { getNames } from '@/helpers/ens';
+import { getNames } from '@/helpers/stamp';
 
 type ApiDelegate = {
   id: string;

--- a/src/composables/useWeb3.ts
+++ b/src/composables/useWeb3.ts
@@ -1,7 +1,7 @@
 import { Web3Provider } from '@ethersproject/providers';
 import { getInstance } from '@snapshot-labs/lock/plugins/vue3';
 import { formatUnits } from '@ethersproject/units';
-import { getNames } from '@/helpers/ens';
+import { getNames } from '@/helpers/stamp';
 import networks from '@/helpers/networks.json';
 
 networks['starknet'] = {

--- a/src/helpers/ens.ts
+++ b/src/helpers/ens.ts
@@ -1,37 +1,13 @@
-import { isAddress } from '@ethersproject/address';
 import { namehash } from '@ethersproject/hash';
 import { getProvider } from '@/helpers/provider';
 import { call } from '@/helpers/call';
 
-const abi = [
-  'function getNames(address[] addresses) view returns (string[] r)',
-  'function addr(bytes32 node) view returns (address r)'
-];
+const abi = ['function addr(bytes32 node) view returns (address r)'];
 
 const ensPublicResolvers = {
   1: '0x4976fb03c32e5b8cfe2b6ccb31c09ba78ebaba41',
   5: '0xd7a4F6473f32aC2Af804B3686AE8F1932bC35750'
 };
-
-export async function getNames(addresses: string[]) {
-  addresses = addresses.slice(0, 250).filter(isAddress);
-  if (addresses.length === 0) return {};
-  const network = 1;
-  const provider = getProvider(network);
-
-  try {
-    const names = await call(
-      provider,
-      abi,
-      ['0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C', 'getNames', [addresses]],
-      { blockTag: 'latest' }
-    );
-    return Object.fromEntries(addresses.map((address, i) => [address, names[i]]));
-  } catch (e) {
-    console.error('failed to reverse resolve names', e);
-    return {};
-  }
-}
 
 export async function resolveName(name: string, chainId: number) {
   const resolver = ensPublicResolvers[chainId];
@@ -45,5 +21,6 @@ export async function resolveName(name: string, chainId: number) {
   });
 
   if (address === '0x0000000000000000000000000000000000000000') return null;
+
   return address;
 }

--- a/src/helpers/stamp.ts
+++ b/src/helpers/stamp.ts
@@ -1,0 +1,22 @@
+export async function getNames(addresses: string[]): Promise<Record<string, string>> {
+  try {
+    const res = await fetch('https://stamp.fyi', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ method: 'lookup_addresses', params: addresses })
+    });
+    const data = (await res.json()).result;
+
+    const dataToLc = Object.fromEntries(Object.entries(data).map(([k, v]) => [k.toLowerCase(), v]));
+    const entries: any = addresses
+      .map(address => [address, dataToLc[address.toLowerCase()] || null])
+      .filter(([, name]) => name);
+
+    return Object.fromEntries(entries);
+  } catch (e) {
+    console.error('Failed to resolve names', e);
+    return {};
+  }
+}

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -21,7 +21,7 @@ import {
   joinHighlightUser
 } from './highlight';
 import { PaginationOpts, SpacesFilter, NetworkApi } from '@/networks/types';
-import { getNames } from '@/helpers/ens';
+import { getNames } from '@/helpers/stamp';
 import { CHOICES } from '@/helpers/constants';
 import { Space, Proposal, Vote, User, Transaction, NetworkID, ProposalState } from '@/types';
 import { ApiSpace, ApiProposal } from './types';

--- a/src/networks/offchain/api/index.ts
+++ b/src/networks/offchain/api/index.ts
@@ -7,7 +7,7 @@ import {
   VOTES_QUERY
 } from './queries';
 import { PaginationOpts, SpacesFilter, NetworkApi } from '@/networks/types';
-import { getNames } from '@/helpers/ens';
+import { getNames } from '@/helpers/stamp';
 import { Space, Proposal, Vote, User, NetworkID, ProposalState } from '@/types';
 import { ApiSpace, ApiProposal, ApiVote } from './types';
 
@@ -192,8 +192,8 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
 
       return data.votes.map(vote => {
         const formattedVote = formatVote(vote);
+        formattedVote.voter.name = names[vote.voter] || undefined;
 
-        formattedVote.voter.name = names[vote.voter] || null;
         return formattedVote;
       });
     },


### PR DESCRIPTION
Moving to Stamp RPC API to resolve names instead of doing requests on frontend, with this change we also resolve Lens and UnstoppableDomains names, and it includes a cache system. To test this change you can try delegates, votes page or others sections where we display ENS names.