### PR TITLE
feat: use ProposalStatusIcon for Proposal UiSelect

### DIFF
--- a/src/components/Ui/Select.vue
+++ b/src/components/Ui/Select.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts" generic="T extends string | number, U extends readonly Item<T>[]">
+import type { Component } from 'vue';
+
 export type Item<T extends string | number> = {
   key: T;
   label: string;
   indicator?: string;
+  component?: Component;
+  componentProps?: Record<string, unknown>;
 };
 
 const props = defineProps<{
@@ -37,6 +41,11 @@ const items = computed(() => props.items);
               class="w-[8px] h-[8px] rounded-full"
               :class="currentItem.indicator"
             />
+            <component
+              :is="currentItem.component"
+              v-else-if="currentItem.component"
+              v-bind="currentItem.componentProps"
+            />
             {{ currentItem.label }}
           </template>
         </button>
@@ -50,6 +59,7 @@ const items = computed(() => props.items);
           @click="() => emit('update:modelValue', item.key)"
         >
           <div v-if="item.indicator" class="w-[8px] h-[8px] rounded-full" :class="item.indicator" />
+          <component :is="item.component" v-else-if="item.component" v-bind="item.componentProps" />
           {{ item.label }}
         </button>
       </UiDropdownItem>

--- a/src/views/Space/Proposals.vue
+++ b/src/views/Space/Proposals.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ProposalStatusIcon from '@/components/ProposalStatusIcon.vue';
 import { getNetwork, supportsNullCurrent } from '@/networks';
 import { Space } from '@/types';
 import { VotingPower } from '@/networks/types';
@@ -13,6 +14,11 @@ const proposalsStore = useProposalsStore();
 const votingPowers = ref([] as VotingPower[]);
 const loadingVotingPower = ref(true);
 const filter = ref('any' as 'any' | 'active' | 'pending' | 'closed');
+
+const selectIconBaseProps = {
+  width: 16,
+  height: 16
+};
 
 const network = computed(() => getNetwork(props.space.network));
 const proposalsRecord = computed(
@@ -84,10 +90,28 @@ watchEffect(() => {
           gap="12px"
           placement="left"
           :items="[
-            { key: 'any', label: 'Any' },
-            { key: 'pending', label: 'Pending', indicator: 'bg-yellow-500' },
-            { key: 'active', label: 'Active', indicator: 'bg-green' },
-            { key: 'closed', label: 'Closed', indicator: 'bg-red' }
+            {
+              key: 'any',
+              label: 'Any'
+            },
+            {
+              key: 'pending',
+              label: 'Pending',
+              component: ProposalStatusIcon,
+              componentProps: { ...selectIconBaseProps, state: 'pending' }
+            },
+            {
+              key: 'active',
+              label: 'Active',
+              component: ProposalStatusIcon,
+              componentProps: { ...selectIconBaseProps, state: 'active' }
+            },
+            {
+              key: 'closed',
+              label: 'Closed',
+              component: ProposalStatusIcon,
+              componentProps: { ...selectIconBaseProps, state: 'passed' }
+            }
           ]"
         />
       </div>


### PR DESCRIPTION
### Summary

A bit weird now, because we use `passed` for `closed` (so it actually includes passed + executed + rejected).

Closes: https://github.com/snapshot-labs/sx-ui/issues/817

### How to test

1. Go to http://localhost:8080/#/sep:0xea4322cc9be9ae0c9400984209c858031b1c4438/proposals

### Screenshots

<img width="550" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/e5eb4a2e-b489-4159-bab3-df07f6fe0e70">

