### PR TITLE
feat: use spaces query instead of ranking

### DIFF
--- a/src/networks/offchain/api/index.ts
+++ b/src/networks/offchain/api/index.ts
@@ -252,11 +252,13 @@ export function createApi(uri: string, networkId: NetworkID): NetworkApi {
         variables: {
           first: Math.min(limit, 20),
           skip,
-          ...filter
+          where: {
+            ...filter
+          }
         }
       });
 
-      return data.ranking.items.map(space => formatSpace(space, networkId));
+      return data.spaces.map(space => formatSpace(space, networkId));
     },
     loadSpace: async (id: string): Promise<Space | null> => {
       const { data } = await apollo.query({

--- a/src/networks/offchain/api/queries.ts
+++ b/src/networks/offchain/api/queries.ts
@@ -77,15 +77,9 @@ export const PROPOSALS_QUERY = gql`
 `;
 
 export const SPACES_RANKING_QUERY = gql`
-  query Ranking($first: Int, $skip: Int, $search: String, $network: String, $category: String) {
-    ranking(
-      first: $first
-      skip: $skip
-      where: { search: $search, network: $network, category: $category }
-    ) {
-      items {
-        ...spaceFragment
-      }
+  query ($first: Int, $skip: Int, $where: SpaceWhere) {
+    spaces(first: $first, skip: $skip, where: $where) {
+      ...spaceFragment
     }
   }
   ${SPACE_FRAGMENT}


### PR DESCRIPTION
### Summary

Ranking is better for explore page, but we don't use it on SX-UI. We can't filter items using ranking query, we have to use regular spaces query.


Closes: https://github.com/snapshot-labs/sx-ui/issues/815

### How to test

1. Favorite this space: http://localhost:8080/#/s:hydraventures.eth
2. It shows up on favorites page.

