### PR TITLE
feat: align loading and empty messages to left

### DIFF
--- a/src/views/Proposal/Votes.vue
+++ b/src/views/Proposal/Votes.vue
@@ -159,7 +159,7 @@ watch([sortBy, choiceFilter], () => {
     </td>
     <template v-else>
       <tbody>
-        <td v-if="votes.length === 0" class="px-4 py-3" colspan="5">
+        <td v-if="votes.length === 0" class="px-4 py-3 flex items-center" colspan="5">
           <IH-exclamation-circle class="inline-block mr-2" />
           <span v-text="'There are no votes here.'" />
         </td>

--- a/src/views/Space/Delegates.vue
+++ b/src/views/Space/Delegates.vue
@@ -118,15 +118,15 @@ watchEffect(() => {
             </tr>
           </thead>
           <td v-if="loading" colspan="3">
-            <UiLoading class="p-4 block text-center" />
+            <UiLoading class="p-4 block" />
           </td>
           <template v-else>
             <tbody>
-              <td v-if="loaded && delegates.length === 0" class="p-4 text-center" colspan="3">
+              <td v-if="loaded && delegates.length === 0" class="p-4 flex items-center" colspan="3">
                 <IH-exclamation-circle class="inline-block mr-2" />
                 There are no delegates.
               </td>
-              <td v-else-if="loaded && failed" class="p-4 text-center" colspan="3">
+              <td v-else-if="loaded && failed" class="p-4 flex items-center" colspan="3">
                 <IH-exclamation-circle class="inline-block mr-2" />
                 Failed to load delegates.
               </td>
@@ -160,7 +160,7 @@ watchEffect(() => {
                 </tr>
                 <template #loading>
                   <td colspan="3">
-                    <UiLoading class="p-4 block text-center" />
+                    <UiLoading class="p-4 block" />
                   </td>
                 </template>
               </BlockInfiniteScroller>

--- a/src/views/Space/Delegates.vue
+++ b/src/views/Space/Delegates.vue
@@ -118,15 +118,19 @@ watchEffect(() => {
             </tr>
           </thead>
           <td v-if="loading" colspan="3">
-            <UiLoading class="p-4 block" />
+            <UiLoading class="px-4 py-3 block" />
           </td>
           <template v-else>
             <tbody>
-              <td v-if="loaded && delegates.length === 0" class="p-4 flex items-center" colspan="3">
+              <td
+                v-if="loaded && delegates.length === 0"
+                class="px-4 py-3 flex items-center"
+                colspan="3"
+              >
                 <IH-exclamation-circle class="inline-block mr-2" />
                 There are no delegates.
               </td>
-              <td v-else-if="loaded && failed" class="p-4 flex items-center" colspan="3">
+              <td v-else-if="loaded && failed" class="px-4 py-3 flex items-center" colspan="3">
                 <IH-exclamation-circle class="inline-block mr-2" />
                 Failed to load delegates.
               </td>


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/800

Votes already has loading indicators aligned to the left. Was it supposed to update votes modal instead? @bonustrack 

### How to test

1. Check http://localhost:8080/#/sep:0xea4322cc9be9ae0c9400984209c858031b1c4438/delegates
2. Check http://localhost:8080/#/sep:0xea4322cc9be9ae0c9400984209c858031b1c4438/proposal/6/votes