### PR TITLE
fix: convert choices to native format

### DIFF
--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -22,6 +22,8 @@ import type {
 import type { Space, SpaceMetadata, StrategyParsedMetadata, Proposal, NetworkID } from '@/types';
 import { getProvider } from '@/helpers/provider';
 
+type Choice = 0 | 1 | 2;
+
 const CONFIGS: Partial<Record<NetworkID, NetworkConfig>> = {
   sn: starknetMainnet,
   'sn-tn': starknetGoerli1
@@ -337,12 +339,17 @@ export function createActions(
         })
       );
 
+      let convertedChoice: Choice = 0;
+      if (choice === 1) convertedChoice = 1;
+      if (choice === 2) convertedChoice = 0;
+      if (choice === 3) convertedChoice = 2;
+
       const data = {
         space: proposal.space.id,
         authenticator,
         strategies: strategiesWithMetadata,
         proposal: proposal.proposal_id as number,
-        choice
+        choice: convertedChoice
       };
 
       if (relayerType === 'starknet') {


### PR DESCRIPTION
### Summary

Now sx-starknet uses same enum as sx-evm so we need to convert it.

Closes: https://github.com/snapshot-labs/sx-ui/issues/826

### How to test

1. Create proposal and vote to abstain.
2. It works and you should see it as abstained vote.
