### PR TITLE
fix: Disable hover on devices that don't support it

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,9 @@ const withOpacity = variableName => {
 };
 
 module.exports = {
+  future: {
+    hoverOnlyWhenSupported: true
+  },
   content: ['./index.html', './src/**/*.{js,ts,vue}'],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
Closes https://github.com/snapshot-labs/sx-ui/issues/755

### Summary
Fix is related to https://github.com/tailwindlabs/tailwindcss/pull/8394
> Again this will be a breaking change in v4, but only for evil people who were writing code like hidden group-hover:block. Until then, everything will work the same, and you can opt-in to this if you want to start using it now.

So the problem is with the `group-hover` class and IOS devices don't support hover events, on the first click it assumes as `hover`

This change will disables on mobile devices but hovers should still work on desktops 
An alternate way is to handle click with JS

### How to test

1. Open the explore page on IOS Safari
2. Click on any space
3. Before fix: It will take two clicks to go to space page
4. After fix: It will take one click to go to space page
5. Also try same on desktops, it should display a star on hover and redirect to space page on click


### Self-review checklist
- [x] I have performed a full self-review of my changes
- [x] Tested on IOS safari
- [x] Tested on desktop chrome
- [x] Test on Android chrome
- [ ] I have tested my changes on a preview deployment
- [x] I have tested my changes on different screen sizes (sm, md)
