### PR TITLE
feat: index multiple delegations

### DIFF
--- a/src/components/Block/Delegates.vue
+++ b/src/components/Block/Delegates.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { _n, shorten } from '@/helpers/utils';
+import { getNetwork } from '@/networks';
+import { Space, SpaceMetadataDelegation } from '@/types';
+
+const props = defineProps<{ space: Space; delegation: SpaceMetadataDelegation }>();
+
+const delegateModalOpen = ref(false);
+const sortBy = ref(
+  'delegatedVotes-desc' as
+    | 'delegatedVotes-desc'
+    | 'delegatedVotes-asc'
+    | 'tokenHoldersRepresentedAmount-desc'
+    | 'tokenHoldersRepresentedAmount-asc'
+);
+const { setTitle } = useTitle();
+const { loading, loadingMore, loaded, failed, hasMore, delegates, fetch, fetchMore, reset } =
+  useDelegates(props.delegation.apiUrl as string);
+
+const currentNetwork = computed(() => {
+  try {
+    return getNetwork(props.space.network);
+  } catch (e) {
+    return null;
+  }
+});
+
+function handleSortChange(type: 'delegatedVotes' | 'tokenHoldersRepresentedAmount') {
+  if (sortBy.value.startsWith(type)) {
+    sortBy.value = sortBy.value.endsWith('desc') ? `${type}-asc` : `${type}-desc`;
+  } else {
+    sortBy.value = `${type}-desc`;
+  }
+}
+
+async function handleEndReached() {
+  if (!hasMore.value) return;
+
+  await fetchMore(sortBy.value);
+}
+
+onMounted(() => {
+  if (!props.delegation.apiUrl) return;
+
+  fetch(sortBy.value);
+});
+
+watch([sortBy], () => {
+  reset();
+  fetch(sortBy.value);
+});
+
+watchEffect(() => {
+  setTitle(`Delegates - ${props.space.name}`);
+});
+</script>
+
+<template>
+  <div v-if="!currentNetwork || !delegation.apiUrl" class="p-4 flex items-center text-skin-link">
+    <IH-exclamation-circle class="inline-block mr-2" />
+    No delegation API configured.
+  </div>
+  <template v-else>
+    <div v-if="delegation.contractAddress" class="p-4 space-x-2 flex">
+      <div class="flex-auto" />
+      <UiTooltip title="Delegate">
+        <UiButton class="!px-0 w-[46px]" @click="delegateModalOpen = true">
+          <IH-user-add class="inline-block" />
+        </UiButton>
+      </UiTooltip>
+    </div>
+    <div class="space-y-3">
+      <div>
+        <Label label="Delegates" sticky />
+
+        <table class="text-left table-fixed w-full">
+          <colgroup>
+            <col class="w-auto" />
+            <col class="w-auto md:w-[120px]" />
+            <col class="w-0 md:w-[200px]" />
+          </colgroup>
+          <thead
+            class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 after:border-b after:absolute after:w-full"
+          >
+            <tr class="bg-skin-border/10">
+              <th class="pl-4 font-medium">
+                <span class="relative bottom-[1px]">Delegatee</span>
+              </th>
+              <th class="hidden md:table-cell">
+                <button
+                  class="relative bottom-[1px] flex items-center justify-end min-w-0 w-full font-medium hover:text-skin-link"
+                  @click="handleSortChange('tokenHoldersRepresentedAmount')"
+                >
+                  <span>Delegators</span>
+                  <IH-arrow-sm-down
+                    v-if="sortBy === 'tokenHoldersRepresentedAmount-desc'"
+                    class="ml-1"
+                  />
+                  <IH-arrow-sm-up
+                    v-else-if="sortBy === 'tokenHoldersRepresentedAmount-asc'"
+                    class="ml-1"
+                  />
+                </button>
+              </th>
+              <th>
+                <button
+                  class="relative bottom-[1px] flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link pr-4"
+                  @click="handleSortChange('delegatedVotes')"
+                >
+                  <span class="truncate">Voting power</span>
+                  <IH-arrow-sm-down v-if="sortBy === 'delegatedVotes-desc'" class="ml-1" />
+                  <IH-arrow-sm-up v-else-if="sortBy === 'delegatedVotes-asc'" class="ml-1" />
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <td v-if="loading" colspan="3">
+            <UiLoading class="px-4 py-3 block" />
+          </td>
+          <template v-else>
+            <tbody>
+              <td
+                v-if="loaded && delegates.length === 0"
+                class="px-4 py-3 flex items-center"
+                colspan="3"
+              >
+                <IH-exclamation-circle class="inline-block mr-2" />
+                There are no delegates.
+              </td>
+              <td v-else-if="loaded && failed" class="px-4 py-3 flex items-center" colspan="3">
+                <IH-exclamation-circle class="inline-block mr-2" />
+                Failed to load delegates.
+              </td>
+              <BlockInfiniteScroller :loading-more="loadingMore" @end-reached="handleEndReached">
+                <tr v-for="(delegate, i) in delegates" :key="i" class="border-b relative">
+                  <td class="text-left flex items-center pl-4 py-3">
+                    <Stamp :id="delegate.id" :size="32" class="mr-3" />
+                    <div class="overflow-hidden">
+                      <a :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')">
+                        <div class="leading-[22px]">
+                          <h4
+                            class="text-skin-link truncate"
+                            v-text="delegate.name || shorten(delegate.id)"
+                          />
+                          <div class="text-sm truncate" v-text="shorten(delegate.id)" />
+                        </div>
+                      </a>
+                    </div>
+                  </td>
+                  <td class="hidden md:table-cell align-middle text-right">
+                    <h4
+                      class="text-skin-link"
+                      v-text="_n(delegate.tokenHoldersRepresentedAmount)"
+                    />
+                    <div class="text-sm" v-text="`${delegate.delegatorsPercentage.toFixed(3)}%`" />
+                  </td>
+                  <td class="text-right pr-4 align-middle">
+                    <h4 class="text-skin-link" v-text="_n(delegate.delegatedVotes)" />
+                    <div class="text-sm" v-text="`${delegate.votesPercentage.toFixed(3)}%`" />
+                  </td>
+                </tr>
+                <template #loading>
+                  <td colspan="3">
+                    <UiLoading class="p-4 block" />
+                  </td>
+                </template>
+              </BlockInfiniteScroller>
+            </tbody>
+          </template>
+        </table>
+      </div>
+    </div>
+    <teleport to="#modal">
+      <ModalDelegate
+        :open="delegateModalOpen"
+        :space="space"
+        :delegation="delegation"
+        @close="delegateModalOpen = false"
+      />
+    </teleport>
+  </template>
+</template>

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -2,11 +2,13 @@
 import { MAX_SYMBOL_LENGTH } from '@/helpers/constants';
 import { validateForm } from '@/helpers/validation';
 import { getNetwork, enabledNetworks } from '@/networks';
+import { SpaceMetadataDelegation } from '@/types';
 
 const props = withDefaults(
   defineProps<{
     showTitle?: boolean;
     form: any;
+    delegationsValue: SpaceMetadataDelegation[];
     id?: string;
     space?: {
       id: string;
@@ -20,9 +22,14 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   (e: 'errors', value: any);
+  (e: 'delegations', value: SpaceMetadataDelegation[]);
   (e: 'pick', field: any);
   (e: 'no-network');
 }>();
+
+const delegationsModalOpen = ref(false);
+const editedDelegation = ref<number | null>(null);
+const delegationInitialState = ref<SpaceMetadataDelegation | null>(null);
 
 const availableNetworks = enabledNetworks
   .map(id => {
@@ -108,48 +115,50 @@ const definition = computed(() => {
               minLength: 1
             }
           }
-        : {}),
-      delegationApiType: {
-        type: ['string', 'null'],
-        enum: [null, 'governor-subgraph'],
-        options: [
-          { id: null, name: 'No delegation API' },
-          { id: 'governor-subgraph', name: 'Governor subgraph' }
-        ],
-        title: 'Delegation API type',
-        nullable: true
-      },
-      ...(props.form.delegationApiType !== null
-        ? {
-            delegationApiUrl: {
-              type: 'string',
-              format: 'uri',
-              title: 'Delegation API URL',
-              examples: ['https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2']
-            },
-            delegationContractNetwork: {
-              type: 'string',
-              enum: [null, ...availableNetworks.map(network => network.id)],
-              options: [{ id: null, name: 'No delegation contract' }, ...availableNetworks],
-              title: 'Delegation contract network',
-              nullable: true
-            },
-            ...(props.form.delegationContractNetwork !== null
-              ? {
-                  delegationContractAddress: {
-                    type: 'string',
-                    title: 'Delegation contract address',
-                    examples: ['0x0000…'],
-                    format: 'address',
-                    minLength: 1
-                  }
-                }
-              : {})
-          }
         : {})
     }
   };
 });
+
+const formErrors = computed(() =>
+  validateForm(definition.value, props.form, { skipEmptyOptionalFields: true })
+);
+
+function addDelegationConfig(config: SpaceMetadataDelegation) {
+  const newValue = [...props.delegationsValue];
+
+  if (editedDelegation.value !== null) {
+    newValue[editedDelegation.value] = config;
+    editedDelegation.value = null;
+  } else {
+    newValue.push(config);
+  }
+
+  emit('delegations', newValue);
+}
+
+function addDelegation() {
+  editedDelegation.value = null;
+  delegationInitialState.value = null;
+  delegationsModalOpen.value = true;
+}
+
+function editDelegation(index: number) {
+  editedDelegation.value = index;
+  delegationInitialState.value = props.delegationsValue[index];
+
+  delegationsModalOpen.value = true;
+}
+
+function deleteDelegation(index: number) {
+  const newValue = [
+    ...props.delegationsValue.slice(0, index),
+    ...props.delegationsValue.slice(index + 1)
+  ];
+  emit('delegations', newValue);
+}
+
+watch(formErrors, value => emit('errors', value));
 
 watch(
   () => props.form.walletNetwork,
@@ -157,12 +166,6 @@ watch(
     if (to === null) emit('no-network');
   }
 );
-
-const formErrors = computed(() =>
-  validateForm(definition.value, props.form, { skipEmptyOptionalFields: true })
-);
-
-watch(formErrors, value => emit('errors', value));
 
 onMounted(() => {
   emit('errors', formErrors.value);
@@ -179,5 +182,32 @@ onMounted(() => {
       :definition="definition"
       @pick="field => emit('pick', field)"
     />
+    <h4 class="eyebrow mb-2">Delegations</h4>
+    <div
+      v-for="(delegation, i) in props.delegationsValue"
+      :key="i"
+      class="flex justify-between items-center rounded-lg border px-4 py-3 mb-3 text-skin-link"
+    >
+      <div class="flex min-w-0">
+        <div class="whitespace-nowrap">{{ delegation.name }}</div>
+      </div>
+      <div class="flex gap-3">
+        <a @click="editDelegation(i)">
+          <IH-pencil />
+        </a>
+        <a @click="deleteDelegation(i)">
+          <IH-trash />
+        </a>
+      </div>
+    </div>
+    <UiButton class="w-full rounded-lg" @click="addDelegation">Add new delegation API</UiButton>
   </div>
+  <teleport to="#modal">
+    <ModalDelegationConfig
+      :open="delegationsModalOpen"
+      :initial-state="delegationInitialState ?? undefined"
+      @close="delegationsModalOpen = false"
+      @add="addDelegationConfig"
+    />
+  </teleport>
 </template>

--- a/src/components/Block/SpaceFormProfile.vue
+++ b/src/components/Block/SpaceFormProfile.vue
@@ -200,7 +200,7 @@ onMounted(() => {
         </a>
       </div>
     </div>
-    <UiButton class="w-full rounded-lg" @click="addDelegation">Add new delegation API</UiButton>
+    <UiButton class="w-full" @click="addDelegation">Add delegation</UiButton>
   </div>
   <teleport to="#modal">
     <ModalDelegationConfig

--- a/src/components/Modal/Delegate.vue
+++ b/src/components/Modal/Delegate.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { clone } from '@/helpers/utils';
 import { getValidator } from '@/helpers/validation';
-import { NetworkID, Space } from '@/types';
+import { NetworkID, Space, SpaceMetadataDelegation } from '@/types';
 
 const DEFAULT_FORM_STATE = {
   delegatee: ''
@@ -10,6 +10,7 @@ const DEFAULT_FORM_STATE = {
 const props = defineProps<{
   open: boolean;
   space: Space;
+  delegation: SpaceMetadataDelegation;
   initialState?: any;
 }>();
 
@@ -46,13 +47,16 @@ const sending = ref(false);
 const formErrors = ref({} as Record<string, any>);
 
 async function handleSubmit() {
-  if (!props.space.delegation_contract) return;
+  if (!props.delegation.contractAddress) return;
   sending.value = true;
 
   try {
-    const [networkId] = props.space.delegation_contract.split(':');
-
-    await delegate(props.space, networkId as NetworkID, form.delegatee);
+    await delegate(
+      props.space,
+      props.delegation.contractNetwork as NetworkID,
+      form.delegatee,
+      `${props.delegation.contractNetwork}:${props.delegation.contractAddress}`
+    );
     emit('close');
   } catch (e) {
     console.log('delegation failed', e);

--- a/src/components/Modal/DelegationConfig.vue
+++ b/src/components/Modal/DelegationConfig.vue
@@ -122,13 +122,13 @@ watch(
 <template>
   <UiModal :open="open" @close="$emit('close')">
     <template #header>
-      <h3 v-text="'Add delegation API'" />
+      <h3 v-text="'Add delegation'" />
     </template>
     <div class="s-box p-4">
       <SIObject :model-value="form" :error="formErrors" :definition="definition" />
     </div>
     <template #footer>
-      <UiButton class="w-full" :disabled="!formValid" @click="handleSubmit"> Confirm </UiButton>
+      <UiButton class="w-full" :disabled="!formValid" @click="handleSubmit">Confirm</UiButton>
     </template>
   </UiModal>
 </template>

--- a/src/components/Modal/DelegationConfig.vue
+++ b/src/components/Modal/DelegationConfig.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import { getNetwork, enabledNetworks } from '@/networks';
+import { validateForm } from '@/helpers/validation';
+import { SpaceMetadataDelegation } from '@/types';
+import { clone } from '@/helpers/utils';
+
+const DEFAULT_FORM_STATE = {
+  name: '',
+  apiType: null,
+  apiUrl: null,
+  contractNetwork: null,
+  contractAddress: null
+};
+
+const form: Ref<SpaceMetadataDelegation> = ref(clone(DEFAULT_FORM_STATE));
+
+const props = defineProps<{
+  open: boolean;
+  initialState?: SpaceMetadataDelegation;
+}>();
+const emit = defineEmits<{
+  (e: 'add', config: SpaceMetadataDelegation);
+  (e: 'close'): void;
+}>();
+
+const availableNetworks = enabledNetworks
+  .map(id => {
+    const { name, readOnly } = getNetwork(id);
+
+    return {
+      id,
+      name,
+      readOnly
+    };
+  })
+  .filter(network => !network.readOnly);
+
+const definition = computed(() => {
+  return {
+    type: 'object',
+    title: 'Space',
+    additionalProperties: true,
+    required: ['name', 'apiType', 'apiUrl'],
+    properties: {
+      name: {
+        type: 'string',
+        title: 'Name',
+        minLength: 1,
+        examples: ['Delegation API name']
+      },
+      apiType: {
+        type: ['string', 'null'],
+        enum: [null, 'governor-subgraph'],
+        options: [
+          { id: null, name: 'No delegation API' },
+          { id: 'governor-subgraph', name: 'Governor subgraph' }
+        ],
+        title: 'Delegation API type',
+        nullable: true
+      },
+      ...(form.value.apiType !== null
+        ? {
+            apiUrl: {
+              type: 'string',
+              format: 'uri',
+              title: 'Delegation API URL',
+              examples: ['https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2']
+            },
+            contractNetwork: {
+              type: 'string',
+              enum: [null, ...availableNetworks.map(network => network.id)],
+              options: [{ id: null, name: 'No delegation contract' }, ...availableNetworks],
+              title: 'Delegation contract network',
+              nullable: true
+            },
+            ...(form.value.contractNetwork !== null
+              ? {
+                  contractAddress: {
+                    type: 'string',
+                    title: 'Delegation contract address',
+                    examples: ['0x0000…'],
+                    format: 'address',
+                    minLength: 1
+                  }
+                }
+              : {})
+          }
+        : {})
+    }
+  };
+});
+
+const formErrors = computed(() =>
+  validateForm(definition.value, form.value, { skipEmptyOptionalFields: true })
+);
+
+const formValid = computed(() => {
+  return (
+    Object.keys(formErrors.value).length === 0 &&
+    form.value.apiType !== null &&
+    form.value.apiUrl !== ''
+  );
+});
+
+async function handleSubmit() {
+  emit('add', form.value);
+  emit('close');
+}
+
+watch(
+  () => props.open,
+  () => {
+    if (props.initialState) {
+      form.value = clone(props.initialState);
+    } else {
+      form.value = clone(DEFAULT_FORM_STATE);
+    }
+  }
+);
+</script>
+
+<template>
+  <UiModal :open="open" @close="$emit('close')">
+    <template #header>
+      <h3 v-text="'Add delegation API'" />
+    </template>
+    <div class="s-box p-4">
+      <SIObject :model-value="form" :error="formErrors" :definition="definition" />
+    </div>
+    <template #footer>
+      <UiButton class="w-full" :disabled="!formValid" @click="handleSubmit"> Confirm </UiButton>
+    </template>
+  </UiModal>
+</template>

--- a/src/components/Modal/EditSpace.vue
+++ b/src/components/Modal/EditSpace.vue
@@ -14,10 +14,7 @@ const DEFAULT_FORM_STATE: SpaceMetadata = {
   votingPowerSymbol: '',
   walletNetwork: null,
   walletAddress: null,
-  delegationApiType: null,
-  delegationApiUrl: null,
-  delegationContractAddress: null,
-  delegationContractNetwork: null
+  delegations: []
 };
 
 const props = defineProps<{
@@ -73,8 +70,7 @@ watch(
     form.discord = props.space.discord;
     form.twitter = props.space.twitter;
     form.votingPowerSymbol = props.space.voting_power_symbol;
-    form.delegationApiType = props.space.delegation_api_type;
-    form.delegationApiUrl = props.space.delegation_api_url;
+    form.delegations = props.space.delegations;
 
     const [walletNetwork, walletAddress] = props.space.wallet.split(':');
     if (walletNetwork && walletAddress) {
@@ -83,19 +79,6 @@ watch(
     } else {
       form.walletNetwork = null;
       form.walletAddress = null;
-    }
-
-    if (props.space.delegation_contract) {
-      const [delegationContractNetwork, delegationContractAddress] =
-        props.space.delegation_contract.split(':');
-
-      if (delegationContractNetwork && delegationContractAddress) {
-        form.delegationContractNetwork = delegationContractNetwork as NetworkID;
-        form.delegationContractAddress = delegationContractAddress;
-      } else {
-        form.delegationContractNetwork = null;
-        form.delegationContractAddress = null;
-      }
     }
   }
 );
@@ -134,6 +117,8 @@ watch(
       :space="space"
       :show-title="false"
       :form="form"
+      :delegations-value="form.delegations"
+      @delegations="v => (form.delegations = v)"
       @pick="handlePick"
       @no-network="form.walletAddress = null"
       @errors="v => (formErrors = v)"

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -39,7 +39,7 @@ const navigationConfig = computed(() => ({
       name: 'Proposals',
       icon: IHNewspaper
     },
-    ...(space.value?.delegation_api_url
+    ...(space.value?.delegations && space.value.delegations.length > 0
       ? {
           delegates: {
             name: 'Delegates',

--- a/src/composables/useActions.ts
+++ b/src/composables/useActions.ts
@@ -489,12 +489,23 @@ export function useActions() {
     uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, space.network);
   }
 
-  async function delegate(space: Space, networkId: NetworkID, delegatee: string) {
+  async function delegate(
+    space: Space,
+    networkId: NetworkID,
+    delegatee: string,
+    delegationContract: string
+  ) {
     if (!web3.value.account) return await forceLogin();
 
     const network = getReadWriteNetwork(networkId);
 
-    const receipt = await network.actions.delegate(auth.web3, space, networkId, delegatee);
+    const receipt = await network.actions.delegate(
+      auth.web3,
+      space,
+      networkId,
+      delegatee,
+      delegationContract
+    );
     console.log('Receipt', receipt);
 
     uiStore.addPendingTransaction(receipt.transaction_hash || receipt.hash, networkId);

--- a/src/helpers/__tests__/utils.test.ts
+++ b/src/helpers/__tests__/utils.test.ts
@@ -17,11 +17,15 @@ describe('utils', () => {
         votingPowerSymbol: 'VOTE',
         walletNetwork: 'gor',
         walletAddress: '0x000000000000000000000000000000000000dead',
-        delegationApiType: 'governor-subgraph',
-        delegationApiUrl:
-          'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2',
-        delegationContractNetwork: 'gor',
-        delegationContractAddress: '0x000000000000000000000000000000000000dead'
+        delegations: [
+          {
+            name: 'sample',
+            apiType: 'governor-subgraph',
+            apiUrl: 'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2',
+            contractNetwork: 'gor',
+            contractAddress: '0x000000000000000000000000000000000000dead'
+          }
+        ]
       });
 
       expect(metadata).toEqual({
@@ -36,10 +40,14 @@ describe('utils', () => {
           twitter: 'SnapshotLabs',
           discord: 'snapshot',
           wallets: ['gor:0x000000000000000000000000000000000000dead'],
-          delegation_api_type: 'governor-subgraph',
-          delegation_api_url:
-            'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2',
-          delegation_contract: 'gor:0x000000000000000000000000000000000000dead'
+          delegations: [
+            {
+              name: 'sample',
+              api_type: 'governor-subgraph',
+              api_url: 'https://thegraph.com/hosted-service/subgraph/arr00/uniswap-governance-v2',
+              contract: 'gor:0x000000000000000000000000000000000000dead'
+            }
+          ]
         }
       });
     });

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -308,15 +308,18 @@ export function createErc1155Metadata(
     description: metadata.description,
     external_url: metadata.externalUrl,
     properties: {
-      delegation_api_type: metadata.delegationApiType,
-      delegation_api_url: metadata.delegationApiUrl,
-      delegation_contract: `${metadata.delegationContractNetwork}:${metadata.delegationContractAddress}`,
       voting_power_symbol: metadata.votingPowerSymbol,
       cover: metadata.cover,
       github: metadata.github,
       twitter: metadata.twitter,
       discord: metadata.discord,
       wallets,
+      delegations: metadata.delegations.map(delegation => ({
+        name: delegation.name,
+        api_type: delegation.apiType,
+        api_url: delegation.apiUrl,
+        contract: `${delegation.contractNetwork}:${delegation.contractAddress}`
+      })),
       ...extraProperties
     }
   };

--- a/src/networks/common/graphqlApi/index.ts
+++ b/src/networks/common/graphqlApi/index.ts
@@ -94,9 +94,19 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     discord: space.metadata.discord,
     voting_power_symbol: space.metadata.voting_power_symbol,
     wallet: space.metadata.wallet,
-    delegation_api_type: space.metadata.delegation_api_type,
-    delegation_api_url: space.metadata.delegation_api_url,
-    delegation_contract: space.metadata.delegation_contract,
+    delegations: space.metadata.delegations.map(delegation => {
+      const { name, api_type, api_url, contract } = JSON.parse(delegation);
+
+      const [network, address] = contract.split(':');
+
+      return {
+        name: name,
+        apiType: api_type,
+        apiUrl: api_url,
+        contractNetwork: network === 'null' ? null : network,
+        contractAddress: address === 'null' ? null : address
+      };
+    }),
     executors: space.metadata.executors,
     executors_types: space.metadata.executors_types,
     voting_power_validation_strategies_parsed_metadata: processStrategiesMetadata(

--- a/src/networks/common/graphqlApi/queries.ts
+++ b/src/networks/common/graphqlApi/queries.ts
@@ -14,9 +14,7 @@ const SPACE_FRAGMENT = gql`
       discord
       voting_power_symbol
       wallet
-      delegation_api_type
-      delegation_api_url
-      delegation_contract
+      delegations
       executors
       executors_types
     }

--- a/src/networks/common/graphqlApi/types.ts
+++ b/src/networks/common/graphqlApi/types.ts
@@ -25,9 +25,7 @@ export type ApiSpace = {
     wallet: string;
     executors: string[];
     executors_types: string[];
-    delegation_api_type: string | null;
-    delegation_api_url: string | null;
-    delegation_contract: string | null;
+    delegations: string[];
   };
   controller: string;
   voting_delay: number;

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -495,12 +495,16 @@ export function createActions(
         { noWait: isContract }
       );
     },
-    delegate: async (web3: Web3Provider, space: Space, networkId: NetworkID, delegatee: string) => {
-      if (!space.delegation_contract) throw new Error('Delegation contract missing');
-
+    delegate: async (
+      web3: Web3Provider,
+      space: Space,
+      networkId: NetworkID,
+      delegatee: string,
+      delegationContract: string
+    ) => {
       await verifyNetwork(web3, CHAIN_IDS[networkId]);
 
-      const [, contractAddress] = space.delegation_contract.split(':');
+      const [, contractAddress] = delegationContract.split(':');
 
       const votesContract = new Contract(
         contractAddress,

--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -29,7 +29,7 @@ export const METADATA: Record<string, Metadata> = {
   arb1: {
     name: 'Arbitrum One',
     chainId: 42161,
-    apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-arbitrum/version/latest',
+    apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-arbitrum/v0.0.17', // TODO: change to use latest, it's stuck syncing right now, hardcoding so we have working UI
     avatar: 'ipfs://bafkreic2p3zzafvz34y4tnx2kaoj6osqo66fpdo3xnagocil452y766gdq',
     blockTime: 0.26082
   },

--- a/src/networks/offchain/api/index.ts
+++ b/src/networks/offchain/api/index.ts
@@ -47,9 +47,17 @@ function formatSpace(space: ApiSpace, networkId: NetworkID): Space {
     max_voting_period: space.voting.period ?? 0,
     proposal_threshold: space.voting.quorum?.toString() ?? '0',
     wallet,
-    delegation_api_type: space.delegationPortal?.delegationType ?? null,
-    delegation_api_url: space.delegationPortal?.delegationApi ?? null,
-    delegation_contract: space.delegationPortal?.delegationContract ?? null,
+    delegations: space.delegationPortal
+      ? [
+          {
+            name: null,
+            apiType: space.delegationPortal?.delegationType ?? null,
+            apiUrl: space.delegationPortal?.delegationApi ?? null,
+            contractNetwork: null,
+            contractAddress: space.delegationPortal?.delegationContract ?? null
+          }
+        ]
+      : [],
     // NOTE: ignored
     created: 0,
     authenticators: [],

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -154,7 +154,13 @@ export type NetworkActions = ReadOnlyNetworkActions & {
     votingStrategiesToRemove: number[],
     validationStrategy: StrategyConfig
   );
-  delegate(web3: Web3Provider, space: Space, networkId: NetworkID, delegatee: string);
+  delegate(
+    web3: Web3Provider,
+    space: Space,
+    networkId: NetworkID,
+    delegatee: string,
+    delegationContract: string
+  );
   send(envelope: any): Promise<any>;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,14 @@ export type SelectedStrategy = {
   type: string;
 };
 
+export type SpaceMetadataDelegation = {
+  name: string | null;
+  apiType: string | null;
+  apiUrl: string | null;
+  contractNetwork: NetworkID | null;
+  contractAddress: string | null;
+};
+
 export type SpaceMetadata = {
   name: string;
   avatar: string;
@@ -33,10 +41,7 @@ export type SpaceMetadata = {
   votingPowerSymbol: string;
   walletNetwork: NetworkID | null;
   walletAddress: string | null;
-  delegationApiType: string | null;
-  delegationApiUrl: string | null;
-  delegationContractNetwork: NetworkID | null;
-  delegationContractAddress: string | null;
+  delegations: SpaceMetadataDelegation[];
 };
 
 export type SpaceSettings = {
@@ -62,9 +67,7 @@ export type Space = {
   cover: string;
   about?: string;
   external_url: string;
-  delegation_api_type: string | null;
-  delegation_api_url: string | null;
-  delegation_contract: string | null;
+  delegations: SpaceMetadataDelegation[];
   twitter: string;
   github: string;
   discord: string;

--- a/src/views/Create.vue
+++ b/src/views/Create.vue
@@ -73,10 +73,7 @@ const metadataForm: SpaceMetadata = reactive(
     votingPowerSymbol: '',
     walletNetwork: null,
     walletAddress: null,
-    delegationApiType: null,
-    delegationApiUrl: null,
-    delegationContractNetwork: null,
-    delegationContractAddress: null
+    delegations: []
   })
 );
 const selectedNetworkId: Ref<NetworkID> = ref(enabledNetworks[0]);
@@ -219,7 +216,9 @@ watchEffect(() => {
           <BlockSpaceFormProfile
             v-if="currentPage === 'profile'"
             :form="metadataForm"
+            :delegations-value="metadataForm.delegations"
             @pick="showPicker = true"
+            @delegations="v => (metadataForm.delegations = v)"
             @no-network="metadataForm.walletAddress = null"
             @errors="v => handleErrors('profile', v)"
           />

--- a/src/views/Space/Delegates.vue
+++ b/src/views/Space/Delegates.vue
@@ -1,54 +1,12 @@
 <script setup lang="ts">
-import { _n, shorten } from '@/helpers/utils';
-import { getNetwork } from '@/networks';
 import { Space } from '@/types';
 
 const props = defineProps<{ space: Space }>();
 
-const delegateModalOpen = ref(false);
-const sortBy = ref(
-  'delegatedVotes-desc' as
-    | 'delegatedVotes-desc'
-    | 'delegatedVotes-asc'
-    | 'tokenHoldersRepresentedAmount-desc'
-    | 'tokenHoldersRepresentedAmount-asc'
-);
 const { setTitle } = useTitle();
-const { loading, loadingMore, loaded, failed, hasMore, delegates, fetch, fetchMore, reset } =
-  useDelegates(props.space.delegation_api_url as string);
 
-const currentNetwork = computed(() => {
-  try {
-    return getNetwork(props.space.network);
-  } catch (e) {
-    return null;
-  }
-});
-
-function handleSortChange(type: 'delegatedVotes' | 'tokenHoldersRepresentedAmount') {
-  if (sortBy.value.startsWith(type)) {
-    sortBy.value = sortBy.value.endsWith('desc') ? `${type}-asc` : `${type}-desc`;
-  } else {
-    sortBy.value = `${type}-desc`;
-  }
-}
-
-async function handleEndReached() {
-  if (!hasMore.value) return;
-
-  await fetchMore(sortBy.value);
-}
-
-onMounted(() => {
-  if (!props.space.delegation_api_url) return;
-
-  fetch(sortBy.value);
-});
-
-watch([sortBy], () => {
-  reset();
-  fetch(sortBy.value);
-});
+const activeDelegationId = ref(0);
+const delegateData = computed(() => props.space.delegations[activeDelegationId.value]);
 
 watchEffect(() => {
   setTitle(`Delegates - ${props.space.name}`);
@@ -57,124 +15,17 @@ watchEffect(() => {
 
 <template>
   <div
-    v-if="!currentNetwork || !space.delegation_api_url"
-    class="p-4 flex items-center text-skin-link"
+    v-if="space.delegations.length !== 1"
+    class="flex px-4 bg-skin-bg border-b sticky top-[71px] lg:top-[72px] z-40 space-x-3"
   >
-    <IH-exclamation-circle class="inline-block mr-2" />
-    No delegation API configured.
+    <a v-for="(delegation, i) in space.delegations" :key="i" @click="activeDelegationId = i">
+      <Link :is-active="activeDelegationId === i" :text="delegation.name || 'Unnamed delegation'" />
+    </a>
   </div>
-  <template v-else>
-    <div v-if="space.delegation_contract" class="p-4 space-x-2 flex">
-      <div class="flex-auto" />
-      <UiTooltip title="Delegate">
-        <UiButton class="!px-0 w-[46px]" @click="delegateModalOpen = true">
-          <IH-user-add class="inline-block" />
-        </UiButton>
-      </UiTooltip>
-    </div>
-    <div class="space-y-3">
-      <div>
-        <Label label="Delegates" sticky />
-
-        <table class="text-left table-fixed w-full">
-          <colgroup>
-            <col class="w-auto" />
-            <col class="w-auto md:w-[120px]" />
-            <col class="w-0 md:w-[200px]" />
-          </colgroup>
-          <thead
-            class="bg-skin-bg sticky top-[112px] lg:top-[113px] z-40 after:border-b after:absolute after:w-full"
-          >
-            <tr class="bg-skin-border/10">
-              <th class="pl-4 font-medium">
-                <span class="relative bottom-[1px]">Delegatee</span>
-              </th>
-              <th class="hidden md:table-cell">
-                <button
-                  class="relative bottom-[1px] flex items-center justify-end min-w-0 w-full font-medium hover:text-skin-link"
-                  @click="handleSortChange('tokenHoldersRepresentedAmount')"
-                >
-                  <span>Delegators</span>
-                  <IH-arrow-sm-down
-                    v-if="sortBy === 'tokenHoldersRepresentedAmount-desc'"
-                    class="ml-1"
-                  />
-                  <IH-arrow-sm-up
-                    v-else-if="sortBy === 'tokenHoldersRepresentedAmount-asc'"
-                    class="ml-1"
-                  />
-                </button>
-              </th>
-              <th>
-                <button
-                  class="relative bottom-[1px] flex justify-end items-center min-w-0 w-full font-medium hover:text-skin-link pr-4"
-                  @click="handleSortChange('delegatedVotes')"
-                >
-                  <span class="truncate">Voting power</span>
-                  <IH-arrow-sm-down v-if="sortBy === 'delegatedVotes-desc'" class="ml-1" />
-                  <IH-arrow-sm-up v-else-if="sortBy === 'delegatedVotes-asc'" class="ml-1" />
-                </button>
-              </th>
-            </tr>
-          </thead>
-          <td v-if="loading" colspan="3">
-            <UiLoading class="px-4 py-3 block" />
-          </td>
-          <template v-else>
-            <tbody>
-              <td
-                v-if="loaded && delegates.length === 0"
-                class="px-4 py-3 flex items-center"
-                colspan="3"
-              >
-                <IH-exclamation-circle class="inline-block mr-2" />
-                There are no delegates.
-              </td>
-              <td v-else-if="loaded && failed" class="px-4 py-3 flex items-center" colspan="3">
-                <IH-exclamation-circle class="inline-block mr-2" />
-                Failed to load delegates.
-              </td>
-              <BlockInfiniteScroller :loading-more="loadingMore" @end-reached="handleEndReached">
-                <tr v-for="(delegate, i) in delegates" :key="i" class="border-b relative">
-                  <td class="text-left flex items-center pl-4 py-3">
-                    <Stamp :id="delegate.id" :size="32" class="mr-3" />
-                    <div class="overflow-hidden">
-                      <a :href="currentNetwork.helpers.getExplorerUrl(delegate.id, 'address')">
-                        <div class="leading-[22px]">
-                          <h4
-                            class="text-skin-link truncate"
-                            v-text="delegate.name || shorten(delegate.id)"
-                          />
-                          <div class="text-sm truncate" v-text="shorten(delegate.id)" />
-                        </div>
-                      </a>
-                    </div>
-                  </td>
-                  <td class="hidden md:table-cell align-middle text-right">
-                    <h4
-                      class="text-skin-link"
-                      v-text="_n(delegate.tokenHoldersRepresentedAmount)"
-                    />
-                    <div class="text-sm" v-text="`${delegate.delegatorsPercentage.toFixed(3)}%`" />
-                  </td>
-                  <td class="text-right pr-4 align-middle">
-                    <h4 class="text-skin-link" v-text="_n(delegate.delegatedVotes)" />
-                    <div class="text-sm" v-text="`${delegate.votesPercentage.toFixed(3)}%`" />
-                  </td>
-                </tr>
-                <template #loading>
-                  <td colspan="3">
-                    <UiLoading class="p-4 block" />
-                  </td>
-                </template>
-              </BlockInfiniteScroller>
-            </tbody>
-          </template>
-        </table>
-      </div>
-    </div>
-    <teleport to="#modal">
-      <ModalDelegate :open="delegateModalOpen" :space="space" @close="delegateModalOpen = false" />
-    </teleport>
-  </template>
+  <BlockDelegates
+    v-if="delegateData"
+    :key="activeDelegationId"
+    :space="space"
+    :delegation="delegateData"
+  />
 </template>


### PR DESCRIPTION
### Summary

**Only Starknet was tested as of now.**

Closes: https://github.com/snapshot-labs/sx-ui/issues/833

Depends on https://github.com/snapshot-labs/sx-api/pull/205
Depends on https://github.com/snapshot-labs/sx-subgraph/pull/43

### How to test

1. Run local sx-api.
2. Run sx-ui with sn-tn only: `VITE_ENABLED_NETWORKS=sn-tn yarn dev`.
3. Deploy new space with multiple delegations.
4. Edit that space delegations in edit space modal.
5. View delegations for space (**currently subgraph fails for some subgraphs because it's overloaded**).

### Screenshots

<img width="574" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/5885c3fa-3138-4f96-b8b9-79d33824c226">
<img width="884" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/1f28ad7c-34a7-4c02-a12f-f6243d7b24ca">
<img width="819" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/7f9a5cb3-de82-40fb-b8a3-bea530a6789b">

