### PR TITLE
feat: show Voting ended label if voting has already ended

### DIFF
--- a/src/views/Proposal/Overview.vue
+++ b/src/views/Proposal/Overview.vue
@@ -50,6 +50,19 @@ const proposalMetadataUrl = computed(() => {
   return sanitizeUrl(url);
 });
 
+const votingTime = computed(() => {
+  if (!props.proposal) return null;
+
+  const current = getCurrent(props.proposal.network);
+  if (!current) return null;
+
+  const time = _rt(getTsFromCurrent(props.proposal.network, props.proposal.max_end));
+
+  const hasEnded = props.proposal.max_end <= current;
+
+  return hasEnded ? `Voting ended ${time}` : time;
+});
+
 async function handleEditClick() {
   if (!props.proposal) return;
 
@@ -206,11 +219,7 @@ async function handleCancelClick() {
           {{ _n(proposal.vote_count) }} {{ proposal.vote_count !== 1 ? 'votes' : 'vote' }}
         </a>
         ·
-        <a
-          class="text-skin-text"
-          @click="modalOpenTimeline = true"
-          v-text="_rt(getTsFromCurrent(proposal.network, proposal.max_end))"
-        />
+        <a class="text-skin-text" @click="modalOpenTimeline = true" v-text="votingTime" />
         <template v-if="proposal.edited"> · (edited)</template>
       </div>
     </div>


### PR DESCRIPTION
### Summary

Without extra label it's confusing what it means when it's just "1y ago". For current proposals it seems fine ("6h left").

### How to test

1. Go to http://localhost:8080/#/arb1:0x2fb231a3ac7c40888d2e6773f5600851b0c20ce4/proposal/2 (numbers don't make sense, ignore that :D)

### Screenshots

<img width="1088" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/7fbb5a82-2bbe-43c1-91d5-704578fc91b6">

