### PR TITLE
fix: use eth mainnet blocks for current

### DIFF
--- a/src/networks/evm/index.ts
+++ b/src/networks/evm/index.ts
@@ -12,10 +12,14 @@ type Metadata = {
   name: string;
   ticker?: string;
   chainId: number;
+  currentChainId?: number;
   apiUrl: string;
   avatar: string;
   blockTime: number;
 };
+
+// shared for both ETH mainnet and ARB1
+const ETH_MAINNET_BLOCK_TIME = 12.09;
 
 export const METADATA: Record<string, Metadata> = {
   matic: {
@@ -29,16 +33,17 @@ export const METADATA: Record<string, Metadata> = {
   arb1: {
     name: 'Arbitrum One',
     chainId: 42161,
-    apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-arbitrum/v0.0.17', // TODO: change to use latest, it's stuck syncing right now, hardcoding so we have working UI
+    currentChainId: 1,
+    apiUrl: 'https://api.studio.thegraph.com/query/23545/sx-arbitrum/version/latest',
     avatar: 'ipfs://bafkreic2p3zzafvz34y4tnx2kaoj6osqo66fpdo3xnagocil452y766gdq',
-    blockTime: 0.26082
+    blockTime: ETH_MAINNET_BLOCK_TIME
   },
   eth: {
     name: 'Ethereum',
     chainId: 1,
     apiUrl: 'https://api.studio.thegraph.com/query/23545/sx/version/latest',
     avatar: 'ipfs://bafkreid7ndxh6y2ljw2jhbisodiyrhcy2udvnwqgon5wgells3kh4si5z4',
-    blockTime: 12.09
+    blockTime: ETH_MAINNET_BLOCK_TIME
   },
   gor: {
     name: 'Ethereum Goerli',
@@ -64,7 +69,7 @@ export const METADATA: Record<string, Metadata> = {
 };
 
 export function createEvmNetwork(networkId: NetworkID): Network {
-  const { name, chainId, apiUrl, avatar } = METADATA[networkId];
+  const { name, chainId, currentChainId, apiUrl, avatar } = METADATA[networkId];
 
   const provider = getProvider(chainId);
   const api = createApi(apiUrl, networkId, {
@@ -99,6 +104,7 @@ export function createEvmNetwork(networkId: NetworkID): Network {
     currentUnit: 'block',
     chainId,
     baseChainId: chainId,
+    currentChainId: currentChainId ?? chainId,
     hasReceive: false,
     supportsSimulation: ['eth', 'gor', 'sep', 'matic', 'arb1'].includes(networkId),
     managerConnectors: EVM_CONNECTORS,

--- a/src/networks/offchain/index.ts
+++ b/src/networks/offchain/index.ts
@@ -41,6 +41,7 @@ export function createOffchainNetwork(networkId: NetworkID): Network {
     currentUnit: 'second',
     chainId: l1ChainId,
     baseChainId: l1ChainId,
+    currentChainId: l1ChainId,
     hasReceive: false,
     supportsSimulation: false,
     managerConnectors: [],

--- a/src/networks/starknet/index.ts
+++ b/src/networks/starknet/index.ts
@@ -116,6 +116,7 @@ export function createStarknetNetwork(networkId: NetworkID): Network {
     currentUnit: 'second',
     chainId,
     baseChainId,
+    currentChainId: baseChainId,
     baseNetworkId,
     hasReceive: true,
     supportsSimulation: true,

--- a/src/networks/types.ts
+++ b/src/networks/types.ts
@@ -218,6 +218,7 @@ type BaseNetwork = {
   currentUnit: 'block' | 'second';
   chainId: number | string;
   baseChainId: number;
+  currentChainId: number;
   baseNetworkId?: NetworkID;
   hasReceive: boolean;
   supportsSimulation: boolean;

--- a/src/stores/meta.ts
+++ b/src/stores/meta.ts
@@ -16,7 +16,7 @@ export const useMetaStore = defineStore('meta', () => {
   async function fetchBlock(networkId: NetworkID) {
     if (currentBlocks.value.get(networkId)) return;
 
-    const provider = getProvider(getNetwork(networkId).baseChainId);
+    const provider = getProvider(getNetwork(networkId).currentChainId);
 
     try {
       const blockNumber = await provider.getBlockNumber();


### PR DESCRIPTION
### Summary

Arbitrum uses eth mainnet blocks for block.number.

Closes: https://github.com/snapshot-labs/sx-ui/issues/824

### How to test

1. http://localhost:8080/#/arb1:0x2fb231a3ac7c40888d2e6773f5600851b0c20ce4/proposal/2
2. Timeline in modal and Ended time make sense.

### Screenshots

<img width="1072" alt="image" src="https://github.com/snapshot-labs/sx-ui/assets/1968722/13be585f-6dcf-406d-9ab5-5596682255c0">
