### PR TITLE
feat: enable evm slot value on mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
-    "@snapshot-labs/sx": "^0.1.0-beta.54",
+    "@snapshot-labs/sx": "^0.1.0-beta.57",
     "@vueuse/core": "^10.4.1",
     "@walletconnect/client": "^1.8.0",
     "ajv": "^8.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/sx@^0.1.0-beta.54":
-  version "0.1.0-beta.54"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.54.tgz#6b0e732aacda1d04c527a37693fee7b2c611c089"
-  integrity sha512-ErREQzE01fwFPHcTQBtjjXAcsOjT6PzvE1dP9f7gcUeRRsuEuj0pZTk2gewn+rJ1GVWwvDI+dMmITxJacgBI7A==
+"@snapshot-labs/sx@^0.1.0-beta.57":
+  version "0.1.0-beta.57"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.57.tgz#63ba1fe658de958fefdaabd509bb5bd205a60e30"
+  integrity sha512-BF3jnnEOGMewZv3++yCjJV6KnWx9qpoDbM+1kP0jCGfhTS5eWVnthGvXVTZV0WP32BMARV/Em29YyfIN25pyNw==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/sx-ui/issues/851

### How to test

1. `VITE_ENABLED_NETWORKS=sn yarn dev`
2. Create space with evm slot value (you can use this contract `0x7421B0f131c32876c0eF305F9e4B2591bfbFF472`).
3. Try creating proposal and voting (once herodotus is processed).

Sample proposal http://localhost:8080/#/sn:0x01232584ed4f94aab39c1bedf295aff876ff30d5c9ecbcb395eaf47cd492d50c/proposal/1