### PR TITLE
fix: apply dark class to html tag

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,6 @@ const el = ref(null);
 const route = useRoute();
 const uiStore = useUiStore();
 const { modalOpen } = useModal();
-const { userSkin } = useUserSkin();
 const { init, app } = useApp();
 const { web3, web3Account } = useWeb3();
 const { loadVotes, votes } = useAccount();
@@ -12,7 +11,6 @@ const { isSwiping, direction } = useSwipe(el);
 
 provide('web3', web3);
 
-const skin = computed(() => userSkin.value);
 const scrollDisabled = computed(() => modalOpen.value || uiStore.sidebarOpen);
 
 onMounted(async () => {
@@ -49,7 +47,7 @@ watch(isSwiping, () => {
 <template>
   <div
     ref="el"
-    :class="{ [skin]: true, 'overflow-hidden': scrollDisabled }"
+    :class="{ 'overflow-hidden': scrollDisabled }"
     class="font-serif text-base min-h-screen bg-skin-bg text-skin-text antialiased"
   >
     <UiLoading v-if="app.loading || !app.init" class="overlay big" />

--- a/src/composables/useUserSkin.ts
+++ b/src/composables/useUserSkin.ts
@@ -33,10 +33,11 @@ export function useUserSkin() {
   watch(
     userSkin,
     () => {
-      document.documentElement.setAttribute(
-        'data-color-scheme',
-        userSkin.value === LIGHT_MODE ? 'light' : 'dark'
-      );
+      if (userSkin.value === LIGHT_MODE) {
+        document.documentElement.classList.remove('dark');
+      } else {
+        document.documentElement.classList.add('dark');
+      }
     },
     { immediate: true }
   );


### PR DESCRIPTION
### Summary

Since https://github.com/snapshot-labs/sx-ui/pull/794 dark style is only applied within Vue tree, which won't apply to body itself.

This causes body to remain white when dark theme is used which can become visible during overscroll. This commit replaces two ways of setting dark theme (data-color-scheme and class) with just once (class) set to html document.

### How to test

1. Go to UI, can switch between dark/light mode with no issues.
2. Run `yarn story:dev` - dark mode works there too.
