### PR TITLE
feat(starknet): add OZ Votes storage proof strategy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@snapshot-labs/lock": "^0.2.0",
     "@snapshot-labs/pineapple": "^1.1.0",
     "@snapshot-labs/prettier-config": "^0.1.0-beta.7",
-    "@snapshot-labs/sx": "^0.1.0-beta.57",
+    "@snapshot-labs/sx": "^0.1.0-beta.58",
     "@vueuse/core": "^10.4.1",
     "@walletconnect/client": "^1.8.0",
     "ajv": "^8.12.0",

--- a/src/views/Space/EditSettings.vue
+++ b/src/views/Space/EditSettings.vue
@@ -263,13 +263,15 @@ watchEffect(async () => {
       <BlockSpaceFormValidation
         v-model="validationStrategy"
         :available-strategies="network.constants.EDITOR_PROPOSAL_VALIDATIONS"
-        :available-voting-strategies="network.constants.EDITOR_VOTING_STRATEGIES"
+        :available-voting-strategies="
+          network.constants.EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES
+        "
         title="Proposal validation"
         description="Proposal validation strategies are used to determine if a user is allowed to create a proposal."
       />
       <BlockSpaceFormStrategies
         v-model="votingStrategies"
-        :available-strategies="network.constants.EDITOR_PROPOSAL_VALIDATION_VOTING_STRATEGIES"
+        :available-strategies="network.constants.EDITOR_VOTING_STRATEGIES"
         title="Voting strategies"
         description="Voting strategies are customizable contracts used to define how much voting power each user has when casting a vote."
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
-"@snapshot-labs/sx@^0.1.0-beta.57":
-  version "0.1.0-beta.57"
-  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.57.tgz#63ba1fe658de958fefdaabd509bb5bd205a60e30"
-  integrity sha512-BF3jnnEOGMewZv3++yCjJV6KnWx9qpoDbM+1kP0jCGfhTS5eWVnthGvXVTZV0WP32BMARV/Em29YyfIN25pyNw==
+"@snapshot-labs/sx@^0.1.0-beta.58":
+  version "0.1.0-beta.58"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/sx/-/sx-0.1.0-beta.58.tgz#bfbcfa824c426dfa12cfe553c5b78e1e7f612224"
+  integrity sha512-hKe4q4UMh45Sp+lpyyQbnfGRGfzEf4zc0Kkw5Bs30rp3t4tr4BXJltSZ7g207I3PNGBnOtH+7Ws19495RZ/iMw==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
### Summary

Closes: https://github.com/snapshot-labs/pitches/issues/74

### How to test

1. Get some token and delegate it to yourself: https://sepolia.etherscan.io/address/0x6fd821e79cdf212ad8b06c59b28fe8c2185291d4#readContract
2. Create new space (with EthSig/EthTx) using OZ Votes storage proof strategy (use above token, slot index 8).
3. Create new proposal.
4. Wait for it to be processed on Herodotus.
5. You can now see your voting power and vote (http://localhost:8080/#/sn-sep:0x07101663a830e0c821785f7537f570901d2a8bf1ed46f70aaacd73c4c7192cf8/proposal/1)

