### PR TITLE
refactor: replace choice magic numbers with string values

### DIFF
--- a/src/components/Proposal.vue
+++ b/src/components/Proposal.vue
@@ -8,7 +8,7 @@ const { getTsFromCurrent } = useMetaStore();
 const route = useRoute();
 const { vote } = useActions();
 const modalOpenTimeline = ref(false);
-const sendingType = ref<null | number>(null);
+const sendingType = ref<Choice | null>(null);
 
 async function handleVoteClick(choice: Choice) {
   sendingType.value = choice;
@@ -83,27 +83,27 @@ async function handleVoteClick(choice: Choice) {
           <div class="flex space-x-2 py-2">
             <UiTooltip title="For">
               <UiButton
-                class="w-full !text-green !border-green !w-[40px] !h-[40px] !px-0"
-                :loading="sendingType === 1"
-                @click="handleVoteClick(1)"
+                class="w-[40px] !text-green !border-green !h-[40px] !px-0"
+                :loading="sendingType === 'for'"
+                @click="handleVoteClick('for')"
               >
                 <IH-check class="inline-block" />
               </UiButton>
             </UiTooltip>
             <UiTooltip title="Against">
               <UiButton
-                class="w-full !text-red !border-red !w-[40px] !h-[40px] !px-0"
-                :loading="sendingType === 2"
-                @click="handleVoteClick(2)"
+                class="w-[40px] !text-red !border-red !h-[40px] !px-0"
+                :loading="sendingType === 'against'"
+                @click="handleVoteClick('against')"
               >
                 <IH-x class="inline-block" />
               </UiButton>
             </UiTooltip>
             <UiTooltip title="Abstain">
               <UiButton
-                class="w-full !text-gray-500 !border-gray-500 !w-[40px] !h-[40px] !px-0"
-                :loading="sendingType === 3"
-                @click="handleVoteClick(3)"
+                class="w-[40px] !text-gray-500 !border-gray-500 !h-[40px] !px-0"
+                :loading="sendingType === 'abstain'"
+                @click="handleVoteClick('abstain')"
               >
                 <IH-minus-sm class="inline-block" />
               </UiButton>

--- a/src/networks/common/helpers.ts
+++ b/src/networks/common/helpers.ts
@@ -1,12 +1,18 @@
-import { getExecutionData as _getExecutionData } from '@snapshot-labs/sx';
+import { getExecutionData as _getExecutionData, Choice as SdkChoice } from '@snapshot-labs/sx';
 import { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
 import { EVM_CONNECTORS, STARKNET_CONNECTORS } from './constants';
 import { getUrl } from '@/helpers/utils';
 import { Connector, NetworkHelpers, StrategyConfig } from '@/networks/types';
-import { Space } from '@/types';
+import { Choice, Space } from '@/types';
 
 type SpaceExecutionData = Pick<Space, 'executors' | 'executors_types'>;
 type ExecutorType = Parameters<typeof _getExecutionData>[0];
+
+export function getSdkChoice(choice: Choice): SdkChoice {
+  if (choice === 'for') return SdkChoice.For;
+  if (choice === 'against') return SdkChoice.Against;
+  return SdkChoice.Abstain;
+}
 
 export function getExecutionData(
   space: SpaceExecutionData,

--- a/src/networks/evm/actions.ts
+++ b/src/networks/evm/actions.ts
@@ -17,6 +17,7 @@ import { createErc1155Metadata, verifyNetwork } from '@/helpers/utils';
 import { convertToMetaTransactions } from '@/helpers/transactions';
 import {
   getExecutionData,
+  getSdkChoice,
   buildMetadata,
   parseStrategyMetadata,
   createStrategyPicker
@@ -37,9 +38,14 @@ import type {
   VotingPower
 } from '@/networks/types';
 import type { MetaTransaction } from '@snapshot-labs/sx/dist/utils/encoding/execution-hash';
-import type { Space, Proposal, SpaceMetadata, StrategyParsedMetadata, NetworkID } from '@/types';
-
-type Choice = 0 | 1 | 2;
+import type {
+  Space,
+  Proposal,
+  SpaceMetadata,
+  StrategyParsedMetadata,
+  Choice,
+  NetworkID
+} from '@/types';
 
 const CONFIGS: Record<number, EvmNetworkConfig> = {
   137: evmPolygon,
@@ -332,11 +338,9 @@ export function createActions(
       connectorType: Connector,
       account: string,
       proposal: Proposal,
-      choice: number
+      choice: Choice
     ) => {
       await verifyNetwork(web3, chainId);
-
-      if (choice < 1 || choice > 3) throw new Error('Invalid chocie');
 
       const isContract = await getIsContract(account);
 
@@ -347,11 +351,6 @@ export function createActions(
         connectorType,
         isContract
       });
-
-      let convertedChoice: Choice = 0;
-      if (choice === 1) convertedChoice = 1;
-      if (choice === 2) convertedChoice = 0;
-      if (choice === 3) convertedChoice = 2;
 
       const strategiesWithMetadata = await Promise.all(
         strategies.map(async strategy => {
@@ -373,7 +372,7 @@ export function createActions(
         authenticator,
         strategies: strategiesWithMetadata,
         proposal: proposal.proposal_id as number,
-        choice: convertedChoice,
+        choice: getSdkChoice(choice),
         metadataUri: ''
       };
 

--- a/src/networks/starknet/actions.ts
+++ b/src/networks/starknet/actions.ts
@@ -10,6 +10,7 @@ import { MANA_URL } from '@/helpers/mana';
 import { createErc1155Metadata, verifyNetwork } from '@/helpers/utils';
 import {
   getExecutionData,
+  getSdkChoice,
   buildMetadata,
   parseStrategyMetadata,
   createStrategyPicker
@@ -25,10 +26,15 @@ import type {
   StrategyConfig,
   VotingPower
 } from '@/networks/types';
-import type { Space, SpaceMetadata, StrategyParsedMetadata, Proposal, NetworkID } from '@/types';
+import type {
+  Space,
+  SpaceMetadata,
+  StrategyParsedMetadata,
+  Proposal,
+  Choice,
+  NetworkID
+} from '@/types';
 import { getProvider } from '@/helpers/provider';
-
-type Choice = 0 | 1 | 2;
 
 const CONFIGS: Partial<Record<NetworkID, NetworkConfig>> = {
   sn: starknetMainnet,
@@ -303,7 +309,7 @@ export function createActions(
       connectorType: Connector,
       account: string,
       proposal: Proposal,
-      choice: number
+      choice: Choice
     ) => {
       const isContract = await getIsContract(connectorType, account);
 
@@ -334,17 +340,12 @@ export function createActions(
         })
       );
 
-      let convertedChoice: Choice = 0;
-      if (choice === 1) convertedChoice = 1;
-      if (choice === 2) convertedChoice = 0;
-      if (choice === 3) convertedChoice = 2;
-
       const data = {
         space: proposal.space.id,
         authenticator,
         strategies: strategiesWithMetadata,
         proposal: proposal.proposal_id as number,
-        choice: convertedChoice
+        choice: getSdkChoice(choice)
       };
 
       if (relayerType === 'starknet') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,8 @@ export type NetworkID =
   | 'sn-sep'
   | 'matic'
   | 'arb1';
-export type Choice = 1 | 2 | 3;
+
+export type Choice = 'for' | 'against' | 'abstain';
 
 export type SelectedStrategy = {
   address: string;

--- a/src/views/Proposal.vue
+++ b/src/views/Proposal.vue
@@ -13,7 +13,7 @@ const proposalsStore = useProposalsStore();
 const { web3 } = useWeb3();
 const { vote } = useActions();
 
-const sendingType = ref<null | number>(null);
+const sendingType = ref<Choice | null>(null);
 const votingPowers = ref([] as VotingPower[]);
 const loadingVotingPower = ref(true);
 
@@ -171,8 +171,8 @@ watchEffect(() => {
               <UiTooltip title="For">
                 <UiButton
                   class="!text-green !border-green !w-[48px] !h-[48px] !px-0"
-                  :loading="sendingType === 1"
-                  @click="handleVoteClick(1)"
+                  :loading="sendingType === 'for'"
+                  @click="handleVoteClick('for')"
                 >
                   <IH-check class="inline-block" />
                 </UiButton>
@@ -180,8 +180,8 @@ watchEffect(() => {
               <UiTooltip title="Against">
                 <UiButton
                   class="!text-red !border-red !w-[48px] !h-[48px] !px-0"
-                  :loading="sendingType === 2"
-                  @click="handleVoteClick(2)"
+                  :loading="sendingType === 'against'"
+                  @click="handleVoteClick('against')"
                 >
                   <IH-x class="inline-block" />
                 </UiButton>
@@ -189,8 +189,8 @@ watchEffect(() => {
               <UiTooltip title="Abstain">
                 <UiButton
                   class="!text-gray-500 !border-gray-500 !w-[48px] !h-[48px] !px-0"
-                  :loading="sendingType === 3"
-                  @click="handleVoteClick(3)"
+                  :loading="sendingType === 'abstain'"
+                  @click="handleVoteClick('abstain')"
                 >
                   <IH-minus-sm class="inline-block" />
                 </UiButton>


### PR DESCRIPTION
### Summary

We used to use 1 | 2 | 3 for vote choice on UI (for, against, abstain). Which was inconsistent with sx.js (0 abstain, 1, for, 2 against).

It could lead to issues as those values are not really clear on the UI. This commit replaces 1 | 2 | 3 with 'for' | 'against' | 'abstain' that are converted to SDK values in single place. This makes UI code more readable as actions are easy to understand.

### How to test
- You can still vote -> signed message (if using sig authenticator) uses correct choice.