### PR TITLE
fix: Keyboard navigation for buttons

### DIFF
--- a/src/components/Block/SpaceFormNetwork.vue
+++ b/src/components/Block/SpaceFormNetwork.vue
@@ -19,16 +19,17 @@ const availableNetworks = enabledNetworks
   <div class="mb-2">
     <h3>Space network</h3>
     <div class="grid grid-cols-auto gap-3 pt-4 mb-3">
-      <div
+      <button
         v-for="network in availableNetworks"
         :key="network.id"
+        type="button"
         :class="{ 'border-skin-link': network.id === model }"
         class="flex items-center rounded-lg border px-4 py-3 text-skin-link cursor-pointer"
         @click="model = network.id"
       >
         <img :src="getUrl(network.avatar) ?? undefined" class="w-[32px] h-[32px] mr-3 rounded-lg" />
         {{ network.name }}
-      </div>
+      </button>
     </div>
   </div>
 </template>

--- a/src/style.scss
+++ b/src/style.scss
@@ -95,10 +95,6 @@ p {
   @apply text-lg pb-2;
 }
 
-* {
-  outline: none !important;
-}
-
 h1,
 h2,
 h3,
@@ -198,7 +194,7 @@ a,
 // Shot UI kit
 
 .s-input {
-  @apply text-skin-heading border border-skin-border block rounded-[24px] py-2 px-3 w-full bg-transparent mb-3;
+  @apply text-skin-heading border border-skin-border block rounded-[24px] py-2 px-3 w-full bg-transparent mb-3 focus:outline-none;
 }
 
 .s-label {

--- a/src/style.scss
+++ b/src/style.scss
@@ -112,6 +112,10 @@ a,
   }
 }
 
+input {
+  @apply outline-none;
+}
+
 .choice-bg {
   &._1 {
     @apply bg-choice-for;

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -294,18 +294,12 @@ export default defineComponent({
         :error="formErrors.title"
       />
       <div class="flex space-x-3">
-        <Link
-          :is-active="!previewEnabled"
-          text="Write"
-          class="border-transparent"
-          @click="previewEnabled = false"
-        />
-        <Link
-          :is-active="previewEnabled"
-          text="Preview"
-          class="border-transparent"
-          @click="previewEnabled = true"
-        />
+        <button type="button" @click="previewEnabled = false">
+          <Link :is-active="!previewEnabled" text="Write" class="border-transparent" />
+        </button>
+        <button type="button" @click="previewEnabled = true">
+          <Link :is-active="previewEnabled" text="Preview" class="border-transparent" />
+        </button>
       </div>
       <Markdown
         v-if="previewEnabled"


### PR DESCRIPTION
### Summary

<!-- Related issues, a description or list of the changes and the motivation behind them -->

Fixes keyboard navigation for button, before outline was disabled everywhere and now it's just disabled for inputs. Also added some buttons where I found them to be missing.

<!--
### Self-review checklist
- [ ] I have performed a full self-review of my changes
- [ ] I have tested my changes on a preview deployment
- [ ] I have tested my changes on different screen sizes (sm, md)
-->
